### PR TITLE
Resolve Market regime filter ticket (wayfinder map)

### DIFF
--- a/.scratch/screening-dashboard/issues/01-idx-free-data-sources.md
+++ b/.scratch/screening-dashboard/issues/01-idx-free-data-sources.md
@@ -1,0 +1,92 @@
+# Free EOD data sources for IDX
+
+Type: research
+Status: resolved
+Blocked by: —
+
+## Question
+
+What free sources can supply daily OHLCV for the full IDX equity universe, and which one should v1 build on?
+
+For each candidate (at minimum: Yahoo Finance `.JK` via yfinance, the IDX official site / IDX API,
+Stockbit, Investing.com, Google Finance, Wikipedia/IDX listing pages, any Indonesian open-data project):
+
+- **Universe coverage** — does it enumerate *all* listed tickers, or only ones you already know? Is there
+  a free way to get the current listing plus delisted names?
+- **History depth** — how many years of daily bars, and is it truncated for small caps?
+- **Adjustment** — are prices adjusted for splits, reverse splits, dividends, and rights issues (very
+  common on IDX)? If unadjusted, is there a corporate-actions feed to adjust with?
+- **Volume units** — IDX quotes in lots (100 shares); confirm whether the source reports shares or lots,
+  since the Rp 1B/day liquidity floor depends on getting value-traded right.
+- **Rate limits, ToS, and stability** — is scraping required, is it against terms, how likely to break.
+- **Freshness** — what time after the IDX close (16:00 WIB) is the day's bar available.
+- **Sector/industry field** — does it carry one, and which taxonomy (IDX-IC vs GICS-like)?
+
+Deliver a comparison table plus a recommendation, including a fallback source and what would make us
+switch. Flag anything that makes a full-universe nightly pull infeasible on a free tier.
+
+## Answer
+
+Findings: [`research/01-idx-data-sources.md`](../research/01-idx-data-sources.md). Verified empirically
+against live data on 2026-08-04, not read from docs.
+
+**Recommendation: Yahoo Finance `.JK` via yfinance**, fallback a headless-browser scrape of idx.co.id.
+Nothing else clears the free bar.
+
+### Verified facts
+
+- **Universe enumeration is solved.** `yf.screen(EquityQuery("eq",["exchange","JKT"]))` returns
+  **840 symbols in 0.8s**, all `quoteType: EQUITY`, with marketCap / sharesOutstanding / ADV attached.
+- **The 840-vs-963 gap is explained** (this closes ticket 05's open question): IDX lists 963; the ~120
+  missing were probed and are **suspended or delisted** (WSKT, SRIL, ENVY, INAF, POLL, BIMA, TRAM,
+  MYRX all absent). They remain fetchable *by symbol* but are not discoverable — so the screener
+  carries **survivorship bias**, which matters for any backtest, not for tonight's scan.
+- **Volume is shares, not lots.** Σ(close×volume) across 834 names = **Rp 12.07 trillion** for the
+  session — a normal IDX day; lots would give Rp 1,207T. So `value_traded = Close × Volume`, no lot
+  correction. **At the Rp 1B/day floor, 292 of 840 names survive** — that is the real tradeable IDX
+  universe. Hand this number straight to tickets 05 and 06.
+- **Throughput is a non-issue; rate limiting is the constraint.** All 840 × 5y downloaded in **11.5s**
+  — 904,414 bars, ~50 MB, zero empties. The *very next* API call threw `YFRateLimitError` and it
+  persisted for minutes across backoffs. Bulk OHLCV is cheap; per-symbol `.info` is what trips it
+  (consistent with ticket 03's independent finding).
+- **Small caps are not truncated** at the recent end — AMAR/HOMI/PGJO/GOTO all run from actual IPO.
+  Truncation is at the *old* end: nothing before 2000 anywhere, and BBCA starts 2004 despite listing
+  in 2000.
+- **4.0% of bars have Volume == 0**, and 5.2% of tickers exceed 20% zero-volume bars. Suspended names
+  emit *more* bars than active ones — phantom flat bars. These must be dropped before any ADR or
+  tightness computation, or they will fabricate contraction.
+
+### The finding that matters most
+
+Yahoo's docs and yfinance's source both state Adj Close accounts for **splits + dividends only**. The
+agent measured something worse than "rights issues are unadjusted": **BBRI's OHLC before 2021-09-08 is
+rescaled by exactly 10/11, with no corresponding entry in either the `Stock Splits` or `Dividends`
+column.** Yahoo *does* apply rights adjustments — invisibly and unauditably.
+
+Consequences:
+- You cannot recover raw traded prices, and cannot verify the adjustment is correct (whether 10/11 is
+  even right here is unverified).
+- **Momentum, MA and consolidation logic are safe** — the series is internally consistent, which is all
+  those need.
+- **Absolute-price rules are not safe** — tick bands, ARA/ARB reconstruction, and anything comparing a
+  historical price to a real-world level. Ticket 05's "adjusted vs raw" question is therefore not a
+  free choice on IDX: raw is simply unavailable.
+
+### Ruled out, with the blocking clause
+
+- **Stockbit** — ToS verbatim bans "data mining, robots, spiders". The best free IDX product; a hard
+  rule-out, not a maybe.
+- **idx.co.id** — Cloudflare **403 on every endpoint including `robots.txt`**, even with full browser
+  headers. The data is a licensed paid product. (Matches ticket 03's independent result.)
+- **Stooq** — now serves a JS proof-of-work challenge instead of CSV. Dead for IDX.
+- **Sectors/Supertype** — excellent fit, but the API needs the paid Insider plan.
+- **Dataset-Saham-IDX** — last data commit 2025-02-23, 17 months stale. Retained only as a stale
+  universe seed, and as the primary citation that IDX volume is `dalam satuan lembar` (shares).
+- **Google Finance** — API dead since 2012, Sheets-only.
+
+### Honest gaps
+
+Could not read idx.co.id content at all (only its access behaviour). Could not verify Investing.com's
+scraping clause, nor the claimed legal takedown of investpy — its README cites only "API changes".
+Could not pin exactly when Yahoo's EOD bar settles: the 2026-08-04 bar was final at 19:49 WIB, so a
+**≥19:00 WIB** schedule is safe and anything earlier is unproven. Feed that to ticket 12.

--- a/.scratch/screening-dashboard/issues/02-us-free-data-sources.md
+++ b/.scratch/screening-dashboard/issues/02-us-free-data-sources.md
@@ -1,0 +1,103 @@
+# Free EOD data sources for US
+
+Type: research
+Status: resolved
+Blocked by: —
+
+## Question
+
+What free sources can supply daily OHLCV for the US equity universe at the scale this screen needs,
+and which one should v1 build on?
+
+Candidates to cover at minimum: Yahoo Finance (yfinance), Stooq, Nasdaq/NYSE listing files,
+Alpha Vantage free tier, Tiingo free tier, Financial Modeling Prep free tier, EODHD free tier,
+Polygon free tier, SEC/CIK reference data.
+
+Evaluate on:
+
+- **Universe enumeration** — a free, reliable list of currently listed common stocks across
+  NYSE/Nasdaq/AMEX, with ETFs and funds separable (his universe is stocks; ETFs appear only as
+  sector proxies).
+- **Scale** — roughly 6,000+ symbols pulled nightly. Which sources survive that on a free tier, and
+  what the wall-clock and rate-limit picture looks like.
+- **History depth and adjustment** — years available; split/dividend adjustment; whether adjusted and
+  raw are both obtainable (ADR and gap math want raw; return math wants adjusted).
+- **Survivorship** — is delisted history retrievable? Matters for any later backtest.
+- **Freshness** — availability after the 16:00 ET close.
+- **Sector/industry field** and its taxonomy.
+- **ToS and stability** — scraping vs. sanctioned API; known breakage history.
+
+Deliver a comparison table plus a recommendation and a fallback. Note explicitly whether one source can
+serve **both** IDX and US, since a single-source design is materially simpler.
+
+## Answer
+
+Findings: [`research/02-us-data-sources.md`](../research/02-us-data-sources.md). Measured against live
+data — Yahoo publishes no rate limits, so every throughput number here is empirical.
+
+**Recommendation: yfinance as the single primary source for *both* markets**, fallback Massive
+(ex-Polygon) Basic for US.
+
+### One source serves both markets
+
+yfinance covers IDX via `.JK` with the same client, call, schema, adjustment fields and **the same
+Yahoo sector taxonomy** as US — `BBCA.JK` returns 5,463 rows back to 2004-06-08 with splits and
+dividends intact. No other viable candidate does this (FMP free is explicitly US-only; Massive is US
+equities). So this ticket's key question is answered: **one ingester, not two**, and cross-market
+sector rotation needs no mapping layer. This corroborates tickets 01 and 03 independently.
+
+### Rate limiting is mandatory, not an optimisation
+
+Full 5,711-symbol US universe, 2y bars:
+
+| Approach | Result |
+| --- | --- |
+| Unthrottled | 75s but **only 52.9% of symbols** — 5,374 × HTTP 429 |
+| **Capped at 12 req/s** | **8.5 min, 99.93% coverage, zero 429s** |
+
+The unthrottled failure mode is the dangerous one: yfinance reports throttled symbols as
+`"possibly delisted; no price data found"`. An unrated implementation ships a screener that silently
+drops half the universe **and blames delisting for it**. This is the third independent sighting of
+Yahoo failing as silence (see tickets 01 and 03) — treat it as a standing property of the data layer,
+not three separate bugs.
+
+**Caveat:** 12 req/s was measured from a **residential IP**. Yahoo is more aggressive toward datacenter
+ranges. Since v1 runs locally this is favourable — the measurement matches the deployment — but it
+becomes an upper bound to re-validate if the app is ever hosted.
+
+### Three problems worth flagging rather than burying
+
+1. **The partial live bar — proven.** At 09:44 ET, AAPL already had a bar dated that day with 8.5M
+   volume: 14 minutes of trading presented as a daily bar. Any ADR, gap or volume computation touching
+   the final bar is silently wrong. And because US and IDX sessions are disjoint, **there is no single
+   safe run time** — this constrains ticket 12's scheduling and ticket 08's use of the latest bar.
+2. **Survivorship bias.** TWTR, ATVI, VMW, SIVBQ all return **0 rows**. Any backtest is biased upward.
+   Cheap mitigation worth starting day one regardless of when validation gets designed: **snapshot the
+   Nasdaq listing files nightly** to accumulate a point-in-time universe going forward.
+3. **ToS.** Yahoo prohibits volume constituting "excessive or abusive usage", judged at their "absolute
+   and sole discretion". Single-user personal use does not trip the income or sharing clauses, but the
+   honest characterisation is **tolerated, not authorised**. Say so in the spec rather than passing
+   over it.
+
+### Verified facts
+
+- **Universe enumeration solved** — Nasdaq Trader files over HTTPS (not just FTP), with an `ETF` flag
+  that separates funds cleanly → **5,711 symbols** after filtering, matching this ticket's ~6,000
+  premise.
+- **Memory** — the 2y in-memory pandas frame measured **161 MB**. Fine locally; worth noting that
+  materialising the whole frame is a choice, and streaming per chunk is the alternative.
+
+### Dead ends
+
+- **Stooq is gone** — returns HTTP 200 with a JS proof-of-work interstitial (verified for both `.us`
+  and `.jk`). Because it is a 200 with HTML, naive clients parse garbage rather than erroring.
+  `pandas-datareader`'s Stooq path no longer imports.
+- Eliminated on arithmetic alone: Alpha Vantage (**25 req/day**), Tiingo (**500 unique symbols/month**),
+  FMP (**250/day**, US-only), EODHD (**20/day**, 1y history).
+
+### For ticket 12
+
+**Polygon.io rebranded to Massive.com** (2025-10-30); polygon.io URLs now 301, so any existing citation
+of its pricing needs re-checking. Its grouped-daily endpoint returns the whole US market in **one
+call** — nightly cost of 1 request — but it is US-only, capped at 2y history, and was **not** exercised
+with a real key. Documented-only.

--- a/.scratch/screening-dashboard/issues/03-sector-taxonomy-sources.md
+++ b/.scratch/screening-dashboard/issues/03-sector-taxonomy-sources.md
@@ -1,0 +1,93 @@
+# Free sector/industry classification for IDX and US
+
+Type: research
+Status: resolved
+Blocked by: —
+
+## Question
+
+What free, machine-readable sector and industry classification exists for IDX and US equities, and how
+close does any of it get to the *theme* level?
+
+- **IDX**: the exchange publishes **IDX-IC** (11 sectors, sub-sectors, industries). Is it obtainable
+  free and in bulk? How does it map to anything US-comparable? What do free aggregators (Yahoo,
+  Stockbit) report for `.JK` tickers, and how complete/accurate is it?
+- **US**: what free sources carry sector/industry (Yahoo's own taxonomy, SIC codes via SEC, any free
+  GICS-like mapping)? GICS itself is licensed — confirm what is and isn't usable.
+- **Cross-market comparability**: can IDX and US names be placed on one sector axis, or must the
+  rotation view be per-market? This directly shapes the sector model ticket.
+- **Theme**: "AI", "nickel downstream", "GLP-1", "uranium" are not in any standard taxonomy. Survey
+  what free options exist at all — thematic ETF holdings as a proxy, curated public lists, correlation
+  clustering, LLM tagging of company descriptions. For each: cost, freshness, and how it would be kept
+  current. This is scouting the option space, not choosing.
+
+Deliver: what's available per market, completeness/accuracy notes, and an honest read on whether a
+free theme layer is viable in v1 or should be flagged as a scope risk.
+
+## Answer
+
+Findings: [`research/03-sector-taxonomy.md`](../research/03-sector-taxonomy.md). Empirically tested,
+not just documented.
+
+**Cross-market comparability is solved — and better than expected.** Yahoo Finance applies Morningstar's
+GECS taxonomy (11 sectors / 145 industries) *identically* to `.JK` and US tickers. Measured coverage:
+**319/320 sampled tickers returned a sector (99.7%)** across 100 liquid IDX + 100 liquid US + 60 random
+small-cap IDX + 60 random small-cap US. The two misses were a suspended name (`SRIL.JK`) and a delisted
+one (`X`) — so a missing sector is a *delisting signal*, not a coverage gap. **One sector axis spans both
+markets, with no mapping table and no GICS exposure.**
+
+**IDX-IC is not usable as a feed.** `idx.co.id` sits behind Cloudflare bot protection — 403 on the
+IDX-IC page, both JSON APIs, the PDF, and even `robots.txt`, from two egress IPs and via a text proxy.
+It is realistically a hand-maintained static file. Two corrections to this ticket's own premise: IDX-IC
+has **12** sectors, not 11 (the 12th is Listed Investment Products), and it is **not 1:1 mappable** to
+Morningstar — its "Infrastructures" sector absorbs telecom + toll roads + utilities, which Morningstar
+splits three ways. Since Morningstar already covers IDX, IDX-IC is not needed.
+
+**GICS confirmed out**, on S&P DJI/MSCI's own disclaimer: the Information "may not be used to create
+derivative works … indices, databases, risk models, analytics, software." That is precisely this use
+case. Corollary: Wikipedia's S&P 500 sector columns are GICS and do not become free by being on
+Wikipedia.
+
+**SEC SIC verified working** — 444 codes scraped from the SEC list, `data.sec.gov/submissions/CIK*.json`
+returns `sic`/`sicDescription`, `company_tickers.json` gives the ticker map. Free and licence-clean, but
+US-only, coarse, and self-reported. Useful as a cross-check, not as the primary axis.
+
+### The operational finding that shapes the build
+
+**Yahoo rate-limits hard, and it fails as silence.** After ~200 `.info` calls Yahoo returned
+`YFRateLimitError` for ~5 minutes — including for `AAPL`. A first pass reported "0% sector coverage"
+purely from throttling; the same sample at 2s spacing with backoff returned 100%. The screener payload
+carries **no** sector/industry fields (verified across 2,090 quote records), so sector costs **one
+request per symbol** — 1–2 hours wall-clock for a full refresh.
+
+Two consequences, both non-negotiable:
+- Sector must be **cached and refreshed incrementally**, never re-pulled wholesale nightly.
+- The implementation **must distinguish "throttled" from "no sector"**, or it will silently null out
+  good data. Note this generalises: any Yahoo-backed field can fail as silence.
+
+**Also flagged for ticket 05:** Yahoo enumerates only **840** IDX instruments against ~950 listed. That
+gap needs reconciling in the universe definition.
+
+### Theme layer — the honest read
+
+Four options surveyed with cost/freshness/maintenance; none chosen (that is ticket 07's call).
+Empirically: ARK serves plain same-day CSV and SSGA serves real XLSX, but **iShares, Global X and
+VanEck all return HTML/redirects** — three of six issuers need bespoke scrapers and break out of the
+box. SEC N-PORT is the clean universal fallback but is quarterly with ~60-day lag, far too stale to
+define a theme.
+
+**On IDX, plainly: there is no free thematic ETF proxy, because IDX has no thematic ETF layer.** Its 60+
+ETFs are index/sector trackers (LQ-45, IDX30, SRI-KEHATI, Consumer, Financial, SOE) — no nickel,
+EV-battery or AI fund exists. Only correlation clustering (free, both markets, but yields unnamed and
+unstable clusters) or LLM tagging of business descriptions (`longBusinessSummary` present for >99% of
+both markets; ~$1.75–3.50 per full pass at Haiku 4.5 via the Batch API) can produce IDX themes at all.
+
+**So the scope risk is not "themes" — it is theme *parity* across markets.** US-only themes are free and
+buildable; both-markets themes require either a small paid LLM line item or hand-curation. Against the
+map's "both markets from day one" constraint, this needs an explicit ruling — carried to ticket 07.
+
+### Unverified
+
+Marked in the file: the IDX-IC 12/35/69/130 counts (Indonesian secondary sources; IDX's own PDF
+unreachable), sectors.app pricing (bot-blocked), and Yahoo's licensing posture for redistribution —
+the last matters only if this app ever stops being personal.

--- a/.scratch/screening-dashboard/issues/04-free-tier-hosting-and-scheduling.md
+++ b/.scratch/screening-dashboard/issues/04-free-tier-hosting-and-scheduling.md
@@ -1,0 +1,83 @@
+# Free-tier hosting and scheduling for a Python worker + TS frontend
+
+Type: research
+Status: resolved
+Blocked by: —
+
+## Question
+
+What free-tier deployment options can host this app — a nightly Python data/compute job, a persistent
+store, and a TypeScript frontend — for a single user?
+
+Cover at minimum: Vercel, Netlify, Fly.io, Railway, Render, Cloudflare (Workers/Pages/D1/R2),
+GitHub Actions as the scheduler, Supabase, Neon, Turso, and plain SQLite-on-disk.
+
+Evaluate on:
+
+- **Scheduled jobs** — can a cron-triggered Python process run on the free tier, and for how long?
+  Nightly pulls of thousands of symbols may take many minutes. What are the hard timeouts?
+- **Two market calendars** — IDX closes 16:00 WIB, US 16:00 ET, ~12 hours apart. Does the option allow
+  two schedules, and does that double any quota?
+- **Persistence** — free row/storage limits versus the likely footprint (years of daily bars ×
+  thousands of symbols). Does anything force us to a file-based store (Parquet/DuckDB on object
+  storage) instead of a hosted DB?
+- **Python + TS together** — one platform, or a split deploy? What the split costs in complexity.
+- **Cold starts, sleeping, and free-tier eviction** — does the app go to sleep and does that matter for
+  a once-a-day user?
+- **Auth** — cheapest way to keep a public URL private for one user.
+
+Deliver two or three concrete viable stacks end to end (job runner + store + frontend + scheduler +
+auth), with the tradeoffs and a recommendation, plus the first thing that would break if the universe
+or history depth grew.
+
+## Answer
+
+Findings: [`research/04-hosting-and-scheduling.md`](../research/04-hosting-and-scheduling.md)
+(~400 lines, primary-source citation per number, as-of 2026-08-04, 12 claims flagged `[UNVERIFIED]`).
+
+**Three hard blockers found, and they largely determine the architecture:**
+
+1. **Execution timeout disqualifies almost every serverless free tier.** Netlify scheduled functions
+   30s; Supabase Edge Functions 150s; Vercel Hobby functions 300s (default *and* max); Cloudflare
+   Workers free 10ms *CPU* per cron invocation. Only **GitHub Actions (6h/job)** and **Cloud Run Jobs
+   (168h max)** clear a multi-minute nightly pull. Render cron has a 12h limit but carries a $1/month
+   minimum, so it is not free.
+
+2. **No free hosted row store holds the bar history.** Neon 0.5 GB/project, Supabase 500 MB, D1
+   500 MB/database, against an estimated ~2 GB in Postgres for 10y × 7,000 symbols. Turso's 5 GB fits
+   by size, but its 10M rows-written/month cap means one 17.6M-row backfill consumes a month's quota.
+   Conclusion: **bars must live as Parquet/DuckDB on object storage**, not in a hosted SQL DB.
+
+3. **GitHub Actions as scheduler is viable.** Documented cron delay is real but irrelevant to EOD —
+   schedule off-the-hour. The 60-day inactivity auto-disable applies to **public** repos only, so a
+   private repo sidesteps it, at the cost of the 2,000 min/month budget.
+
+**Recommended — Stack A:** GitHub Actions (private repo) → Parquet in Cloudflare R2 → precomputed JSON
+artifacts → static TS frontend on Vercel Hobby → Vercel Authentication. $0, no credit card anywhere.
+The load-bearing move is that **the frontend never queries bar history** — it reads ~3 MB of nightly
+precomputed artifacts, which is what removes the need for a queryable free DB over 17M rows. First
+thing to break: 2,000 Actions minutes/month (escape hatch: flip the repo public).
+
+Alternatives costed: **Stack B** (Actions + Turso + Cloudflare Pages + Cloudflare Access) buys edge SQL
+for interactive drill-down, breaks first on Turso's write quota during backfill. **Stack C** (Cloud Run
+Jobs + GCS + Cloud Scheduler) has the largest compute ceiling but requires a billing account and bills
+on overrun.
+
+**Caveats to carry forward:** Vercel Hobby is contractually non-commercial/personal use only. Two
+previously-common answers are now dead — Hugging Face Spaces requires a paid plan for anything but
+Static, and Fly.io has no free tier for new orgs. All per-row storage estimates are the agent's own
+arithmetic, not vendor figures.
+
+## Superseded — subject ruled out of scope
+
+After this research landed, v1 was scoped to **run locally**, with hosting deferred to a later effort
+and a paid tier (~$10–20/mo) pre-approved for it. The findings above are therefore **background for
+that future effort, not binding constraints on v1**:
+
+- The free-tier execution timeouts and storage caps do not apply to a local run.
+- The precomputed-artifact model — the one architectural conclusion that would have shaped v1's
+  backend/frontend boundary — **no longer applies**. Ticket 12 assumes a live local backend that the
+  UI may query freely.
+
+The research itself remains valid as of 2026-08-04; free-tier terms move fast, so re-verify before
+relying on it.

--- a/.scratch/screening-dashboard/issues/05-universe-definition.md
+++ b/.scratch/screening-dashboard/issues/05-universe-definition.md
@@ -1,0 +1,59 @@
+# Universe definition and data hygiene
+
+Type: grilling
+Status: open
+Blocked by: 01, 02
+
+## Question
+
+What exactly is "the tradeable universe" for each market, and what gets thrown out before anything is
+ranked?
+
+The method reference fixes the two floors (§1): US ≥ $20M/day average dollar volume, IDX ≥ Rp 1B/day,
+and ADR ≥ 4–5%. This ticket settles everything around them:
+
+- **Floor mechanics** — average dollar volume over what window? Median instead of mean, given IDX spikes?
+  Is the ADR floor a hard universe gate or a per-setup gate (it appears in both §1 and §3.5)?
+- **Which floor binds** — the reference warns that on IDX, position value ≤ 5–10% of average daily value
+  traded binds before the Rp 1B floor once the account grows. Does the universe encode that, and does
+  the app need to know the account size to do it?
+- **US numbers are concrete (ticket 02):** Nasdaq Trader listing files enumerate **5,711 symbols** after
+  filtering, and carry an `ETF` flag that separates funds cleanly — so the instrument-filtering question
+  below has a ready mechanism on the US side. The equivalent IDX filter is the screener's
+  `quoteType: EQUITY` (ticket 01).
+- **Instrument filtering** — common stock only? Exclude ETFs, funds, REITs, warrants, rights, preferred?
+  Sector-proxy ETFs are wanted for the rotation view but not as candidates — one universe or two?
+- **Minimum listing age** — how much history before a name is rankable at all, and what happens to a
+  90-day-old IPO that's up 300% (exactly the kind of name he'd want).
+- **IDX-specific exclusions** — suspended names, ARA/ARB limit days, "papan pemantauan khusus" (special
+  monitoring board), full-call-auction names, no-trade days. Which of these disqualify and which are
+  just gaps to handle.
+- **Adjusted vs raw prices** — returns want adjusted; ADR and gap math arguably want raw. Which series
+  feeds which computation, and what happens on a rights-issue day.
+- **Rebuild cadence** — is the universe recomputed nightly, or pinned weekly so rankings stay stable?
+- **Expected size** — roughly how many names survive per market. His tradeable US universe at size is
+  ~150 stocks; is that the shortlist or the universe?
+- **The IDX enumeration gap — answered by ticket 01.** Yahoo's 840 vs IDX's 963 listed is explained:
+  the missing ~120 are suspended or delisted. Not a coverage gap for tonight's scan; it *is*
+  survivorship bias for any backtest (see the validation fog patch). Nothing to decide here beyond
+  acknowledging it.
+- **IDX numbers are now concrete (ticket 01):** 840 enumerable, **292 clear the Rp 1B/day floor** using
+  `Close × Volume` (volume is shares, not lots — verified). Decide whether 292 is the universe you want
+  or whether the floor needs moving.
+- **Adjusted vs raw on IDX is not a free choice (ticket 01).** Yahoo applies rights adjustments
+  invisibly and unauditably, so raw traded prices are **unrecoverable**. Momentum/MA/consolidation math
+  is unaffected; any rule referencing an absolute real-world price level (tick bands, ARA/ARB
+  reconstruction) cannot be implemented on IDX history. Decide what depends on that.
+- **Phantom bars (ticket 01)** — 4.0% of IDX bars have `Volume == 0`, and suspended names emit *more*
+  bars than active ones. Define the drop rule here, since every downstream computation inherits it.
+- **Throttling vs. missing data (from ticket 03)** — Yahoo rate-limits after ~200 rapid calls and
+  **fails as silence**, returning empty rather than erroring loudly. Any universe-construction step
+  must treat "no data" as suspect until proven, or a throttled run will silently shrink the universe.
+
+Resolve against `references/qullamaggie-method.md` §1, and against whatever the data-source research
+says is actually obtainable.
+
+**From ticket 10 (market regime filter):** the regime evaluates the last **closed** session per market
+and surfaces its date. Determining "closed" — the market-calendar rule that distinguishes a complete
+daily bar from the partial one ticket 02 proved Yahoo will hand you mid-session — is settled *here*, and
+applies to every consumer of the latest bar, not just the regime.

--- a/.scratch/screening-dashboard/issues/05-universe-definition.md
+++ b/.scratch/screening-dashboard/issues/05-universe-definition.md
@@ -1,0 +1,357 @@
+# Universe definition and data hygiene
+
+Type: grilling
+Status: resolved
+Blocked by: 01, 02
+
+## Question
+
+What exactly is "the tradeable universe" for each market, and what gets thrown out before anything is
+ranked?
+
+The method reference fixes the two floors (§1): US ≥ $20M/day average dollar volume, IDX ≥ Rp 1B/day,
+and ADR ≥ 4–5%. This ticket settles everything around them:
+
+- **Floor mechanics** — average dollar volume over what window? Median instead of mean, given IDX spikes?
+  Is the ADR floor a hard universe gate or a per-setup gate (it appears in both §1 and §3.5)?
+- **Which floor binds** — the reference warns that on IDX, position value ≤ 5–10% of average daily value
+  traded binds before the Rp 1B floor once the account grows. Does the universe encode that, and does
+  the app need to know the account size to do it?
+- **US numbers are concrete (ticket 02):** Nasdaq Trader listing files enumerate **5,711 symbols** after
+  filtering, and carry an `ETF` flag that separates funds cleanly — so the instrument-filtering question
+  below has a ready mechanism on the US side. The equivalent IDX filter is the screener's
+  `quoteType: EQUITY` (ticket 01).
+- **Instrument filtering** — common stock only? Exclude ETFs, funds, REITs, warrants, rights, preferred?
+  Sector-proxy ETFs are wanted for the rotation view but not as candidates — one universe or two?
+- **Minimum listing age** — how much history before a name is rankable at all, and what happens to a
+  90-day-old IPO that's up 300% (exactly the kind of name he'd want).
+- **IDX-specific exclusions** — suspended names, ARA/ARB limit days, "papan pemantauan khusus" (special
+  monitoring board), full-call-auction names, no-trade days. Which of these disqualify and which are
+  just gaps to handle.
+- **Adjusted vs raw prices** — returns want adjusted; ADR and gap math arguably want raw. Which series
+  feeds which computation, and what happens on a rights-issue day.
+- **Rebuild cadence** — is the universe recomputed nightly, or pinned weekly so rankings stay stable?
+- **Expected size** — roughly how many names survive per market. His tradeable US universe at size is
+  ~150 stocks; is that the shortlist or the universe?
+- **The IDX enumeration gap — answered by ticket 01.** Yahoo's 840 vs IDX's 963 listed is explained:
+  the missing ~120 are suspended or delisted. Not a coverage gap for tonight's scan; it *is*
+  survivorship bias for any backtest (see the validation fog patch). Nothing to decide here beyond
+  acknowledging it.
+- **IDX numbers are now concrete (ticket 01):** 840 enumerable, **292 clear the Rp 1B/day floor** using
+  `Close × Volume` (volume is shares, not lots — verified). Decide whether 292 is the universe you want
+  or whether the floor needs moving.
+- **Adjusted vs raw on IDX is not a free choice (ticket 01).** Yahoo applies rights adjustments
+  invisibly and unauditably, so raw traded prices are **unrecoverable**. Momentum/MA/consolidation math
+  is unaffected; any rule referencing an absolute real-world price level (tick bands, ARA/ARB
+  reconstruction) cannot be implemented on IDX history. Decide what depends on that.
+- **Phantom bars (ticket 01)** — 4.0% of IDX bars have `Volume == 0`, and suspended names emit *more*
+  bars than active ones. Define the drop rule here, since every downstream computation inherits it.
+- **Throttling vs. missing data (from ticket 03)** — Yahoo rate-limits after ~200 rapid calls and
+  **fails as silence**, returning empty rather than erroring loudly. Any universe-construction step
+  must treat "no data" as suspect until proven, or a throttled run will silently shrink the universe.
+
+Resolve against `references/qullamaggie-method.md` §1, and against whatever the data-source research
+says is actually obtainable.
+
+## Answer
+
+Resolved 2026-08-04 in a grilling session. Thirteen decisions below. Every number in the "Measured"
+section was produced during this session against live Yahoo data (`yfinance 1.5.2`, throwaway venv,
+nothing installed into the project) by applying the rules exactly as decided — so the universe sizes
+are observations of *this* rule stack, not estimates.
+
+A principle emerged across the answers and is worth stating once, because three separate rules are
+instances of it: **removal requires stronger evidence than admission.** Sticky membership (D7),
+the asymmetric hysteresis band (D11) and the post-rank ADR filter (D3) all encode it. Admitting a
+marginal name shows you something you can dismiss with your eyes; removing one hides it forever.
+
+### D1 — One instruments table with a `role` column, not two universes
+
+`role` is `candidate` or `reference`. Sector-proxy ETFs are ingested as `reference` — computed like
+anything else, never rankable. Floors filter `role = candidate`.
+
+Rationale: ingestion, bar storage and ADR/return math are identical for `XLE` and `AAPL`; two
+universes duplicate all of it for nothing. Membership stops being the thing that encodes tradeability
+— the floors do that. Role is free at enumeration on both sides: the Nasdaq Trader `ETF` flag on US,
+`quoteType: EQUITY` on IDX.
+
+**Hand-off to ticket 07:** IDX has essentially no sector-ETF `reference` set, so the rotation view
+will likely need a *computed* sector index there rather than a proxy instrument.
+
+### D2 — Liquidity floor is the **median** of `close × volume` over the trailing **20 traded bars**
+
+Median, not mean. 20 bars to match ADR's `SMA20`, so one window constant across the app.
+
+Rationale: on IDX a Rp 200M/day name that prints one Rp 40B block trade clears a 20-day *mean* of
+Rp 1B on that single bar without having become tradeable. The median asks "on a typical day, is there
+Rp 1B here?", which is the question the floor exists to answer.
+
+**Correction to an in-session claim:** the median was predicted to bind "meaningfully tighter" than
+ticket 01's single-day rule. Measured, it binds ~14% tighter (288 vs 336 on the same day) — real, but
+much less than predicted.
+
+### D3 — ADR is **not** a universe gate; it is a post-rank filter, default on at ≥ 4%
+
+Universe = liquidity + instrument type + listing age. ADR filters the ranked list and is toggleable.
+
+Rationale, strongest first:
+- **Decile denominators must be stable.** Ranking is against the whole tradeable universe per market.
+  If ADR gates membership, the denominator breathes with the volatility regime — in a dead tape the
+  universe shrinks and a name's decile rank improves without the name doing anything, so rankings stop
+  being comparable across time. Liquidity is stable enough to gate on; volatility is not.
+- **An ADR gate is structurally late.** A 3.5-ADR name that starts moving is a name whose ADR is
+  *becoming* 8. Gating evicts it on the eve of the move and readmits it ~20 bars later, after the
+  setup. The method exists to catch stocks that just woke up.
+- **§3.5 already prices ADR** as a scored dimension. Gating too means low-ADR names never reach the
+  rubric designed to penalise them, making that dimension near-constant across everything you see.
+
+### D4 — The IDX sizing caveat is **not** encoded in the app at all
+
+No gate, no `account_size` config, no warning badge. The app surfaces median-20d dollar volume on the
+candidate row; the ≤ 5–10%-of-ADV participation rule is applied by the trader at entry.
+
+Rationale: encoded as a gate, decile ranks would shift when the account is *funded* — names vanishing
+from the leaderboard because the account grew. Rejected as a badge too: it is a rule the trader already
+applies, and §8 (position sizing) is out of scope on this map.
+
+### D5 — Minimum listing age: one low universe gate, then per-lookback eligibility
+
+Universe gate: **≥ 20 non-phantom bars** (the minimum for ADR and median dollar volume to exist).
+Ranking: each lookback ranks only names with that much history. A 90-day-old IPO appears in the 1m and
+3m leaderboards and is **absent** — not zero-filled, not backfilled — from 6m/12m/18m/24m.
+
+Rationale: a single global gate forces a false choice — 24 months never shows a recent IPO (which the
+method wants), 20 days fills the 12-month board with 4-month names carrying garbage returns. Partial-
+window returns are *systematically* extreme, so they'd colonise the top decile on noise and train the
+user to ignore the top rows. Per-lookback denominators differ, which is correct: they're different
+questions.
+
+Also: a **"recent listing" marker** for names under ~12 months of bars — a flag, never a disqualifier.
+
+**Fact, not assumption:** neither source gives a true listing date (Nasdaq Trader files don't carry
+one; Yahoo doesn't expose it reliably), so **listing age = date of first available bar**. On IDX that
+proxy floors at 2000 (ticket 01 measured Yahoo's IDX history as effectively beginning then) — harmless,
+26 years past any threshold.
+
+### D6 — Phantom bars are dropped; a density gate doubles as suspension detection
+
+1. A bar is phantom if `volume == 0`. It is **removed from the series** — never zero-filled, never
+   carried forward — before ADR, tightness, returns or dollar volume.
+2. Windows count **traded bars**, not calendar days.
+3. **Density gate:** a name stays in the universe only if ≥ 16 of the market's last 20 sessions were
+   non-phantom for it *and* its most recent final bar is within 3 sessions of the market's latest.
+
+Rationale:
+- A no-trade bar prints `high == low == close`, contributing exactly 0 to `SMA20(high/low − 1)` and
+  dragging ADR toward zero. A thin name would screen as "slow" because it didn't trade.
+- Dropping alone opens a hole, which is what part 3 closes: in pure traded-bar space, a name suspended
+  for eight months with 20 scattered trades has a well-formed 20-bar ADR and would sail in on stale data.
+- **The density gate removes the need for a suspension list, which is unobtainable anyway** (ticket 01
+  measured idx.co.id as Cloudflare-403 to every server-side request). "Hasn't traded in 3 sessions" is
+  the *behaviour* we care about, and it catches suspensions, monitoring-board illiquidity and quiet
+  delistings identically, with nothing to maintain and nothing to go stale. An official list would tell
+  us less.
+
+**No trading-calendar dependency:** "the market's last 20 sessions" is the union of bar dates across
+that market's universe on the night's pull. That *is* the exchange calendar, observed — it costs nothing
+and cannot drift, which a hardcoded two-exchange holiday table certainly would.
+
+Thresholds 80% / 3 sessions are defaults, not sacred.
+
+### D7 — Throttle-silence: absence of data means nothing; incomplete runs don't publish
+
+1. Zero rows is **`unresolved`**, a third state — never `absent`. Retried with backoff.
+2. **Sticky membership.** A name leaves the universe only on positive evidence — real bars failing the
+   density gate. Never because a fetch failed. `unresolved` names carry yesterday's classification
+   forward, visibly stale-marked.
+3. **Run-level completeness gate.** If < ~99% of enumerated symbols resolve after retries, the run is
+   **quarantined**: it does not replace the universe or the leaderboard. Last good run stands, bannered.
+   (Ticket 02 measured 99.93% at 12 req/s, so this is a low bar in practice.)
+4. **Enumeration is checked too.** A materially smaller symbol list than the last good run is a failed
+   run, not a shrinking exchange.
+
+Rationale: missing data and a dead stock produce byte-identical responses, so no per-symbol care can
+separate them — the only robust move is to make the ambiguous signal non-actionable. Rule 2 is
+load-bearing; 1/3/4 are plumbing. Silent shrinkage is worse than a failed run *because it looks like
+success*: a smaller universe makes every decile easier to reach, pushing junk onto the leaderboard with
+nothing anywhere saying "this is wrong". Rule 4 exists because per-symbol failures are countable against
+a known denominator, but a truncated enumeration moves the denominator itself and passes rule 3 at 100%.
+
+### D8 — Provisional bars are dropped; finality is keyed to the exchange clock
+
+A bar dated `D` is final iff, in that exchange's local timezone, `now > D's normal session close + 30
+min`. Non-final bars are **discarded at ingest** — not stored as provisional, not shown flagged.
+
+Rationale: ticket 02 *proved* this (14 minutes of trading served as a full day), and a partial bar
+corrupts ADR, dollar volume and tightness simultaneously — on today's bar, the one weighted most. It
+cannot depend on the schedule because the app runs **locally**, invoked at any hour; keying to the
+exchange clock makes results identical regardless of when it's run. Store-and-flag was rejected: it
+obliges every downstream computation to remember to exclude, forever, and the one that forgets fails
+silently — precisely the bug class this ticket fights. One filter at ingest is one place to be right.
+
+Interacts with D6: "latest traded bar within 3 sessions" counts **final** bars.
+
+Two facts checked so no table is needed:
+- **US half-days need no handling.** Early closes are at 13:00 ET, so a rule keyed to the normal 16:00
+  close + 30 min errs in the safe direction — it waits longer than necessary, never shorter.
+- **IDX is clear:** ticket 01 measured the 2026-08-04 bar present at 19:49 WIB against a 16:00 close.
+
+### D9 — Adjusted everywhere, except dollar volume; and **no absolute-price rules in v1**
+
+- **Adjusted series** for returns, MAs, gaps, contraction, ADR, tightness.
+- **Unadjusted `close × volume`** for dollar volume.
+- **Store both** series (raw OHLC + `Adj Close` + dividends + splits arrive in one Yahoo call).
+- **No minimum price filter, no absolute-price rule anywhere.**
+
+Rationale — this reframes ticket 01's scariest finding as mostly harmless:
+- **Nearly every quantity in the method is a ratio, and ratios are invariant to multiplicative
+  adjustment.** ADR is `SMA20(high/low − 1)`; scale by 10/11 and `high/low` is unchanged. Percentage
+  range, distance-to-MA, tightness, percentage returns: all invariant. **The BBRI 10/11 rights rescale
+  changes no number we compute.**
+- Adjustment bites in only two places. First, at a corporate action *inside* a window — raw prints an
+  ex-dividend gap that never traded and a split cliff; adjusted removes both correctly, so **adjusted
+  wins for anything spanning history**.
+- Second, absolute price levels — and **v1 has none**. Tick bands and ARA/ARB reconstruction are
+  already unimplementable (D10). A minimum price filter is also rejected: the dollar-volume floor
+  excludes penny junk far more precisely, and on IDX low nominal prices are normal (a Rp 50 stock is
+  not a US-sense penny stock). With no absolute-price rule in the system, "raw IDX prices are
+  unrecoverable" costs exactly nothing.
+- **Dollar volume is the real exception:** Yahoo rescales prices for corporate actions but leaves
+  volume alone, so `adjusted close × raw volume` is wrong by the adjustment ratio for all pre-event
+  history. Identical within a clean 20-day window; only the unadjusted product is meaningful across one.
+
+### D10 — No IDX-specific exclusion mechanics. Built deliberately, not omitted
+
+Three of the ticket's five IDX hazards are already dead: **suspended** → D6 density gate, **no-trade
+days** → D6 phantom drop, **delisted** → D7 sticky membership + enumeration check. The other two:
+
+**Special monitoring board / full call auction — no exclusion.** The authoritative list is on
+idx.co.id (Cloudflare-403), and neither ticket 01 nor 03 surfaced a board/segment field from Yahoo, so
+any rule would be a guess dressed as a filter. Not needed: call-auction names fail the Rp 1B median or
+the 80% density gate. And the converse is the real defence — a monitoring-board name that *does* clear
+a 20-day median of Rp 1B across 16 of 20 sessions is genuinely liquid, and excluding it would be
+excluding a real name on a label rather than its behaviour.
+
+**ARA/ARB limit days — not handled here; stays in fog for ticket 08.** Detection needs the auto-reject
+band (tiered by price and board; table on the blocked idx.co.id), and per D9 raw IDX prices are
+unrecoverable so bands can't be inferred from history. A genuine dead end on free data, not an unmade
+decision. The distortion runs in the safe direction: a limit-locked bar has a collapsed high/low range,
+so it **understates** ADR — risking a missed candidate, not a bad one promoted.
+
+**Accepted residual risk: a limit-locked IDX name may screen as low-ADR and we will not know.**
+
+### D11 — Nightly rebuild, with an asymmetric hysteresis band and nightly membership snapshots
+
+Rebuild nightly. A name **enters** at ≥ 1.0× the floor and **leaves** only below **0.8×**. Snapshot
+universe membership nightly, one row per name per night.
+
+Rationale: pinning weekly is stale in exactly the wrong direction — a name that just became liquid is a
+name that just started attracting money, which is the signal; and since data is pulled nightly anyway,
+pinning buys no compute saving. But a hard threshold plus nightly rebuild produces boundary churn:
+names entering and exiting night after night with no change in price action, each transition moving the
+decile denominator and re-ranking everything. Measured: **25 IDX names and 141 US names** sit in the
+0.8–1.0× band — small enough to confirm the band is a targeted fix, not a blunt one.
+
+The band is asymmetric by design (easy in, sticky out), consistent with D7 and D3.
+
+Snapshots are the only way any future validation can ask "what was rankable that night" — the one thing
+we can start accumulating today for free against the survivorship-bias problem. Complements the nightly
+listing-file snapshots already assigned to ticket 12.
+
+### D12 — Floors kept at their reference values: **Rp 1B/day** (IDX) and **$20M/day** (US)
+
+And **§1's "~150 stocks" is his shortlist, not his universe** — the floors are not tuned to hit it.
+
+Rationale: §1's 150 is what survives liquidity *and* ADR ≥ 4–5% *and* his account size. Ours is the
+liquidity-only population, since D3 moved ADR downstream and D4 dropped account size entirely — a
+different stage of the funnel, so matching the numbers would mean over-filtering by two criteria
+deliberately moved elsewhere.
+
+288 IDX names gives a ~29-name top decile — reviewable nightly. At Rp 5B it'd be 165 names, so a decile
+is 16 and the ranking gets coarse and jumpy at the boundary. At Rp 500M it'd be 364, but the extra 76
+are names the trader's own participation rule makes untradeable anyway — extra rows, diluted deciles.
+
+The floor is one config number over a nightly-rebuilt universe. Ticket 08's detection work will say far
+more about whether 288 is the right pool than more reasoning here.
+
+### D13 — Instrument filtering: **common stock only**
+
+Excluded by security-name pattern: **warrants, rights, units, notes/bonds, preferred, trusts/funds.**
+**ADRs are kept** — they are common equity and are not in any excluded class.
+
+This was a stricter cut than initially recommended, chosen deliberately by the trader: "exclude them
+all, i want stocks only."
+
+**A defect found by measuring rather than reasoning, recorded because it nearly shipped:** the first
+preferred pattern included `Depositary Sh`, but "American Depositary Shares" is the **ADR** structure.
+That regex would have deleted **BABA, ARM, SE, PDD, NOK, SHEL, JD, VALE, UL, INFY, ARGX, SIMO** from the
+universe — the most liquid, highest-ADR names the method exists to trade. Corrected to
+`\bPreferred\b|\bPfd\b`, which rescued **278 names**.
+
+**Accepted costs, named rather than hidden:**
+- Excluding trusts/funds on a name match deletes **NTRS (Northern Trust)** — an operating bank caught by
+  its legal name — plus ~22 liquid REITs/BDCs (DLR, ESS, CPT, FRT, ARCC).
+- Excluding units deletes **MLP common units** (ET at ~$179M/day, MPLX at ~$88M).
+- Excluding preferred deletes **ITUB and BNS**, whose US lines are preferred-share ADRs and are the
+  primary way to trade those issuers.
+
+**⚠ This is the only non-behavioural rule in the entire ticket** — every other rule tests what a name
+*does*; this one matches its name. It misfires in both directions and **needs a spot-check against the
+surviving list on the first real pipeline run.**
+
+**Low stakes, worth knowing:** the whole instrument-type question moves ~38 names out of 2,004 (1.9%)
+on US. The liquidity floor and density gate do nearly all the work.
+
+---
+
+## Measured — universe sizes under this exact rule stack
+
+Live Yahoo data, 2026-08-04, `yfinance 1.5.2`. Stage order: enumerate → drop phantom bars → density
+gate → median-20d floor → instrument-type exclusion.
+
+| stage | IDX | US |
+|---|---|---|
+| enumerated | 840 (`quoteType: EQUITY`) | 6,944 (non-ETF, non-test) |
+| ≥ 1 non-phantom bar | 840 | 6,789 (97.77%) |
+| passing density gate | 831 | 5,937 |
+| median-20d ≥ floor | 288 (Rp 1B) | 2,004 ($20M) |
+| **after D13 instrument exclusion** | **288** | **1,966** |
+| in 0.8–1.0× hysteresis band | 25 | 141 |
+
+Floor sensitivity (median-20d, post-density):
+
+| IDX floor | survivors | | US floor | survivors |
+|---|---|---|---|---|
+| Rp 0.5B | 364 | | $10M | 2,437 |
+| **Rp 1B** | **288** | | **$20M** | **2,004** |
+| Rp 2B | 228 | | $50M | 1,390 |
+| Rp 5B | 165 | | $100M | 928 |
+| Rp 10B | 109 | | | |
+
+Two observations from the measurement:
+
+- **The density gate's value is market-asymmetric.** It removed 9 names on IDX but **852** on US. Yahoo's
+  IDX screener already returns only actively-traded names, whereas the Nasdaq Trader files carry a long
+  tail of barely-traded instruments. On IDX the gate is a *guard* against future suspensions; on US it is
+  a bulk filter doing real work tonight.
+- **Instrument-type filtering is nearly cosmetic** next to the liquidity floor (1.9% of US names).
+
+## Findings handed to other tickets
+
+- **→ Ticket 06 (ranking and decile model): "top decile" is probably the wrong cut on US.** A decile of
+  1,966 is ~197 names — unreviewable in a 10-minute nightly pass, and lopsided against IDX's ~29. §1
+  gives a tighter native definition: a momentum leader is the **top 1–2% of gainers**, which on ~2,000
+  names is ~30 — matching IDX's decile almost exactly. Ticket 06 should decide between a percentile that
+  is constant *in rank* vs constant *in count* across two markets of very different size.
+- **→ Ticket 06: per-lookback denominators differ** by construction (D5). Ranking must handle a universe
+  whose size varies by lookback.
+- **→ Ticket 08: ARA/ARB limit days** remain undecided and unimplementable on free data (D10). Whether
+  contraction/tightness need to handle them is ticket 08's call.
+- **→ Ticket 07: IDX has no meaningful sector-ETF `reference` set** (D1) — rotation there likely needs a
+  computed sector index.
+- **→ Ticket 12: history depth** is now specifiable and lands there (see map fog graduation).
+
+## Probe scripts
+
+Disposable, in the job scratch dir — `idx_universe.py`, `us_universe.py`, `us_instrument_types.py`,
+`us_noncommon_liquid.py`. Nothing was installed into the project.

--- a/.scratch/screening-dashboard/issues/06-ranking-and-decile-model.md
+++ b/.scratch/screening-dashboard/issues/06-ranking-and-decile-model.md
@@ -1,0 +1,31 @@
+# Ranking and decile model
+
+Type: grilling
+Status: open
+Blocked by: 05
+
+## Question
+
+How is "top decile" computed, over which periods, and what does the leaderboard actually show?
+
+Settled during charting: ranking is against the **whole tradeable universe, per market**. Open:
+
+- **Lookbacks** — §1 names 1/3/6/12/18/24 months for the gainers scan; §3.1 gates the setup on
+  "top decile of 1–6 month returns". Which lookbacks does the app compute, which one gates the setup,
+  and is the gate "top decile in *any* of 1/3/6m" or a composite?
+- **Return calculation** — simple close-to-close on adjusted prices? Calendar months or trading days?
+  What happens when a name lacks the full lookback (see universe minimum-age decision).
+- **Composite RS score** — does the app produce a single weighted momentum rank (IBD-style) or keep the
+  lookbacks separate? He talks in separate lookbacks; a composite is easier to sort by.
+- **"Each period" in the ask** — the request was "top deciles each period". Does that mean a leaderboard
+  per lookback, or a time series showing who has been in the top decile over successive weeks (i.e. how
+  leadership is changing)? These are different features.
+- **Decile vs top-N** — §1 says "top 1–2% of gainers" for a momentum leader; §3.1 says top decile.
+  Reconcile: is the decile the universe gate and the top 1–2% a separate "leader" badge?
+- **Volatility adjustment** — should raw return be normalised by ADR? A 300% move in a 12-ADR name is a
+  different thing from a 300% move in a 3-ADR name. He does not do this; decide whether we do.
+- **Rank stability** — how much day-to-day churn is acceptable, and is any smoothing applied.
+- **Persistence** — are historical ranks stored so leadership change is visible, and how far back.
+
+This ticket also feeds the sector model — decide whether sector strength is aggregated from these same
+member ranks or computed independently.

--- a/.scratch/screening-dashboard/issues/06-ranking-and-decile-model.md
+++ b/.scratch/screening-dashboard/issues/06-ranking-and-decile-model.md
@@ -1,0 +1,40 @@
+# Ranking and decile model
+
+Type: grilling
+Status: open
+Blocked by: 05
+
+## Question
+
+How is "top decile" computed, over which periods, and what does the leaderboard actually show?
+
+Settled during charting: ranking is against the **whole tradeable universe, per market**. Open:
+
+- **Lookbacks** — §1 names 1/3/6/12/18/24 months for the gainers scan; §3.1 gates the setup on
+  "top decile of 1–6 month returns". Which lookbacks does the app compute, which one gates the setup,
+  and is the gate "top decile in *any* of 1/3/6m" or a composite?
+- **Return calculation** — simple close-to-close on adjusted prices? Calendar months or trading days?
+  What happens when a name lacks the full lookback (see universe minimum-age decision).
+- **Composite RS score** — does the app produce a single weighted momentum rank (IBD-style) or keep the
+  lookbacks separate? He talks in separate lookbacks; a composite is easier to sort by.
+- **"Each period" in the ask** — the request was "top deciles each period". Does that mean a leaderboard
+  per lookback, or a time series showing who has been in the top decile over successive weeks (i.e. how
+  leadership is changing)? These are different features.
+- **Decile vs top-N** — §1 says "top 1–2% of gainers" for a momentum leader; §3.1 says top decile.
+  Reconcile: is the decile the universe gate and the top 1–2% a separate "leader" badge?
+  **Ticket 05 makes this concrete and urgent.** Measured universe sizes are **288 IDX / 1,966 US**, so a
+  top decile is **~29 names on IDX but ~197 on US** — unreviewable in a 10-minute nightly pass, and
+  wildly lopsided between two markets shown side by side. §1's own top-1–2% gives ~30 on US, which
+  matches IDX's decile almost exactly. So the real decision is whether the cut is constant **in rank**
+  (a percentile, which scales with universe size) or constant **in count** (a top-N, which does not).
+- **Per-lookback denominators differ** (ticket 05, D5). A name is ranked in a lookback only if it has
+  that much history, so the 12-month population is smaller than the 1-month one. Ranking must handle a
+  universe whose size varies by lookback — and "top decile" means a decile *of that lookback's*
+  population.
+- **Volatility adjustment** — should raw return be normalised by ADR? A 300% move in a 12-ADR name is a
+  different thing from a 300% move in a 3-ADR name. He does not do this; decide whether we do.
+- **Rank stability** — how much day-to-day churn is acceptable, and is any smoothing applied.
+- **Persistence** — are historical ranks stored so leadership change is visible, and how far back.
+
+This ticket also feeds the sector model — decide whether sector strength is aggregated from these same
+member ranks or computed independently.

--- a/.scratch/screening-dashboard/issues/07-sector-theme-and-rotation-model.md
+++ b/.scratch/screening-dashboard/issues/07-sector-theme-and-rotation-model.md
@@ -1,0 +1,45 @@
+# Sector/theme leadership and rotation model
+
+Type: grilling
+Status: open
+Blocked by: 03, 06
+
+## Question
+
+How does the app decide what is leading, and what does "where the rotation goes" mean concretely?
+
+- **Sector strength metric** — median member return? Share of members in the top decile? Equal-weighted
+  vs cap-weighted sector index? Sector ETF price for US (§1 warns he prefers the high-ADR stock over the
+  low-ADR ETF, but the ETF may still be the cleanest strength proxy). IDX has no equivalent ETF layer,
+  so the metric may have to differ per market — is that acceptable?
+- **Cross-market comparability** — one leaderboard spanning IDX + US sectors, or strictly per market?
+  Depends on what ticket 03 finds about taxonomies.
+- **Rotation, defined** — the ask says "where the rotation goes". Candidates: change in sector rank over
+  a window; a relative-rotation-style quadrant (relative strength vs. relative momentum); a flow-of-rank
+  visual over successive periods; simply "which sectors newly entered the top". Pick one and define it
+  numerically, because the visual follows from the definition.
+- **Theme layer — now a sharp ruling, thanks to ticket 03.** The sector axis is settled (Yahoo/
+  Morningstar GECS, both markets). Theme is not, and the constraint is specific: **IDX has no thematic
+  ETF layer at all**, so the ETF-holdings proxy that works for US produces *nothing* for IDX. The
+  choice is therefore about **parity**, not about themes in general:
+  - **US-only themes** — free, buildable from ARK/SSGA (ARK serves same-day CSV, SSGA real XLSX;
+    iShares, Global X and VanEck need bespoke scrapers and break out of the box). Breaks the map's
+    "both markets from day one" constraint for this one feature.
+  - **Both markets via LLM tagging** of `longBusinessSummary` (present for >99% of both markets),
+    ~$1.75–3.50 per full pass at Haiku 4.5 via the Batch API. Small, but it is a paid line item in an
+    otherwise free-data v1, and it needs a re-tagging cadence.
+  - **Both markets via correlation clustering** — free, but produces unnamed and unstable clusters,
+    which is arguably not a "theme" at all.
+  - **Hand-curated** — you maintain the list. Cheapest to build, most honest about how themes actually
+    form, costs your time and goes stale silently.
+  - **No theme layer in v1** — sector only, theme deferred. Ruled out of scope rather than half-built.
+
+  Whichever wins: how is a stock assigned (one theme or many?), and how does a new theme get added
+  mid-quarter? Themes are born fast, and that is exactly when they matter.
+- **§10 tie-in** — "pullbacks are information": whatever holds support while the index tests lower is
+  showing RS and leads the next leg. Does the app surface that explicitly, or is it emergent from the
+  rankings?
+- **Sector confirmation in the score** — §3.5 gives "sector/theme confirmation" one point. This ticket
+  must define it precisely enough to be computed as a boolean.
+
+Resolve against `references/qullamaggie-method.md` §1 and §10.

--- a/.scratch/screening-dashboard/issues/08-setup-detection-algorithm.md
+++ b/.scratch/screening-dashboard/issues/08-setup-detection-algorithm.md
@@ -1,0 +1,73 @@
+# Setup detection algorithm — making the breakout/continuation computable
+
+Type: grilling
+Status: open
+Blocked by: 05
+
+## Question
+
+How does a machine decide, from daily bars alone, that a stock is in a valid breakout/continuation
+setup? This is the highest-risk ticket on the map.
+
+§3 is written for a human eye. Each clause needs a computable definition — or an explicit admission
+that it can't be computed and must be shown to the human instead:
+
+- **Consolidation detection** — where does the base start and end? Anchor on the prior move's high, on a
+  swing detection, on a volatility-contraction measure? §3.1 requires ≥ 3–5 days sideways.
+- **Range contraction / tightness** — the load-bearing quantity (§3.5 weights it ×2). Candidates:
+  ratio of recent N-day range to earlier N-day range; ATR or ADR compression; declining true range
+  slope; narrowing high/low envelope. Pick one and define the threshold.
+- **Higher lows** — over what pivot detection, and does a single undercut break it? §3.2 says undercuts
+  and overshoots are *desirable*, so a naive monotonic test will reject the best setups. This is the
+  trap to design around.
+- **Orderliness** — the other ×2 dimension, and the fuzziest. "Smooth drift, not a barcode." Candidates:
+  distribution of candle body sizes; count of wide-range days in the base; R² of a linear fit to the
+  pullback; ratio of net drift to path length. Decide whether this is scorable at all or is the point
+  where the human takes over.
+- **The trendline** — §3.2 is explicit that the correct procedure is *find the tight cluster sitting on a
+  rising MA, anchor there, extrapolate backwards over the prior highs* — not connect-the-swing-highs.
+  Can that be automated? Its output sets the alert level and therefore the entry, and the entry sets
+  whether the ≤ 1×ADR stop is affordable — so getting this wrong invalidates the trade, not just the
+  chart. If it can't be automated reliably, what does the app draw instead?
+- **MAs caught up** — §3.1 wants the 10 and 20 to have converged on price, with a stated preference for
+  20-day-based setups. Define "caught up" as a distance threshold, and how the 10-vs-20 preference
+  shows up in the score.
+- **Volume** — dry-up in the base and expansion on the break, both as numeric tests.
+- **Backside veto** — §5 says never buy a breakout in a backside stock. That test needs 60-minute bars
+  (10/20/65 EMA flipping to resistance), which an EOD-only app doesn't have. Decide the daily-bar
+  substitute, or accept the gap and surface it as a warning.
+- **Stop affordability** — §7 caps the stop at 1×ADR and §6 says pick the shortest timeframe whose stop
+  you can afford. With EOD data only, what stop can the app estimate, and does it reject candidates
+  whose implied stop exceeds 1×ADR?
+- **Output shape** — one boolean plus a score, or a set of graded signals the star rubric consumes?
+
+**Data hazards this ticket must design around (from ticket 01):**
+
+- **Phantom zero-volume bars** — 4.0% of IDX bars, concentrated in suspended names, which emit *more*
+  bars than active ones. A flat bar is maximal "contraction" to any naive tightness measure, so these
+  will manufacture five-star setups out of dead stocks unless dropped first.
+- **ARA/ARB limit days** on IDX cap the daily range artificially, which biases both ADR and any
+  range-contraction measure downward. Decide whether they need detecting.
+- **Invisible rights adjustments** mean absolute historical price levels are not trustworthy on IDX.
+  Relative geometry (ranges, ratios, MA distance) is fine; anything anchored to a real price is not.
+- **The last bar may be partial (ticket 02)** — while a session is open, the current day's bar contains
+  only the hours traded so far. Breakout detection keys on the *most recent* bar, which is precisely
+  the one at risk. Decide explicitly whether detection ever runs against an open session, or only ever
+  against closed bars.
+
+- **ARA/ARB limit days on IDX — inherited from ticket 05, undecided by design.** Ticket 05 (D10)
+  established that limit-day detection is a dead end on free data: the auto-reject band is tiered by
+  price and board with the table behind Cloudflare, and raw IDX prices are unrecoverable so the bands
+  cannot be inferred from history either. The distortion is that a limit-locked bar has a **collapsed
+  high/low range**, which understates ADR and flatters tightness. Whether contraction/tightness must
+  handle this at all is **this ticket's call** — it is the only place the question can be answered,
+  because it depends on how contraction is defined.
+- **The partial-bar question below is already settled** by ticket 05 (D8): non-final bars are dropped at
+  ingest on an exchange-clock rule, so detection *never* sees an open session. What remains for this
+  ticket is only whether detection wants anything else from the current session.
+- **Inputs this ticket can assume**, all fixed by ticket 05: phantom (`volume == 0`) bars are already
+  removed and windows count **traded bars**, not calendar days; series are **adjusted** (so all ratio
+  measures are adjustment-safe); there is **no absolute-price rule** anywhere, so detection must not
+  introduce one on IDX.
+
+Resolve against `references/qullamaggie-method.md` §3, §6, §7. Expect this to spawn follow-on tickets.

--- a/.scratch/screening-dashboard/issues/08-setup-detection-algorithm.md
+++ b/.scratch/screening-dashboard/issues/08-setup-detection-algorithm.md
@@ -1,0 +1,63 @@
+# Setup detection algorithm — making the breakout/continuation computable
+
+Type: grilling
+Status: open
+Blocked by: 05
+
+## Question
+
+How does a machine decide, from daily bars alone, that a stock is in a valid breakout/continuation
+setup? This is the highest-risk ticket on the map.
+
+§3 is written for a human eye. Each clause needs a computable definition — or an explicit admission
+that it can't be computed and must be shown to the human instead:
+
+- **Consolidation detection** — where does the base start and end? Anchor on the prior move's high, on a
+  swing detection, on a volatility-contraction measure? §3.1 requires ≥ 3–5 days sideways.
+- **Range contraction / tightness** — the load-bearing quantity (§3.5 weights it ×2). Candidates:
+  ratio of recent N-day range to earlier N-day range; ATR or ADR compression; declining true range
+  slope; narrowing high/low envelope. Pick one and define the threshold.
+- **Higher lows** — over what pivot detection, and does a single undercut break it? §3.2 says undercuts
+  and overshoots are *desirable*, so a naive monotonic test will reject the best setups. This is the
+  trap to design around.
+- **Orderliness** — the other ×2 dimension, and the fuzziest. "Smooth drift, not a barcode." Candidates:
+  distribution of candle body sizes; count of wide-range days in the base; R² of a linear fit to the
+  pullback; ratio of net drift to path length. Decide whether this is scorable at all or is the point
+  where the human takes over.
+- **The trendline** — §3.2 is explicit that the correct procedure is *find the tight cluster sitting on a
+  rising MA, anchor there, extrapolate backwards over the prior highs* — not connect-the-swing-highs.
+  Can that be automated? Its output sets the alert level and therefore the entry, and the entry sets
+  whether the ≤ 1×ADR stop is affordable — so getting this wrong invalidates the trade, not just the
+  chart. If it can't be automated reliably, what does the app draw instead?
+- **MAs caught up** — §3.1 wants the 10 and 20 to have converged on price, with a stated preference for
+  20-day-based setups. Define "caught up" as a distance threshold, and how the 10-vs-20 preference
+  shows up in the score.
+- **Volume** — dry-up in the base and expansion on the break, both as numeric tests.
+- **Backside veto** — §5 says never buy a breakout in a backside stock. That test needs 60-minute bars
+  (10/20/65 EMA flipping to resistance), which an EOD-only app doesn't have. Decide the daily-bar
+  substitute, or accept the gap and surface it as a warning.
+- **Stop affordability** — §7 caps the stop at 1×ADR and §6 says pick the shortest timeframe whose stop
+  you can afford. With EOD data only, what stop can the app estimate, and does it reject candidates
+  whose implied stop exceeds 1×ADR?
+- **Output shape** — one boolean plus a score, or a set of graded signals the star rubric consumes?
+
+**Data hazards this ticket must design around (from ticket 01):**
+
+- **Phantom zero-volume bars** — 4.0% of IDX bars, concentrated in suspended names, which emit *more*
+  bars than active ones. A flat bar is maximal "contraction" to any naive tightness measure, so these
+  will manufacture five-star setups out of dead stocks unless dropped first.
+- **ARA/ARB limit days** on IDX cap the daily range artificially, which biases both ADR and any
+  range-contraction measure downward. Decide whether they need detecting.
+- **Invisible rights adjustments** mean absolute historical price levels are not trustworthy on IDX.
+  Relative geometry (ranges, ratios, MA distance) is fine; anything anchored to a real price is not.
+- **The last bar may be partial (ticket 02)** — while a session is open, the current day's bar contains
+  only the hours traded so far. Breakout detection keys on the *most recent* bar, which is precisely
+  the one at risk. Decide explicitly whether detection ever runs against an open session, or only ever
+  against closed bars.
+
+Resolve against `references/qullamaggie-method.md` §3, §6, §7. Expect this to spawn follow-on tickets.
+
+**Owed to ticket 10 (market regime filter):** detection must emit a defined **trigger level** per
+detected setup — the price the breakout keys on. Ticket 10 records it nightly from launch so a
+follow-through series accumulates forward; without a stable definition here there is nothing to record
+against, and the capture cannot be backfilled later.

--- a/.scratch/screening-dashboard/issues/09-star-score-calibration.md
+++ b/.scratch/screening-dashboard/issues/09-star-score-calibration.md
@@ -1,0 +1,29 @@
+# Star score calibration
+
+Type: prototype
+Status: open
+Blocked by: 08
+
+## Question
+
+Does the computed 1–5 star score agree with your eye?
+
+§3.5 gives the rubric — 8 dimensions, tightness and orderliness weighted ×2, max 10, stars = score ÷ 2,
+trade 4–5 stars full size. Ticket 08 makes each dimension computable. This ticket checks whether the
+composition actually produces the grades you'd give.
+
+Build a throwaway prototype that scores real historical setups and puts the chart next to the score, then
+sit with it and disagree with it. Specifically:
+
+- Pull a set of known-good historical examples (his own named ones where available — the ZM / AR / APPS
+  worked examples in §3.2 — plus names you recall) and a set of known-bad ones ("barcode", wide and
+  loose, low ADR, no prior move).
+- Score them. Where does the score disagree with your judgement, and in which direction?
+- Are the ×2 weights right, or does one dimension dominate in practice?
+- Is the 4-star trade threshold in the right place, or does it admit junk / reject winners?
+- Are the sub-scores better as booleans (§3.5's "1 point if…") or as continuous 0–1 values? Booleans are
+  faithful to the rubric but throw away information near thresholds.
+- Does the score need to be per-market calibrated? IDX and US have different volatility regimes.
+
+Output: a calibrated rubric with concrete thresholds, plus a record of the disagreements — the failure
+cases are as valuable as the parameters. Link the prototype rather than pasting it here.

--- a/.scratch/screening-dashboard/issues/10-market-regime-filter.md
+++ b/.scratch/screening-dashboard/issues/10-market-regime-filter.md
@@ -1,0 +1,149 @@
+# Market regime filter
+
+Type: grilling
+Status: resolved
+Blocked by: 02
+
+## Question
+
+How does the app compute and present "is this a tape you should be swinging long in?"
+
+§10 gives the rules qualitatively. Make them numeric:
+
+- **Which index per market** — US: S&P 500, Nasdaq Composite, Russell 2000, or an equal-weighted
+  breadth measure of your own universe? His names are small/mid momentum, so the S&P may be the wrong
+  proxy. IDX: IHSG, LQ45, or a universe-derived breadth measure?
+- **The gates** — §10's "do not swing long" is 10-day sloping down **and** 20-day sloping down **and**
+  10 below 20. Define "sloping down" (slope over how many days, what threshold). Define the
+  long-friendly condition symmetrically.
+- **Three states or two** — long-friendly / choppy / don't-swing. "Choppy" is where he sits out, and
+  it's the hardest to define. What makes a tape choppy numerically — whipsaw count, failed-breakout
+  rate, index ADR, MA crossover frequency?
+- **Breadth and follow-through** — "breakouts follow through" and "sectors moving in packs" are the
+  signals he actually cites. The app can measure its own hit rate: what fraction of last week's
+  detected breakouts are still above their breakout level? That's a strong regime signal and it's free
+  once detection exists. Decide whether it's in v1.
+- **What the app does with it** — a banner? A size multiplier on every candidate? Does a hostile regime
+  suppress the candidate list entirely, or just annotate it? He does not stop looking; he stops sizing.
+- **Per market independently** — IDX and US regimes diverge. Two separate verdicts, presumably; confirm.
+
+Resolve against `references/qullamaggie-method.md` §10 and §2.
+
+## Answer
+
+Both markets get their own verdict, computed nightly from a single index each, using only sign-based
+slope tests. No parameter on this ticket needs calibration, which is deliberate: nothing here can be
+backtested, because delisted names return zero rows on Yahoo (ticket 02) and any historical series
+rebuilt from today's universe is biased upward.
+
+### Index per market
+
+| Market | Index | Ticker |
+| --- | --- | --- |
+| US | Nasdaq Composite | `^IXIC` |
+| IDX | IHSG (Jakarta Composite) | `^JKSE` |
+
+Availability verified against the Yahoo chart endpoint already in use — `^JKSE`, `^GSPC`, `^IXIC`,
+`^RUT` and `R-LQ45X.JK` all return full daily history, so this was a free choice, not a constrained one.
+
+- **Nasdaq Composite over S&P 500**: `^GSPC` is cap-weighted into mega-caps and its 10/20-day slope can
+  read healthy while small/mid momentum — the tape these candidates actually trade in — is in a
+  downtrend.
+- **Nasdaq Composite over Russell 2000**: `^RUT` fails the other way, dominated by unprofitable
+  micro-caps and biotech that can sit in a downtrend for a year while momentum growth works, which would
+  suppress sizing through a tradeable market.
+- **IHSG over LQ45**: LQ45 is 45 large caps; the Rp 1B/day liquidity floor puts most IDX candidates
+  outside it, so LQ45 would be measuring a different market from the one being screened.
+
+### Moving averages and slope
+
+§2 fixes the daily MAs as **simple** (the 65 EMA is the only exponential on the daily), so:
+
+- `SMA10`, `SMA20` over index **daily closes**.
+- **Rising** iff `SMA[t] > SMA[t-5]`; **falling** iff `SMA[t] < SMA[t-5]`. **Sign only — no magnitude
+  threshold.** Five trading days is the natural resolution for a swing timeframe, and sign-only means
+  there is no parameter to fit against an unbacktestable series.
+- Hysteresis comes from the compound gate rather than from a deadband: the 20-day turns slowly, so the
+  HOSTILE condition cannot flicker on a single bar.
+
+### The three states
+
+Evaluated independently per market, on the last **closed** session:
+
+- **`HOSTILE`** — `SMA10` falling **AND** `SMA20` falling **AND** `SMA10 < SMA20`. (§10 verbatim.)
+- **`FRIENDLY`** — `close > SMA10` **AND** `close > SMA20` **AND** `SMA10` rising **AND** `SMA20` rising.
+- **`CHOPPY`** — everything else.
+
+Chop is the **residual**, not a measured quantity. This is the load-bearing choice on the ticket: §10's
+two named conditions are not complements, and the gap between them *is* chop — "false signals both ways,
+I don't see an edge right now". Defining it as the residual adds **zero parameters**, maps §10
+clause-for-clause, and fails safe, since a tape that cannot make up its mind lands in the cautious middle
+by construction.
+
+**No precedence rule is needed.** HOSTILE requires `SMA10` falling and FRIENDLY requires it rising, so
+the two are mutually exclusive by construction; the three states partition the space exactly.
+
+**Warm-up**: 25 index bars (`SMA20` plus the 5-day slope lookback). Below that, the state is undefined
+rather than defaulted.
+
+### What the app does with it
+
+- A **persistent banner per market** — two banners, never combined into a global verdict. IHSG and the
+  Nasdaq run on different cycles; a combined roll-up would require a combination rule with nothing to
+  justify it, and would have a strong IHSG sat out because the Nasdaq rolled over.
+- Each banner carries a **sizing posture**: `FRIENDLY` → full size, `CHOPPY` → reduced, `HOSTILE` → sit
+  out. **Advisory words only, not a computed position size** — the §8 sizing calculator is out of scope,
+  and this must not smuggle it back in.
+- **The candidate list is identical in all three states.** Never filtered, never reordered by regime.
+  This is the literal reading of §10 — *he does not stop looking, he stops sizing* — and it keeps the
+  regime out of the detection path, so a bad regime call can never hide a setup.
+- **The regime never touches the star score.** §3.5 grades the setup; a 5-star base is still a 5-star
+  base in a bad tape, and folding regime in would destroy that distinction.
+- The banner displays the **as-of session date** (see Dependencies).
+
+### Breadth — shown, does not gate
+
+Share of that market's tradeable universe above its own rising `SMA10`/`SMA20`, displayed beside the
+banner. It is **not an input to the verdict** in v1.
+
+The reason is specific, not caution for its own sake: **breadth is the measure survivorship bias corrupts
+most directly.** Yahoo's screener enumerates only live names, so every historical breadth reading is
+computed without the names that would have dragged it down — biased upward by a known but unmeasurable
+amount. Any threshold picked today would be fitted to a series that is wrong in a known direction. It
+costs nothing to compute (the universe is already pulled), so it goes on screen to be watched live and
+promoted to a gate later, with evidence.
+
+### Breakout follow-through — captured from day one, displayed later
+
+Every detected setup and its **trigger level** is written to the store nightly, starting with the first
+run.
+
+- It is the **only regime signal here that is not survivorship-biased**, because it is recorded forward
+  in real time rather than reconstructed from a surviving universe.
+- It is **irrecoverable if skipped** — it cannot be rebuilt from Yahoo after the fact, so the clock has
+  to start at launch.
+- It needs months of history before the number means anything, so **no live reading and no gate in v1**.
+
+This mirrors the nightly listing-file snapshot already assigned to ticket 12, and it is a genuine
+contribution to the validation problem sitting in the map's fog.
+
+### Dependencies handed to other tickets
+
+- **Ticket 08 (setup detection)** owes this ticket a defined **trigger level** per detected setup — the
+  quantity the follow-through capture records and later measures against.
+- **Ticket 12 (architecture)** owes this ticket a **nightly setup-snapshot table** (symbol, date, trigger
+  level) alongside the listing-file snapshot it already carries.
+- **Ticket 05 (universe and data hygiene)** owns the **partial-last-bar** hazard from ticket 02 — a daily
+  bar can be dated as complete while a session is still open. The regime must evaluate the last *closed*
+  session and surface its date; how "closed" is determined per market calendar is settled there, not here.
+
+### Explicitly rejected
+
+- **Breadth replacing the index** — bets the whole filter on the measure the bias hits hardest.
+- **Follow-through as a gate** — downstream of ticket 08, the highest-risk ticket on the map; a detection
+  bug would silently corrupt the regime call too.
+- **Hostile regime suppressing the candidate list** — contradicts "he does not stop looking", and the
+  best setups often form during the hostile stretch that precedes the turn.
+- **A continuous 0–100 regime score** — nothing in §10 to calibrate a continuous scale against.
+- **Explicitly measured chop** (index ADR, crossover counts) — thresholds picked blind that can then
+  contradict the slope gates.

--- a/.scratch/screening-dashboard/issues/10-market-regime-filter.md
+++ b/.scratch/screening-dashboard/issues/10-market-regime-filter.md
@@ -1,0 +1,30 @@
+# Market regime filter
+
+Type: grilling
+Status: open
+Blocked by: 02
+
+## Question
+
+How does the app compute and present "is this a tape you should be swinging long in?"
+
+§10 gives the rules qualitatively. Make them numeric:
+
+- **Which index per market** — US: S&P 500, Nasdaq Composite, Russell 2000, or an equal-weighted
+  breadth measure of your own universe? His names are small/mid momentum, so the S&P may be the wrong
+  proxy. IDX: IHSG, LQ45, or a universe-derived breadth measure?
+- **The gates** — §10's "do not swing long" is 10-day sloping down **and** 20-day sloping down **and**
+  10 below 20. Define "sloping down" (slope over how many days, what threshold). Define the
+  long-friendly condition symmetrically.
+- **Three states or two** — long-friendly / choppy / don't-swing. "Choppy" is where he sits out, and
+  it's the hardest to define. What makes a tape choppy numerically — whipsaw count, failed-breakout
+  rate, index ADR, MA crossover frequency?
+- **Breadth and follow-through** — "breakouts follow through" and "sectors moving in packs" are the
+  signals he actually cites. The app can measure its own hit rate: what fraction of last week's
+  detected breakouts are still above their breakout level? That's a strong regime signal and it's free
+  once detection exists. Decide whether it's in v1.
+- **What the app does with it** — a banner? A size multiplier on every candidate? Does a hostile regime
+  suppress the candidate list entirely, or just annotate it? He does not stop looking; he stops sizing.
+- **Per market independently** — IDX and US regimes diverge. Two separate verdicts, presumably; confirm.
+
+Resolve against `references/qullamaggie-method.md` §10 and §2.

--- a/.scratch/screening-dashboard/issues/11-dashboard-information-architecture.md
+++ b/.scratch/screening-dashboard/issues/11-dashboard-information-architecture.md
@@ -1,0 +1,31 @@
+# Dashboard information architecture
+
+Type: prototype
+Status: open
+Blocked by: 06, 07, 08
+
+## Question
+
+What do you see when you open this app, and what is the ten-minute nightly path through it?
+
+His nightly review is ~10 minutes (§1). Design to that, not to a data-exploration tool. Build rough
+screens to react to — outlines or a clickable stub, not production UI.
+
+- **Landing screen** — regime verdict, tonight's candidate count, what changed since yesterday? What is
+  the single thing you want to see before anything else?
+- **Candidate list** — columns and default sort. Star score, ADR, decile ranks, sector, distance to
+  the trendline/trigger, implied stop width vs 1×ADR, dollar volume. Which of these earn their space?
+- **Chart view** — candles with 10/20/50 SMA and 65 EMA (§2), the detected trendline, the base
+  highlighted, volume with the dry-up/expansion marked. Does the score breakdown sit next to it so you
+  can see *why* it scored what it did?
+- **Decile leaderboards** — one table per lookback, or one table with a column per lookback? How is
+  change-over-time shown (per ticket 06's reading of "each period")?
+- **Sector/rotation view** — follows from ticket 07's numeric definition of rotation. Quadrant chart,
+  ranked bars with rank-change arrows, or a heatmap over time?
+- **Two markets** — tabs, toggle, or side by side? They have different closes, so at any given hour one
+  is fresher than the other. How is staleness communicated?
+- **Navigation between them** — click a sector, see its members; click a name, see its chart.
+- **Rejected candidates** — is there a view of what was screened out and why? Useful for trusting the
+  screen early on, dead weight later.
+
+Output: agreed screen inventory and the nightly path. Link the prototype rather than pasting it here.

--- a/.scratch/screening-dashboard/issues/11-dashboard-information-architecture.md
+++ b/.scratch/screening-dashboard/issues/11-dashboard-information-architecture.md
@@ -1,0 +1,36 @@
+# Dashboard information architecture
+
+Type: prototype
+Status: open
+Blocked by: 06, 07, 08
+
+## Question
+
+What do you see when you open this app, and what is the ten-minute nightly path through it?
+
+His nightly review is ~10 minutes (§1). Design to that, not to a data-exploration tool. Build rough
+screens to react to — outlines or a clickable stub, not production UI.
+
+- **Landing screen** — regime verdict, tonight's candidate count, what changed since yesterday? What is
+  the single thing you want to see before anything else?
+- **Candidate list** — columns and default sort. Star score, ADR, decile ranks, sector, distance to
+  the trendline/trigger, implied stop width vs 1×ADR, dollar volume. Which of these earn their space?
+- **Chart view** — candles with 10/20/50 SMA and 65 EMA (§2), the detected trendline, the base
+  highlighted, volume with the dry-up/expansion marked. Does the score breakdown sit next to it so you
+  can see *why* it scored what it did?
+- **Decile leaderboards** — one table per lookback, or one table with a column per lookback? How is
+  change-over-time shown (per ticket 06's reading of "each period")?
+- **Sector/rotation view** — follows from ticket 07's numeric definition of rotation. Quadrant chart,
+  ranked bars with rank-change arrows, or a heatmap over time?
+- **Two markets** — tabs, toggle, or side by side? They have different closes, so at any given hour one
+  is fresher than the other. How is staleness communicated?
+- **Navigation between them** — click a sector, see its members; click a name, see its chart.
+- **Rejected candidates** — is there a view of what was screened out and why? Useful for trusting the
+  screen early on, dead weight later.
+
+Output: agreed screen inventory and the nightly path. Link the prototype rather than pasting it here.
+
+**From ticket 10 (market regime filter):** the screens must carry **two persistent regime banners**, one
+per market, each showing its state (`FRIENDLY` / `CHOPPY` / `HOSTILE`), a sizing posture, the as-of
+session date, and a universe-breadth reading beside it. The candidate list is **identical in all three
+states** — the regime never filters or reorders it — so the banner is the only place regime appears.

--- a/.scratch/screening-dashboard/issues/12-architecture-and-deployment.md
+++ b/.scratch/screening-dashboard/issues/12-architecture-and-deployment.md
@@ -1,0 +1,64 @@
+# Architecture and local runtime shape
+
+Type: grilling
+Status: open
+Blocked by: 05
+
+## Question
+
+What is the runtime shape of this app, end to end, running on your own machine?
+
+v1 runs locally with a live backend — the UI may query the store freely rather than reading precomputed
+views. Hosting is out of scope (see the map), so this ticket is about the local pipeline and the local
+serving path, not deployment.
+
+- **Pipeline stages** — ingest → adjust/normalise → compute indicators (ADR, MAs, returns) → rank →
+  detect setups → score. Which run nightly in full, which are incremental, and what is materialised
+  versus computed on request? Locally, compute is cheap and the tradeoff is your patience, not a quota.
+- **Store** — DuckDB file, SQLite, or Parquet on disk queried by DuckDB? Driven by the actual footprint
+  from ticket 05's universe size × history depth, and by which one makes the detection work (ticket 08)
+  fastest to iterate against.
+- **Two calendars** — IDX closes 16:00 WIB, US 16:00 ET, ~12 hours apart, with different holidays.
+  Two scheduled runs or one that handles whichever market last closed? And what actually triggers them
+  on a laptop that is sometimes asleep — cron, a launchd job, or you running a command?
+  **Ticket 01 pins the IDX side:** the 2026-08-04 bar was final at 19:49 WIB, so a **≥19:00 WIB**
+  schedule is safe; earlier is unproven and would need measuring.
+- **Rate-limit pacing — settled empirically, needs implementing.** Tickets 01, 02 and 03 all hit
+  throttling independently. Ticket 02 measured it: unthrottled returns **52.9%** of the US universe,
+  **12 req/s returns 99.93% in 8.5 minutes**. Yahoo fails as silence — throttled symbols come back as
+  "possibly delisted; no price data found" — so the pipeline must pace, back off, and **distinguish
+  throttling from genuinely missing data**, or a bad night silently halves the universe and blames
+  delisting. (The 12 req/s figure was measured from a residential IP, which is what a local v1 is.)
+- **The partial-bar problem (ticket 02)** — while a session is open, Yahoo already serves a bar dated
+  today containing only the hours traded so far. US and IDX sessions are disjoint, so **there is no
+  single safe run time**. Decide the guard: run each market only after its own close (≥19:00 WIB for
+  IDX per ticket 01), discard any bar dated today unless the session has closed, or validate bar
+  completeness explicitly. This is a correctness issue, not a scheduling nicety — a partial bar
+  corrupts ADR, gap and volume math silently.
+- **Point-in-time universe snapshots** — ticket 02 recommends snapshotting the Nasdaq listing files
+  (and the IDX screener result) nightly from day one, accumulating a survivorship-free universe going
+  forward. Cheap now, impossible to backfill later. Decide whether v1 does this even though validation
+  is not yet designed.
+- **Missed runs** — a laptop misses nights. Does the app detect a gap on next launch and backfill it
+  automatically? This matters more locally than it would on a server.
+- **Backend/frontend boundary** — a local Python API (FastAPI or similar) that the TS frontend queries.
+  Confirm, and settle what the API surface looks like: per-screen endpoints, or a general query layer?
+- **Failure handling** — the nightly pull will fail sometimes (rate limits, source breakage). Does the
+  app serve yesterday's data with a staleness banner? Retries? How do you find out it failed, given
+  there is no alerting infrastructure?
+- **Backfill** — the first run pulls years of history for thousands of symbols. How long does that
+  take, is it resumable, and is the snapshot committed/archived so it survives a machine rebuild?
+- **Reproducibility for the detection work** — tickets 08 and 09 need a frozen data snapshot to iterate
+  against, so results don't shift under them as new bars arrive. How is that snapshot pinned?
+- **Repo layout** — one repo, two apps (Python + TS)? Where the shared domain vocabulary lives, and how
+  the frontend learns the backend's types.
+- **Portability** — how much of this design would survive being hosted later? Note the choices that
+  would be expensive to reverse, without designing for hosting now.
+
+Resolve against ticket 05's universe size. Ticket 04's free-tier findings are **background only** —
+v1 is not constrained by them.
+
+**Owed to ticket 10 (market regime filter):** a **nightly setup-snapshot table** (symbol, date, trigger
+level) written every run from launch, alongside the listing-file snapshot this ticket already carries.
+Both are forward-accumulating and irrecoverable if skipped. Ticket 10 also needs index bars for `^IXIC`
+and `^JKSE` ingested on the same path as equities.

--- a/.scratch/screening-dashboard/issues/12-architecture-and-deployment.md
+++ b/.scratch/screening-dashboard/issues/12-architecture-and-deployment.md
@@ -1,0 +1,80 @@
+# Architecture and local runtime shape
+
+Type: grilling
+Status: open
+Blocked by: 05
+
+## Question
+
+What is the runtime shape of this app, end to end, running on your own machine?
+
+v1 runs locally with a live backend — the UI may query the store freely rather than reading precomputed
+views. Hosting is out of scope (see the map), so this ticket is about the local pipeline and the local
+serving path, not deployment.
+
+- **Pipeline stages** — ingest → adjust/normalise → compute indicators (ADR, MAs, returns) → rank →
+  detect setups → score. Which run nightly in full, which are incremental, and what is materialised
+  versus computed on request? Locally, compute is cheap and the tradeoff is your patience, not a quota.
+- **Store** — DuckDB file, SQLite, or Parquet on disk queried by DuckDB? Driven by the actual footprint
+  from ticket 05's universe size × history depth, and by which one makes the detection work (ticket 08)
+  fastest to iterate against.
+- **Two calendars** — IDX closes 16:00 WIB, US 16:00 ET, ~12 hours apart, with different holidays.
+  Two scheduled runs or one that handles whichever market last closed? And what actually triggers them
+  on a laptop that is sometimes asleep — cron, a launchd job, or you running a command?
+  **Ticket 01 pins the IDX side:** the 2026-08-04 bar was final at 19:49 WIB, so a **≥19:00 WIB**
+  schedule is safe; earlier is unproven and would need measuring.
+- **Rate-limit pacing — settled empirically, needs implementing.** Tickets 01, 02 and 03 all hit
+  throttling independently. Ticket 02 measured it: unthrottled returns **52.9%** of the US universe,
+  **12 req/s returns 99.93% in 8.5 minutes**. Yahoo fails as silence — throttled symbols come back as
+  "possibly delisted; no price data found" — so the pipeline must pace, back off, and **distinguish
+  throttling from genuinely missing data**, or a bad night silently halves the universe and blames
+  delisting. (The 12 req/s figure was measured from a residential IP, which is what a local v1 is.)
+- **The partial-bar problem (ticket 02)** — while a session is open, Yahoo already serves a bar dated
+  today containing only the hours traded so far. US and IDX sessions are disjoint, so **there is no
+  single safe run time**. Decide the guard: run each market only after its own close (≥19:00 WIB for
+  IDX per ticket 01), discard any bar dated today unless the session has closed, or validate bar
+  completeness explicitly. This is a correctness issue, not a scheduling nicety — a partial bar
+  corrupts ADR, gap and volume math silently.
+- **Point-in-time universe snapshots** — ticket 02 recommends snapshotting the Nasdaq listing files
+  (and the IDX screener result) nightly from day one, accumulating a survivorship-free universe going
+  forward. Cheap now, impossible to backfill later. Decide whether v1 does this even though validation
+  is not yet designed.
+- **Missed runs** — a laptop misses nights. Does the app detect a gap on next launch and backfill it
+  automatically? This matters more locally than it would on a server.
+- **Backend/frontend boundary** — a local Python API (FastAPI or similar) that the TS frontend queries.
+  Confirm, and settle what the API surface looks like: per-screen endpoints, or a general query layer?
+- **Failure handling** — the nightly pull will fail sometimes (rate limits, source breakage). Does the
+  app serve yesterday's data with a staleness banner? Retries? How do you find out it failed, given
+  there is no alerting infrastructure?
+- **Backfill** — the first run pulls years of history for thousands of symbols. How long does that
+  take, is it resumable, and is the snapshot committed/archived so it survives a machine rebuild?
+- **Reproducibility for the detection work** — tickets 08 and 09 need a frozen data snapshot to iterate
+  against, so results don't shift under them as new bars arrive. How is that snapshot pinned?
+- **Repo layout** — one repo, two apps (Python + TS)? Where the shared domain vocabulary lives, and how
+  the frontend learns the backend's types.
+- **Portability** — how much of this design would survive being hosted later? Note the choices that
+  would be expensive to reverse, without designing for hosting now.
+
+- **History depth — graduated from the map's fog into this ticket by ticket 05.** The data-source
+  research it was waiting on is done, and ticket 05 fixed the demand side, so this is now purely a
+  storage decision. Constraints: ranking lookbacks run to **24 months** (§1), so ~3 years is the
+  functional minimum and 5 years gives comfortable headroom; ticket 01 measured **5 years × 840 IDX
+  names ≈ 904k bars ≈ 50 MB**, and running locally removes any storage ceiling. Depth is therefore
+  cheap — decide it, don't agonise.
+- **Two nightly snapshots to store**, both cheap and both only useful if started early: listing files
+  (already on this ticket) and, added by ticket 05 (D11), **universe membership** — one row per name per
+  night, so a future validation can ask what was *rankable* that night, not merely what was listed.
+- **Pipeline invariants this ticket must preserve**, all from ticket 05: an `unresolved` third state
+  distinct from absent; **sticky membership** (removal needs positive evidence, never a failed fetch);
+  **run quarantine** when < ~99% of symbols resolve, leaving the last good run serving with a banner;
+  an **exchange-clock finality rule** dropping provisional bars at ingest; and the exchange calendar
+  derived from observed bar dates rather than a hardcoded holiday table. The store needs to hold **both**
+  adjusted and unadjusted series (D9).
+- **Rate limiting is a hard requirement, not a nicety.** Ticket 02 measured an unthrottled pull
+  returning only **52.9%** of the universe while reporting the losses as "possibly delisted"; 12 req/s
+  gives 99.93% in 8.5 min. Combined with run quarantine, an unthrottled ingester would simply never
+  publish.
+
+Resolve against ticket 05's universe size — now measured: **288 IDX / 1,966 US** names, ~2,250 total
+symbols to pull nightly. Ticket 04's free-tier findings are **background only** — v1 is not constrained
+by them.

--- a/.scratch/screening-dashboard/issues/13-assemble-v1-spec.md
+++ b/.scratch/screening-dashboard/issues/13-assemble-v1-spec.md
@@ -1,0 +1,27 @@
+# Assemble the v1 spec
+
+Type: grilling
+Status: open
+Blocked by: 06, 07, 08, 09, 10, 11, 12
+
+## Question
+
+Write the v1 spec — the destination of this map.
+
+Every decision on the map is recorded in its own ticket. This ticket assembles them into one document a
+build session can work from without re-reading the map:
+
+- Scope and non-goals (pull the Out of scope section forward explicitly).
+- Domain glossary — universe, candidate, base, setup, star score, leader, regime, rotation. Use
+  `/domain-modeling`; this is the ubiquitous language the code should speak.
+- Data contract — sources, schemas, refresh cadence, adjustment rules, failure modes.
+- Computation spec — every formula with its parameters: ADR, liquidity, returns, deciles, sector
+  strength, rotation, setup detection, star score, regime.
+- Screen inventory and the nightly path.
+- Architecture and deployment.
+- Acceptance criteria — what makes v1 done. Concretely: on a given evening, what should the app show
+  and how would you know it's right?
+- Open risks carried into the build, and what would trigger a rethink.
+
+Where a decision was made under an assumption that could not be verified during wayfinding, say so
+in the spec rather than presenting it as settled.

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -1,0 +1,122 @@
+# Map: Qullamaggie Screening Dashboard v1
+
+## Destination
+
+A buildable v1 spec for a **locally-run**, single-user, EOD screening dashboard covering **IDX and US**,
+implementing the **Breakout/Continuation setup only**: auto-detected setups with 1–5 star scores,
+in-app charts, top-decile leaderboards per lookback, sector/theme leadership + rotation, and the
+market regime filter. The spec is detailed enough to hand to a build session — no production code
+is written during wayfinding.
+
+## Notes
+
+- **Domain**: equity momentum swing trading, Qullamaggie method. The canonical method reference is
+  `references/qullamaggie-method.md` — every ticket should be resolved against it, and it already
+  fixes many parameters (ADR definition, liquidity floors, stop and sizing rules, star rubric).
+- **Skills to consult**: `/grilling` and `/domain-modeling` on every HITL ticket; `/research` for
+  research tickets; `/prototype` for prototype tickets.
+- **Standing constraints** (settled during charting, not up for re-litigation without saying so):
+  - Both markets from day one.
+  - Free data sources only — no paid feeds, no existing TradingView/broker subscription.
+  - **Runs locally**, single user. No hosting, no free-tier limits, no auth in v1 — a local
+    backend serving a local browser. Hosting is deferred (see Out of scope).
+  - **A live backend is assumed.** The UI may query the store freely; it is not restricted to
+    reading precomputed views. When hosting does arrive, a paid tier (~$10–20/mo) is accepted
+    rather than contorting the design to fit a free tier.
+  - EOD nightly cadence. No intraday, no streaming.
+  - Python backend + TypeScript frontend.
+  - Full auto-detection of the setup + a computed 1–5 star score (not just a ranked shortlist).
+  - Charts rendered in-app, showing the evidence behind the score.
+  - "Top decile" is ranked against the whole tradeable universe **per market**, not within sector.
+- **Known risk carried into the map**: §3.5 double-weights *tightness* and *orderliness*, the two
+  dimensions least amenable to automation. Setup detection is the highest-risk ticket on this map.
+- **Standing property of the data layer** (found independently by tickets 01, 02 and 03): **Yahoo fails
+  as silence.** Throttled requests return empty results — and for price history, the literal message
+  "possibly delisted; no price data found". Every ingestion path must distinguish throttling from
+  genuinely missing data, or bad runs silently shrink the universe while looking successful.
+
+## Decisions so far
+
+<!-- one line per resolved ticket: gist + link -->
+
+- [Free EOD data sources for IDX](issues/01-idx-free-data-sources.md) — **yfinance `.JK`**, fallback a
+  headless scrape of idx.co.id; Stockbit is ToS-barred and idx.co.id is Cloudflare-blocked. Universe
+  enumeration solved (840 symbols in 0.8s); volume is **shares not lots**, so **292 names clear the
+  Rp 1B/day floor**. Bulk OHLCV is fast (840 × 5y in 11.5s, ~50 MB) but rate limits bite immediately
+  after. Two hazards: Yahoo applies **rights adjustments invisibly** (BBRI rescaled 10/11 with no
+  split/dividend entry) so raw IDX prices are unrecoverable, and **4% of bars are phantom zero-volume**
+  and must be dropped before any ADR or tightness math.
+
+- [Free EOD data sources for US](issues/02-us-free-data-sources.md) — **yfinance is the single source
+  for both markets** (same client, schema and sector taxonomy for `.JK` and US), fallback Massive
+  (ex-Polygon) for US. Universe enumeration via Nasdaq Trader files → **5,711 symbols**. Rate limiting
+  is mandatory: unthrottled returns only **52.9%** of the universe while reporting the losses as
+  "possibly delisted"; **12 req/s gives 99.93% in 8.5 min**. Two hazards: the **last daily bar may be
+  partial** while a session is open (proven — 14 minutes of trading dated as a full day), and delisted
+  names return zero rows, so any backtest is survivorship-biased.
+
+- [Free sector/industry classification for IDX and US](issues/03-sector-taxonomy-sources.md) —
+  **Yahoo/Morningstar GECS is the sector axis for both markets**: one taxonomy, 99.7% measured coverage
+  across 320 sampled tickers, no mapping table, no GICS licence exposure. IDX-IC is Cloudflare-blocked
+  and not needed; GICS is contractually out. Two operational constraints fall out: sector costs one
+  request per symbol (1–2h per full refresh, so cache incrementally) and **Yahoo throttling fails as
+  silence** — must be distinguished from genuinely missing data. Theme *parity* across markets is the
+  open scope risk, carried to ticket 07.
+
+- [Universe definition and data hygiene](issues/05-universe-definition.md) — **288 IDX / 1,966 US names**,
+  measured under the exact rule stack, not estimated. The universe is **liquidity + instrument type +
+  listing age only**: median-20d `close × volume` ≥ Rp 1B / $20M, common stock only (ADRs kept), ≥ 20
+  non-phantom bars. **ADR is a post-rank filter, not a gate** — gating would make decile denominators
+  breathe with the volatility regime and would evict names on the eve of the move. Phantom bars
+  (`volume == 0`) are dropped and windows count traded bars; an **80%/3-session density gate doubles as
+  suspension detection**, so the Cloudflare-blocked IDX suspension list is never needed. **Absence of
+  data means nothing** — membership is sticky, removal needs positive evidence, and runs resolving < 99%
+  of symbols are quarantined rather than published. Provisional bars are dropped on an exchange-clock
+  finality rule. **Adjusted everywhere except dollar volume, and no absolute-price rules** — which makes
+  ticket 01's unrecoverable-raw-IDX-prices finding cost nothing, since almost every quantity in the
+  method is a ratio and ratios survive adjustment. Nightly rebuild with a 0.8× hysteresis band. One
+  principle unifies D3/D7/D11: **removal requires stronger evidence than admission.**
+
+*(the hosting research also resolved, but its subject was subsequently ruled out of scope — see below)*
+
+## Not yet specified
+
+- **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
+  is no longer the blocker — both markets have plenty (IDX back to ~2000–2004, US ample). The blockers
+  are that detection isn't defined yet (ticket 08) and that **delisted names return zero rows on
+  Yahoo**, so any replay is survivorship-biased upward with no free fix. The one concrete action is
+  already assigned to ticket 12: start snapshotting listing files nightly, so a point-in-time universe
+  accumulates from today whatever validation eventually looks like. **Ticket 05 added the layer above
+  it** — nightly snapshots of universe *membership* (one row per name per night), so a future validation
+  can ask what was actually rankable on a given night, not merely what was listed.
+- **Alerting.** He hangs price alerts on the trendline. Whether v1 notifies at all, and through what
+  channel, waits on detection being defined. Running locally narrows the options — a desktop
+  notification or a nightly digest, not a push service.
+- **Watchlist persistence and user state.** Whether the app remembers names you've marked, and what
+  storage that implies, waits on the architecture ticket.
+- **Chart rendering approach.** Library and how the detected trendline / MA context is drawn — waits
+  on the dashboard IA ticket.
+  <!-- "History depth" graduated into ticket 12: the data-source research it waited on is done, and
+       ticket 05 fixed the demand side (24-month lookbacks + 20-bar minimum). It is now a storage
+       decision, not fog. -->
+  <!-- "Data quality handling on IDX" graduated: ticket 05 resolved phantom bars, rights adjustment
+       and suspended names. The ARA/ARB remainder is now assigned to ticket 08, so it is no longer fog. -->
+- **Survivorship bias.** Yahoo's screener enumerates only live names, so delisted history is not
+  discoverable. Harmless for nightly scanning, potentially fatal for any backtest — folds into the
+  validation patch above once that takes shape.
+
+## Out of scope
+
+- **Episodic Pivot (§4)** — deferred by the method reference itself; needs intraday/pre-market data.
+- **Parabolic short (§5)** — not practically available on IDX, largest blow-up risk.
+- **Position sizing calculator (§8)** — considered and ruled out of v1.
+- **Trade journal / open position tracking (§9 sell-rule management)** — a second product.
+- **Intraday or real-time data** — v1 is EOD only.
+- **Multi-user / sharing** — single user.
+- **Hosting, deployment, scheduling infrastructure, and auth** — v1 runs locally, so none of this is on
+  the route to the destination. The research is already done and preserved for whenever hosting becomes
+  a separate effort: [Free-tier hosting and scheduling](issues/04-free-tier-hosting-and-scheduling.md)
+  → [findings](research/04-hosting-and-scheduling.md). Headline for that future effort: serverless
+  execution timeouts rule out everything except GitHub Actions and Cloud Run Jobs, and no free hosted
+  SQL can hold the bar history. A paid tier (~$10–20/mo) is pre-approved for it, so those free-tier
+  findings are background rather than binding.

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -1,0 +1,124 @@
+# Map: Qullamaggie Screening Dashboard v1
+
+## Destination
+
+A buildable v1 spec for a **locally-run**, single-user, EOD screening dashboard covering **IDX and US**,
+implementing the **Breakout/Continuation setup only**: auto-detected setups with 1–5 star scores,
+in-app charts, top-decile leaderboards per lookback, sector/theme leadership + rotation, and the
+market regime filter. The spec is detailed enough to hand to a build session — no production code
+is written during wayfinding.
+
+## Notes
+
+- **Domain**: equity momentum swing trading, Qullamaggie method. The canonical method reference is
+  `references/qullamaggie-method.md` — every ticket should be resolved against it, and it already
+  fixes many parameters (ADR definition, liquidity floors, stop and sizing rules, star rubric).
+- **Skills to consult**: `/grilling` and `/domain-modeling` on every HITL ticket; `/research` for
+  research tickets; `/prototype` for prototype tickets.
+- **Standing constraints** (settled during charting, not up for re-litigation without saying so):
+  - Both markets from day one.
+  - Free data sources only — no paid feeds, no existing TradingView/broker subscription.
+  - **Runs locally**, single user. No hosting, no free-tier limits, no auth in v1 — a local
+    backend serving a local browser. Hosting is deferred (see Out of scope).
+  - **A live backend is assumed.** The UI may query the store freely; it is not restricted to
+    reading precomputed views. When hosting does arrive, a paid tier (~$10–20/mo) is accepted
+    rather than contorting the design to fit a free tier.
+  - EOD nightly cadence. No intraday, no streaming.
+  - Python backend + TypeScript frontend.
+  - Full auto-detection of the setup + a computed 1–5 star score (not just a ranked shortlist).
+  - Charts rendered in-app, showing the evidence behind the score.
+  - "Top decile" is ranked against the whole tradeable universe **per market**, not within sector.
+- **Known risk carried into the map**: §3.5 double-weights *tightness* and *orderliness*, the two
+  dimensions least amenable to automation. Setup detection is the highest-risk ticket on this map.
+- **Standing property of the data layer** (found independently by tickets 01, 02 and 03): **Yahoo fails
+  as silence.** Throttled requests return empty results — and for price history, the literal message
+  "possibly delisted; no price data found". Every ingestion path must distinguish throttling from
+  genuinely missing data, or bad runs silently shrink the universe while looking successful.
+
+## Decisions so far
+
+<!-- one line per resolved ticket: gist + link -->
+
+- [Free EOD data sources for IDX](issues/01-idx-free-data-sources.md) — **yfinance `.JK`**, fallback a
+  headless scrape of idx.co.id; Stockbit is ToS-barred and idx.co.id is Cloudflare-blocked. Universe
+  enumeration solved (840 symbols in 0.8s); volume is **shares not lots**, so **292 names clear the
+  Rp 1B/day floor**. Bulk OHLCV is fast (840 × 5y in 11.5s, ~50 MB) but rate limits bite immediately
+  after. Two hazards: Yahoo applies **rights adjustments invisibly** (BBRI rescaled 10/11 with no
+  split/dividend entry) so raw IDX prices are unrecoverable, and **4% of bars are phantom zero-volume**
+  and must be dropped before any ADR or tightness math.
+
+- [Free EOD data sources for US](issues/02-us-free-data-sources.md) — **yfinance is the single source
+  for both markets** (same client, schema and sector taxonomy for `.JK` and US), fallback Massive
+  (ex-Polygon) for US. Universe enumeration via Nasdaq Trader files → **5,711 symbols**. Rate limiting
+  is mandatory: unthrottled returns only **52.9%** of the universe while reporting the losses as
+  "possibly delisted"; **12 req/s gives 99.93% in 8.5 min**. Two hazards: the **last daily bar may be
+  partial** while a session is open (proven — 14 minutes of trading dated as a full day), and delisted
+  names return zero rows, so any backtest is survivorship-biased.
+
+- [Free sector/industry classification for IDX and US](issues/03-sector-taxonomy-sources.md) —
+  **Yahoo/Morningstar GECS is the sector axis for both markets**: one taxonomy, 99.7% measured coverage
+  across 320 sampled tickers, no mapping table, no GICS licence exposure. IDX-IC is Cloudflare-blocked
+  and not needed; GICS is contractually out. Two operational constraints fall out: sector costs one
+  request per symbol (1–2h per full refresh, so cache incrementally) and **Yahoo throttling fails as
+  silence** — must be distinguished from genuinely missing data. Theme *parity* across markets is the
+  open scope risk, carried to ticket 07.
+
+*(the hosting research also resolved, but its subject was subsequently ruled out of scope — see below)*
+
+- [Market regime filter](issues/10-market-regime-filter.md) — **three states per market from one index
+  each** (US `^IXIC`, IDX `^JKSE`), on simple `SMA10`/`SMA20` of daily closes. Slope is **sign-only**
+  (`SMA[t]` vs `SMA[t-5]`), so the whole filter has **zero tunable parameters** — deliberate, because
+  survivorship bias makes any threshold uncalibratable. `HOSTILE` = both falling and 10 below 20;
+  `FRIENDLY` = close above both and both rising; `CHOPPY` = **the residual**, which is where §10's two
+  named conditions leave a gap. The three are mutually exclusive by construction. Effect is **advisory
+  only**: a per-market banner with a sizing posture (full / reduced / sit), and the candidate list is
+  identical in all three states — regime never filters, reorders, or touches the star score. Breadth is
+  **displayed but does not gate** (it is the measure survivorship bias corrupts most). Breakout
+  follow-through is **captured nightly from day one but never shown or gated in v1** — it is the only
+  unbiased regime signal available and is irrecoverable if not started at launch.
+
+## Not yet specified
+
+- **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
+  is no longer the blocker — both markets have plenty (IDX back to ~2000–2004, US ample). The blockers
+  are that detection isn't defined yet (ticket 08) and that **delisted names return zero rows on
+  Yahoo**, so any replay is survivorship-biased upward with no free fix. The one concrete action is
+  already assigned to ticket 12: start snapshotting listing files nightly, so a point-in-time universe
+  accumulates from today whatever validation eventually looks like. Ticket 10 adds a **second
+  forward-accumulating capture** on the same principle — every detected setup and its trigger level,
+  written nightly from launch. Both exist because they are unbiased *and* irrecoverable after the fact;
+  together they are the seed of whatever validation is eventually possible.
+- **Alerting.** He hangs price alerts on the trendline. Whether v1 notifies at all, and through what
+  channel, waits on detection being defined. Running locally narrows the options — a desktop
+  notification or a nightly digest, not a push service.
+- **Watchlist persistence and user state.** Whether the app remembers names you've marked, and what
+  storage that implies, waits on the architecture ticket.
+- **Chart rendering approach.** Library and how the detected trendline / MA context is drawn — waits
+  on the dashboard IA ticket.
+- **History depth.** How many years of daily bars for how many symbols — waits on the data-source
+  research. Running locally removes the free-tier storage ceiling, so this is now purely a question of
+  how much history the sources give us and how much the computations need.
+- **Data quality handling on IDX.** Ticket 01 confirmed the suspicion and made most of it sharp enough
+  to live in ticket 05 (phantom zero-volume bars, invisible rights adjustment, suspended-name noise).
+  What remains foggy: **ARA/ARB limit days** — they distort range-based measures like ADR and
+  tightness, but since raw prices are unrecoverable they cannot be reconstructed from history. Whether
+  this needs handling at all depends on how ticket 08 defines contraction.
+- **Survivorship bias.** Yahoo's screener enumerates only live names, so delisted history is not
+  discoverable. Harmless for nightly scanning, potentially fatal for any backtest — folds into the
+  validation patch above once that takes shape.
+
+## Out of scope
+
+- **Episodic Pivot (§4)** — deferred by the method reference itself; needs intraday/pre-market data.
+- **Parabolic short (§5)** — not practically available on IDX, largest blow-up risk.
+- **Position sizing calculator (§8)** — considered and ruled out of v1.
+- **Trade journal / open position tracking (§9 sell-rule management)** — a second product.
+- **Intraday or real-time data** — v1 is EOD only.
+- **Multi-user / sharing** — single user.
+- **Hosting, deployment, scheduling infrastructure, and auth** — v1 runs locally, so none of this is on
+  the route to the destination. The research is already done and preserved for whenever hosting becomes
+  a separate effort: [Free-tier hosting and scheduling](issues/04-free-tier-hosting-and-scheduling.md)
+  → [findings](research/04-hosting-and-scheduling.md). Headline for that future effort: serverless
+  execution timeouts rule out everything except GitHub Actions and Cloud Run Jobs, and no free hosted
+  SQL can hold the bar history. A paid tier (~$10–20/mo) is pre-approved for it, so those free-tier
+  findings are background rather than binding.

--- a/.scratch/screening-dashboard/research/01-idx-data-sources.md
+++ b/.scratch/screening-dashboard/research/01-idx-data-sources.md
@@ -1,0 +1,505 @@
+# Free EOD data sources for the IDX equity universe
+
+Research note for ticket `01-idx-free-data-sources.md`.
+
+**As-of date: 2026-08-04.** Everything below was either read from the source that owns the claim, or
+**measured directly** on this date by installing `yfinance 1.5.2` in a throwaway venv and pulling live
+data. Measured results are tagged **[MEASURED]** with the number observed. Claims that could not be
+confirmed against a primary source are tagged **[UNVERIFIED]**.
+
+Nothing was installed into the project. The probe scripts live in the job scratch dir
+(`$CLAUDE_JOB_DIR/tmp/probe*.py`) and are disposable.
+
+---
+
+## 0. TL;DR
+
+1. **Build on Yahoo Finance `.JK` via `yfinance`. There is no serious competitor on a free tier.**
+   Every other candidate is either paywalled (IDX official, Sectors), contractually closed
+   (Stockbit, Investing.com), bot-walled (idx.co.id, Stooq — both measured), or dead
+   (Dataset-Saham-IDX, last data commit 2025-02-23).
+2. **The universe problem is solved, but only for *actively traded* names.** `yfinance`'s screener
+   (`EquityQuery("eq", ["exchange","JKT"])`) enumerates the whole exchange in one call —
+   **[MEASURED] 840 symbols in 0.8 s**. IDX itself reports **963 listed companies as of July 2026**,
+   so the screener is missing ~120. **[MEASURED]** the missing ones are suspended/delisted names
+   (WSKT, SRIL, ENVY, INAF, POLL, BIMA, TRAM, MYRX all absent). For a momentum screener that
+   omission is nearly free; for a backtest it is **survivorship bias** and must be flagged.
+3. **Volume is in shares, not lots — verified by arithmetic, not by trusting docs.** [MEASURED]
+   Σ(close × volume) across all 834 priced names on 2026-08-04 = **Rp 12.07 trillion**, which is
+   the right order of magnitude for an IDX session. A lots reading would give Rp 1,207 trillion.
+   The Rp 1B/day liquidity floor can be computed directly as `close × volume`.
+4. **The adjustment story is the real risk.** Yahoo's `Adj Close` covers **splits and dividends
+   only** — stated by Yahoo, confirmed in yfinance's source. But **[MEASURED]** Yahoo *also* applies
+   an **unlabelled** retroactive rescale for rights issues: BBRI's OHLC before 2021-09-08 is scaled
+   by exactly **10/11**, with **no corresponding entry in either the `Stock Splits` or `Dividends`
+   column**. Consequence: you cannot recover the raw exchange-traded price from yfinance, and you
+   cannot audit which corporate actions were applied.
+5. **History depth is fine for the method and trivial to store.** [MEASURED] Yahoo's IDX history
+   effectively begins in 2000 (nothing earlier across all 840 names); small caps are **not**
+   truncated — they carry full history from their actual IPO. 5 years × 840 names = **904,414 bars**,
+   ≈ 50 MB uncompressed, far inside every free-tier store in ticket 04.
+6. **The operational constraint is rate limiting, not volume.** [MEASURED] A threaded (8-way) bulk
+   `yf.download` of all 840 symbols × 5y finished in **11.5 s**, but the *next* API call returned
+   `YFRateLimitError`, and the limit persisted for minutes. Nightly jobs must pace and retry.
+
+**Recommendation: Yahoo Finance via `yfinance`, with the screener as the universe source, plus a
+manually-maintained supplement list for suspended names.**
+**Fallback: a headless-browser scrape of idx.co.id** (the only free path to the official data, and the
+only source of true unadjusted prices + IDX-IC sectors) — see §7.
+
+---
+
+## 1. Comparison table
+
+| Source | Enumerates universe? | History depth | Adjustment | Volume units | ToS / access | Freshness | Sector field | Free? |
+|---|---|---|---|---|---|---|---|---|
+| **Yahoo Finance `.JK` (yfinance)** | **Yes** — screener returns 840 (vs 963 listed); misses suspended | **[MEASURED]** effectively 2000→now; small caps full from IPO | Splits + divs, **plus an unlabelled rights rescale**; no raw prices | **Shares** [MEASURED] | Unofficial endpoints; Yahoo ToS says personal use; **works unauthenticated** [MEASURED] | Bar for 2026-08-04 present at 19:49 WIB; feed marked `exchangeDataDelayedBy: 10` min | Yahoo's own GICS-like taxonomy, **not IDX-IC** | Yes |
+| **IDX official (idx.co.id)** | Yes (authoritative) | Full | Raw/unadjusted + official corporate actions | Shares (`dalam satuan lembar`) | **Cloudflare 403 to every server-side request** [MEASURED]; data is a *licensed paid product* | Same-day | **IDX-IC** (authoritative) | Web scrape only; API is paid |
+| **Sectors (sectors.app)** | Yes, "99% of IDX" | [UNVERIFIED] | [UNVERIFIED] | [UNVERIFIED] | Clean REST API, but **requires paid "Insider" plan** | Daily | Own sub-sector taxonomy | **No** |
+| **Stockbit** | Yes | Deep | Adjusted | Shares | **ToS explicitly bans robots/spiders** | Same-day | Yes | Closed |
+| **Investing.com** | Partial | Deep | Adjusted | Shares | `investpy` broke on API changes; heavy anti-bot | Same-day | Yes | Closed in practice |
+| **Google Finance** | No | Sheets only | Adjusted | Shares | **No API since 2012**; Sheets-only, not for professional use | ≤20 min delayed | No | Not usable programmatically |
+| **Stooq** | ? | ? | ? | ? | **[MEASURED] JS proof-of-work challenge on every CSV URL** — automated access blocked | — | No | Blocked |
+| **Dataset-Saham-IDX (GitHub, CC BY-NC)** | Yes (`List Emiten/all.csv`) | 2019 → **2025-02-23** | **Raw, unadjusted** + `listedShares` | Shares (documented) | CC BY-NC 4.0 (non-commercial only) | **Dead — last data commit 2025-02-23** [MEASURED] | Yes (`Sectors/`) | Yes, but stale |
+| **Alpha Vantage / Twelve Data / Finnhub free tiers** | No | — | — | — | Free keys exist; **IDX coverage [UNVERIFIED]**, and free quotas (25–800 calls/day) cannot cover 840 symbols nightly | — | — | Effectively no |
+
+---
+
+## 2. Yahoo Finance / yfinance — measured in detail
+
+### 2.1 Universe enumeration
+
+`yfinance ≥ 0.2.5x` exposes Yahoo's screener. This is the single most useful finding in the ticket:
+
+```python
+from yfinance import EquityQuery
+import yfinance as yf
+yf.screen(EquityQuery("eq", ["exchange", "JKT"]), offset=0, size=250,
+          sortField="dayvolume", sortAsc=False)
+```
+
+**[MEASURED]** `total: 840`, paginated 250 at a time, **all 840 retrieved in 0.8 s total**.
+Every result had `quoteType: EQUITY` — no warrants, rights, or ETFs polluting the list.
+Each row already carries `marketCap`, `sharesOutstanding`, `regularMarketVolume`,
+`averageDailyVolume3Month`, `fiftyTwoWeekHigh/Low`, `fiftyDayAverage`, `twoHundredDayAverage`,
+`firstTradeDateMilliseconds`, and `prevName`/`nameChangeDate` — enough to seed the universe table
+without a second call per symbol.
+
+**The gap.** IDX reported **963 listed companies as of 10 July 2026**
+([Databoks, citing IDX](https://databoks.katadata.co.id/en/market/statistics/6a24e09f528c8/listed-companies-on-the-idx-remained-relatively-stagnant-through-april-2026)),
+and Wikipedia's IDX article records 956 as of December 2025
+([Indonesia Stock Exchange](https://en.wikipedia.org/wiki/Indonesia_Stock_Exchange)). So ~120 names
+are missing from the screener.
+
+**[MEASURED]** I probed 13 tickers directly. The pattern is unambiguous — the screener returns names
+that traded, and drops names under suspension:
+
+| Ticker | In screener? | `history()` result |
+|---|---|---|
+| BBRI, BUKA, ARTO | yes | 119 bars/6mo, last **2026-08-04**, real volume |
+| INAF, POLL, BIMA | **no** | 121 bars/6mo, last 2026-08-03, **volume = 0**, price flat |
+| WSKT, SRIL, ENVY, TRAM, HKMU | **no** | **1 bar in 2 years**, dated 2026-07-17, volume = 0 |
+| KPAS | **no** | 228 bars, stops **2025-07-23** |
+| MYRX | **no** | `possibly delisted; no price data found` |
+
+Two consequences:
+
+- **Suspended names are reachable by symbol but not discoverable.** If you want them, you need a
+  symbol list from elsewhere. Yahoo's own search endpoint is *not* that list — **[MEASURED]**
+  `query2.finance.yahoo.com/v1/finance/search?q=INAF` returns a US mutual fund and no `.JK` result.
+- **Delisted names disappear entirely.** Any historical replay built on the screener universe will
+  have survivorship bias baked in. This directly constrains the "Validation / backtest" item still
+  open on the map.
+
+**Practical fix:** persist your own universe table. Union the nightly screener result with everything
+you have ever seen, and mark symbols `active` / `stale` by whether they appeared tonight. That gives
+you delisting dates for free after a few months of running, and costs nothing.
+
+### 2.2 History depth
+
+**[MEASURED]** `firstTradeDateMilliseconds` across all 840 symbols, by year:
+
+```
+2000: 43   2005: 33   2010: 16   2015: 15   2020: 44   2025: 26
+2001: 61   2006: 10   2011: 24   2016: 12   2021: 48   2026:  7
+2002: 64   2007: 25   2012: 17   2017: 29   2022: 55
+2003: 20   2008: 11   2013: 24   2018: 45   2023: 75
+2004: 21   2009:  9   2014: 19   2019: 47   2024: 40
+```
+
+**Nothing before 2000** — that is Yahoo's epoch for this exchange, not a listing fact. The 2000–2002
+cluster (168 names) is pre-2000 listings truncated to the epoch.
+
+Depth is also **patchy in the early years**, and the reported `firstTradeDate` is Yahoo's earliest
+bar, not the true listing date: **[MEASURED]** BBCA's `firstTradeDate` is **2004-06-08**
+(5,463 bars), but BBCA has been listed since 2000. TLKM starts 2004-09-28, ANTM 2005-09-29,
+BUMI 2001-06-07.
+
+**Small caps are not truncated.** [MEASURED] AMAR from 2020-01-09, HOMI from 2020-09-10,
+PGJO from 2020-01-20, GOTO from 2022-04-11 — all matching their actual IPO dates, all with full
+daily coverage. The truncation risk is at the *old* end, not the *small* end. For a Qullamaggie
+screener needing ~1–2 years of context per name, depth is a non-issue; for backtesting it caps you
+at roughly 2005-onward for a clean cross-section.
+
+### 2.3 Adjustment — the one place Yahoo will hurt you
+
+**What the owners of the claim say.** Yahoo's own help page defines Adjusted Close as
+"the closing price after adjustments for all applicable splits and dividend distributions,"
+adhering to CRSP standards, with no mention of any other corporate action
+([Yahoo Finance help, SLN28256](https://help.yahoo.com/kb/SLN28256.html)).
+yfinance's fetcher agrees at the source level — it requests exactly
+`params['events'] = 'div,splits,capitalGains'` and computes `df['Adj'] = df['Adj Close'] / df['Close']`
+([`yfinance/scrapers/history.py`](https://github.com/ranaroussi/yfinance/blob/main/yfinance/scrapers/history.py)).
+**Rights issues are not in that list.**
+
+This matters disproportionately on IDX, where rights issues (HMETD/PMHMETD) are routine and often
+deeply discounted.
+
+**What I actually measured, which is worse than "not adjusted".** I pulled BBRI's September 2021
+window (its large rights issue) with `auto_adjust=False`:
+
+```
+2021-09-07  Open 3536.30  Close 3554.48   Adj Close 2528.53   Splits 0.0   Divs 0.0
+2021-09-08  Open 3820.00  Close 3730.00   Adj Close 2653.39   Splits 0.0   Divs 0.0
+```
+
+Every bar before 2021-09-08 has non-round prices; every bar from 2021-09-08 onward is round (IDX
+trades on whole-rupiah ticks). The pre-event prices are scaled by exactly **10/11 ≈ 0.909091**
+(`3536.30 / 0.909091 = 3890`, a real BBRI price). Yet `Ticker("BBRI.JK").splits` contains only
+**2011-01-11 (2:1)** and **2017-11-10 (5:1)** — nothing in 2021 — and 2021's only dividend is
+2021-04-06.
+
+So: **Yahoo applied a rights-issue rescale to the OHLC series and exposed it in neither the
+`Stock Splits` nor the `Dividends` column.** Three consequences for the build:
+
+1. **`Close` from yfinance is not the raw exchange close.** Anything that depends on the actual
+   traded price — IDX tick-size bands, ARA/ARB auto-rejection limits, "was this a Rp 50 floor stock"
+   — cannot be computed from yfinance data alone.
+2. **You cannot audit the adjustment.** `Adj Close / Close` recovers only the dividend factor; the
+   split and rights factors are already folded into OHLC upstream and are not itemised.
+3. **Whether the factor is *correct* is [UNVERIFIED].** 10/11 does not obviously match a
+   theoretical-ex-rights-price calculation for BBRI's 2021 issue. If it is wrong, you get a phantom
+   gap in the price series at the rights date — exactly the kind of artefact that a breakout detector
+   will happily flag as a setup.
+
+**Mitigation for v1:** since the series is *internally consistent* (continuously adjusted backwards),
+momentum, ADR, moving averages and consolidation detection all work fine. The risk is confined to
+(a) absolute-price rules, and (b) trusting an individual historical bar. A cheap guard is to flag
+any single-bar move beyond ~±25% that has no `Stock Splits`/`Dividends` event as *suspect
+corporate action* and exclude the name from that night's ranking.
+
+### 2.4 Volume units — settled
+
+The ticket asks whether IDX-sourced volume is lots or shares. Two independent confirmations:
+
+- **IDX's own convention** is shares. The Dataset-Saham-IDX column dictionary, which mirrors the IDX
+  daily trading summary field-for-field, documents `volume` as *"Volume perdagangan (dalam satuan
+  lembar)"* — trading volume **in shares** — and carries a separate `value` field in rupiah
+  ([Keterangan Nama Kolom.md](https://github.com/wildangunawan/Dataset-Saham-IDX/blob/master/Keterangan%20Nama%20Kolom.md)).
+- **[MEASURED] on Yahoo's data directly.** Σ(`Close` × `Volume`) over all 834 priced names on
+  2026-08-04 = **Rp 12.07 trillion**, a normal IDX session. Top contributors: BBCA Rp 903 bn,
+  BBRI Rp 585 bn, TPIA Rp 517 bn, BMRI Rp 517 bn. Interpreting volume as lots would put the session
+  at Rp 1,207 trillion (~US$74 bn), which is absurd for IDX.
+
+**So `value_traded = Close × Volume` in rupiah, directly.** No ×100 correction.
+
+**[MEASURED] what that does to the universe** under the method's liquidity floor (20-day median
+value traded):
+
+| Floor | Names passing (of 840) |
+|---|---|
+| Rp 1 bn/day | **292** |
+| Rp 3 bn/day | 196 |
+| Rp 5 bn/day | 165 |
+| Rp 10 bn/day | 109 |
+
+The tradeable IDX universe is ~290 names at the Rp 1B floor, not 840 and not 963. That is a
+materially useful number for the universe-definition ticket (05) and for "top decile" sizing
+(≈29 names per decile).
+
+### 2.5 Data quality: zero-volume and phantom bars
+
+**[MEASURED]** across 840 symbols × 5 years: the mean fraction of bars with `Volume == 0` is
+**4.0%**, and **5.2% of tickers have >20% zero-volume bars**. Yahoo emits a bar with a carried-forward
+price and zero volume on days a stock did not trade or was suspended — INAF/POLL/BIMA showed
+*more* bars over 6 months (121) than actively traded names (119).
+
+This aligns with IDX's own convention, where a suspended stock reports 0 for High, Low, Change,
+Volume and Value ([same column dictionary](https://github.com/wildangunawan/Dataset-Saham-IDX/blob/master/Keterangan%20Nama%20Kolom.md)).
+
+**Any ADR, range, or consolidation-tightness computation must drop `Volume == 0` bars**, or a
+suspended stock will look like the tightest consolidation in the market. This is a concrete answer
+to the map's open "Data quality handling on IDX" item.
+
+### 2.6 Sector field — wrong taxonomy
+
+**[MEASURED]** `Ticker.info` returns Yahoo's own taxonomy, with both display and key forms:
+
+| Ticker | `sector` | `industry` |
+|---|---|---|
+| BBCA | Financial Services | Banks - Regional |
+| ANTM | Basic Materials | Gold |
+| TLKM | Communication Services | Telecom Services |
+| BUMI | Energy | Thermal Coal |
+| PGJO | Industrials | Marine Shipping |
+
+This is a GICS-*like* scheme, **not IDX-IC** (the exchange's own Industrial Classification, in force
+since 2021, with 12 sectors and a sub-industry level). Two implications:
+
+- It is *consistent with the US market's* sector labels, which is actually an advantage for the
+  cross-market sector-rotation view the map calls for — you get one taxonomy across IDX and US free.
+- It will not match what an Indonesian trader sees on Stockbit or the IDX site, and the sector
+  *indices* used for relative-strength (IDXENERGY, IDXFINANCE, …) are IDX-IC. Deciding which
+  taxonomy wins belongs to ticket 03; this note just establishes that Yahoo gives you the
+  GICS-like one and nothing else.
+- Cost: `Ticker.info` is one request per symbol. Cache it and refresh monthly, not nightly.
+
+### 2.7 Rate limits, stability, freshness
+
+**[MEASURED] throughput.** `yf.download(840 symbols, period="5y", threads=8)` completed in
+**11.5 seconds** and returned data for **all 840** (zero empties), **904,414 bars total**.
+
+**[MEASURED] rate limit.** Immediately after that bulk pull, the next screener call and then ~10
+consecutive `Ticker.history()` calls all raised `YFRateLimitError('Too Many Requests. Rate limited.
+Try after a while.')`. The block persisted across several minutes and multiple 15–20 s backoffs;
+requests only started succeeding again after a few minutes of near-idle. **The nightly job must
+pace itself and retry with exponential backoff** — this is the single most likely thing to break a
+scheduled run. In practice: use one batched `yf.download` for prices (cheap, 1 request per ~200
+symbols) and *avoid* per-symbol `.info` calls in the same run.
+
+**[MEASURED] endpoint stability.** `https://query1.finance.yahoo.com/v8/finance/chart/BBCA.JK`
+answers **unauthenticated, with no crumb/cookie dance**, returning full metadata. The historically
+fragile part of yfinance (the crumb/consent flow) is not currently on the critical path for chart
+data.
+
+**Freshness.** [MEASURED] at **19:49 WIB on 2026-08-04** — 3h49m after the 16:00 WIB close — the
+2026-08-04 bar was present and final for every actively-traded name. Yahoo's quote metadata reports
+`exchangeDataDelayedBy: 10` (minutes) and `sourceInterval: 10` for all 840 symbols, so the intraday
+feed is 10-minute delayed. **[UNVERIFIED]:** the exact earliest time the settled EOD bar appears. A
+nightly job scheduled at ~19:00 WIB / 12:00 UTC or later is comfortably safe; anything before
+~17:00 WIB should be treated as unproven.
+
+### 2.8 Storage footprint
+
+**[MEASURED]** 5 years × 840 symbols = **904,414 daily bars**, ≈ **50 MB** as 6 float columns.
+Extrapolating to full available history (effectively 2000-onward, most names much shorter) gives
+roughly **2.5M bars / ~140 MB** [UNVERIFIED — estimated from the `firstTradeDate` distribution, not
+downloaded].
+
+This is important context for ticket 04's conclusion: **IDX alone fits inside a 500 MB hosted row
+store comfortably.** Ticket 04's ~2 GB blocker is driven by the US universe (7,000 symbols), not by
+IDX. If the storage design ever needs to degrade gracefully, IDX is not the part that breaks.
+
+### 2.9 Terms of service — an honest reading
+
+This is the weakest part of the recommendation and should be stated plainly.
+
+- yfinance's own README: *"yfinance is **not** affiliated, endorsed, or vetted by Yahoo, Inc. It's an
+  open-source tool that uses Yahoo's publicly available APIs, and is intended for research and
+  educational purposes"* and *"Remember - the Yahoo! finance API is intended for personal use only"*
+  ([README](https://github.com/ranaroussi/yfinance/blob/main/README.md)).
+- Yahoo's Developer API ToS restricts commercial exploitation — *"Sell, lease, share, transfer, or
+  sublicense the Yahoo APIs … or derive income from the use or provision of the Yahoo APIs"* — and
+  bans usage that *"exceeds reasonable request volume, constitutes excessive or abusive usage"*
+  ([Yahoo Developer API ToU](https://legal.yahoo.com/us/en/yahoo/terms/product-atos/apiforydn/index.html)).
+- **Caveat on that citation:** those are the terms for Yahoo's *documented developer program*.
+  `query1.finance.yahoo.com/v8/finance/chart` is an **undocumented internal endpoint** that no
+  published Yahoo ToS explicitly covers. Anyone telling you the position is clear-cut is
+  overstating it. **[UNVERIFIED]** whether these specific terms bind use of the chart endpoint.
+
+**Where that leaves this project.** The map's constraints — *single user*, *hosted free tier*,
+*no redistribution*, *EOD only* — land this squarely in the "personal use" framing that yfinance
+itself invokes. There is no redistribution and no income. The volume constraint is the live one, and
+§2.7 shows it is real and enforced. **If this ever became multi-user or commercial, the source has to
+change.** That is the clearest "what would make us switch" trigger.
+
+---
+
+## 3. IDX official — free in principle, closed in practice
+
+**[MEASURED] the site actively blocks automated access.** Every server-side request I made returned
+Cloudflare **HTTP 403**, including with a full browser header set (UA, Accept, Referer, `sec-ch-ua`,
+`Sec-Fetch-*`, compression):
+
+- `https://www.idx.co.id/primary/StockData/GetSecuritiesStock?...` → **403**
+- `https://www.idx.co.id/primary/ListedCompany/GetCompanyProfiles?...` → **403**
+- `https://www.idx.co.id/en/market-data/stocks-data/stock-list/` → **403**
+- even `https://www.idx.co.id/robots.txt` → **403** ("Sorry, you have been blocked")
+
+I could not read IDX's robots.txt to check whether scraping is *permitted*, because the block also
+covers robots.txt. That is itself the answer about intent.
+
+**The data is a commercial product.** IDX sells market data under IDX Data Services, with a licence
+catalogue and pricelist covering IDX Market Data, Connection, Index, Publication and Advertisement
+licences, distinguishing Display vs Non-Display categories and requiring a Display licence to
+redistribute ([IDX Data Services](https://www.idx.co.id/en/products/idx-data-services/),
+[2024 catalogue and pricelist](https://www.idx.co.id/media/2qalvu4z/20240923_idx-data-catalogue-pricelist-2024.pdf),
+[data.idx.co.id](https://data.idx.co.id/)). Free programmatic access is not on offer.
+
+**But it is the only source of three things we cannot get elsewhere:** true unadjusted OHLC, the
+authoritative IDX-IC sector classification, and an official corporate-actions record (which would
+let us do rights adjustment properly). That is why it is the fallback, not a rejected option — see §7.
+
+---
+
+## 4. Sources whose terms forbid this use
+
+**Stockbit — explicitly closed.** Their Terms of Use state, verbatim:
+
+> "You agree not to reproduce, retransmit, distribute, disseminate, sell, publish, broadcast or
+> circulate the content received through Stockbit.com to anyone, including but not limited to others
+> in the same company or organization, nor any use of data mining, robots, spiders, or similar data
+> gathering and extraction tools for any purpose without the express prior written consent of
+> Stockbit"
+
+([stockbit.com/terms](https://stockbit.com/terms)). That covers exactly what we would be doing.
+**Rule it out.** It is otherwise the best free IDX data product in existence, which makes this a
+genuine loss, not a formality.
+
+**Investing.com — closed in practice.** `investpy`, the canonical Python client, carries a
+maintainer warning that it *"is not working fine currently due to some Investing.com changes in
+their APIs"* and redirects users to a stopgap replacement
+([investpy README](https://github.com/alvarobartt/investpy/blob/master/README.md)). To be fair to
+the source: the README does **not** allege legal action, only API changes — I could not verify the
+frequently-repeated blog claim that Investing.com issued a takedown. **[UNVERIFIED].** I was unable
+to fetch Investing.com's own terms page during this research, so their scraping clause is
+**[UNVERIFIED]** — but a source whose only working client is abandoned is not a foundation for a
+nightly job regardless.
+
+**Google Finance — no programmatic access at all.** Google deprecated the Finance API in 2011 and
+shut it down in 2012; the only supported access is the `GOOGLEFINANCE()` Sheets formula, whose data
+is delayed and marked not for professional use
+([GOOGLEFINANCE docs](https://support.google.com/docs/answer/3093281?hl=en)). A spreadsheet formula
+cannot back a Python nightly job. **Dead end.**
+
+**Stooq — bot-walled.** [MEASURED] every CSV URL (`stooq.com/q/d/l/?s=bbca.jk&i=d`,
+`?s=bbca.id`, and the symbol-list endpoint `stooq.com/db/l/?g=44`) now returns a JavaScript
+**proof-of-work challenge** ("This site requires JavaScript to verify your browser") instead of CSV.
+Whatever its coverage used to be, it is no longer accessible to a headless Python job. **Dead end.**
+
+---
+
+## 5. Indonesian open-data projects — all stale or paid
+
+**Sectors / sectors.app (Supertype)** — the most credible commercial-grade Indonesian API. Covers
+IDX + SGX + KLSE, "99% coverage of IDX-listed stocks", daily updates, endpoints for company
+profiles, historical prices, dividends, indices. **But:** *"Sectors Financial API is available to our
+Insider plan subscribers"* ([docs.sectors.app](https://docs.sectors.app/)), and **[MEASURED]**
+`api.sectors.app/v2/companies/` returns `{"error":"Authentication credentials were not provided."}`.
+Their pricing page is behind a Vercel bot checkpoint, so the exact Insider price is **[UNVERIFIED]** —
+but there is no free API tier. **Violates the free-sources-only constraint.**
+
+**wildangunawan/Dataset-Saham-IDX** — a genuinely good dataset that is **dead**. [MEASURED] via the
+GitHub API: **last data commit `2025-02-23` ("Update data per 23 Feb 25")**, ~17 months stale as of
+today. Licence is **CC BY-NC 4.0** (non-commercial — fine for a single-user personal dashboard, not
+for anything else). It scrapes the IDX daily summary and therefore carries fields Yahoo does not:
+`value`, `frequency`, `listedShares`, `tradebleShares`, `foreignBuy`/`foreignSell`, `delistingDate`,
+and both regular and non-regular market volume. Useful as a **historical reference for validating
+Yahoo's numbers up to Feb 2025**, and its `List Emiten/all.csv` is a usable (if stale) seed for the
+suspended names the Yahoo screener drops. Not a live source.
+
+**baguskto/saham-mcp** — advertises "958 IDX stocks, 2019–2025" but is a thin wrapper that reads CSVs
+from Dataset-Saham-IDX, so it inherits the same 2025-02 staleness
+([README](https://github.com/baguskto/saham-mcp)). Not an independent source.
+
+**goapi.io** — Indonesian commercial REST API for IDX with historical prices; free registration is
+advertised but free-tier quotas are **[UNVERIFIED]** ([goapi.io](https://goapi.io/api-data-saham-indonesia/)).
+Not investigated further because Yahoo already dominates on coverage and cost.
+
+**Kaggle datasets** (`muamkh/ihsgstockdata`, `garethharrison/daily-IHSG`) — snapshots, not feeds. No
+use for a nightly job.
+
+---
+
+## 6. Dead ends, stated plainly
+
+- I **could not read idx.co.id at all**, by any server-side means, including robots.txt. Every claim
+  about IDX's own endpoints in §3 is about *access*, not content — I never saw a payload.
+- I **could not verify Investing.com's scraping clause** (fetch blocked), nor the widely repeated
+  claim that they issued a legal takedown to `investpy`. The investpy README says only "API changes".
+- I **could not verify Sectors' Insider price** (Vercel bot checkpoint), only that the API requires it.
+- I **could not empirically pin the exact time** the settled EOD bar becomes available on Yahoo; that
+  needs observation across a session boundary, not a single point-in-time probe.
+- The BBRI 10/11 rescale is **verified as an unlabelled adjustment**, but whether it is the *correct*
+  factor is **[UNVERIFIED]** — establishing that needs an authoritative corporate-actions record,
+  which is exactly the thing no free source provides.
+- I did **not** test Alpha Vantage / Twelve Data / Finnhub IDX coverage with real API keys. Their
+  free quotas (25–800 calls/day) cannot support 840 symbols nightly regardless of coverage, so the
+  question is moot. **[UNVERIFIED]** whether they carry `.JK` at all.
+
+---
+
+## 7. Recommendation
+
+### Primary: Yahoo Finance via `yfinance`
+
+Nothing else clears the bar. It is the only source that is simultaneously free, programmatically
+accessible, covering the whole active universe, deep enough in history, and fast enough to pull
+nightly inside a free-tier job. Concretely:
+
+- **Universe:** nightly `yf.screen(EquityQuery("eq",["exchange","JKT"]))`, paginated 250 at a time.
+  Union into a persisted universe table; mark anything not seen tonight as `stale`. Do **not** treat
+  the screener as the historical universe.
+- **Prices:** one batched `yf.download(symbols, period=..., auto_adjust=False, threads=8)`.
+  **[MEASURED] 11.5 s for 840 × 5y.** Keep both `Close` and `Adj Close`.
+- **Liquidity:** `Close × Volume` in rupiah, no lot correction. 20-day median ≥ Rp 1B leaves
+  **~292 names [MEASURED]**.
+- **Hygiene:** drop `Volume == 0` bars before any range/ADR/tightness computation. Flag any
+  unexplained single-bar move >±25% (no split, no dividend) as a suspect corporate action.
+- **Sectors:** cache `Ticker.info` sector/industry **monthly**, never in the nightly price run —
+  per-symbol `.info` calls are what trip the rate limiter.
+- **Pacing:** exponential backoff on `YFRateLimitError`; assume a cold-start budget of roughly one
+  bulk download plus a small number of extra calls.
+
+### Fallback: headless-browser scrape of idx.co.id
+
+If Yahoo breaks — endpoint change, crumb wall returning, or the rate limit tightening below what a
+nightly full-universe pull needs — the only remaining free path to IDX data is the exchange's own
+site, driven by a real browser to satisfy Cloudflare (Playwright in the GitHub Actions runner ticket
+04 already recommends). It is more work and more fragile per-run, but it is strictly better data:
+raw unadjusted prices, official value/frequency/foreign-flow fields, IDX-IC sectors, and delisting
+dates. Note that IDX sells this data commercially (§3), so this fallback is defensible only for
+strictly personal, non-redistributed use.
+
+**Secondary fallback for the universe list only:** `Dataset-Saham-IDX`'s `List Emiten/all.csv`
+(CC BY-NC), stale at Feb 2025, as a seed for suspended tickers the Yahoo screener omits.
+
+### What would make us switch
+
+1. **Multi-user or any commercial use.** The "personal use" framing yfinance leans on stops applying.
+2. **Rate limiting tightening** below the ~1-bulk-download-per-night budget measured in §2.7.
+3. **A backtest that needs delisted names.** The Yahoo screener universe is survivorship-biased
+   (§2.1); a serious historical replay forces the IDX scrape or a paid source.
+4. **Rights-issue accuracy becoming load-bearing** — e.g. if absolute price levels, ARA/ARB bands, or
+   tick-size rules enter the star score. Yahoo's opaque adjustment (§2.3) cannot support that.
+5. **Sectors/Supertype introducing a free tier.** It is the best-shaped product for this use case and
+   only price disqualifies it.
+
+### Is a full-universe nightly pull feasible on a free tier?
+
+**Yes, comfortably — for IDX.** [MEASURED] 840 symbols, 5 years, 11.5 seconds, ~50 MB. Even a full
+backfill is minutes, not hours, and fits inside every free-tier store and every scheduler in ticket
+04. The binding constraint is **Yahoo's rate limiter**, not compute, bandwidth, or storage.
+
+---
+
+## 8. Sources
+
+- [yfinance README (legal disclaimer, personal-use statement)](https://github.com/ranaroussi/yfinance/blob/main/README.md)
+- [yfinance `scrapers/history.py` (adjustment implementation)](https://github.com/ranaroussi/yfinance/blob/main/yfinance/scrapers/history.py)
+- [Yahoo Finance help — Adjusted Close definition (SLN28256)](https://help.yahoo.com/kb/SLN28256.html)
+- [Yahoo Developer API Terms of Use](https://legal.yahoo.com/us/en/yahoo/terms/product-atos/apiforydn/index.html)
+- [IDX Data Services (product page)](https://www.idx.co.id/en/products/idx-data-services/)
+- [IDX Data Catalogue and Pricelist 2024 (PDF)](https://www.idx.co.id/media/2qalvu4z/20240923_idx-data-catalogue-pricelist-2024.pdf)
+- [IDX Data Services Portal](https://data.idx.co.id/)
+- [Stockbit Terms of Use](https://stockbit.com/terms)
+- [investpy README (maintainer deprecation notice)](https://github.com/alvarobartt/investpy/blob/master/README.md)
+- [GOOGLEFINANCE function docs](https://support.google.com/docs/answer/3093281?hl=en)
+- [Sectors Financial API docs (Insider-plan gate)](https://docs.sectors.app/)
+- [Sectors.app](https://sectors.app/)
+- [wildangunawan/Dataset-Saham-IDX](https://github.com/wildangunawan/Dataset-Saham-IDX)
+- [Dataset-Saham-IDX column dictionary (volume in shares; suspension = zeros)](https://github.com/wildangunawan/Dataset-Saham-IDX/blob/master/Keterangan%20Nama%20Kolom.md)
+- [baguskto/saham-mcp](https://github.com/baguskto/saham-mcp)
+- [goapi.io — API Data Saham Indonesia](https://goapi.io/api-data-saham-indonesia/)
+- [Databoks — IDX listed company count, 2026](https://databoks.katadata.co.id/en/market/statistics/6a24e09f528c8/listed-companies-on-the-idx-remained-relatively-stagnant-through-april-2026)
+- [Wikipedia — Indonesia Stock Exchange](https://en.wikipedia.org/wiki/Indonesia_Stock_Exchange)

--- a/.scratch/screening-dashboard/research/02-us-data-sources.md
+++ b/.scratch/screening-dashboard/research/02-us-data-sources.md
@@ -1,0 +1,431 @@
+# Free EOD data sources for US (and IDX)
+
+Research note resolving `issues/02-us-free-data-sources.md`.
+Date of investigation: 2026-08-04. All rate limits and prices verified against vendor pages on that date.
+
+Empirical tests were run in a throwaway venv (`yfinance 1.5.2`, Python 3.12.6) outside the project.
+Nothing was installed into the repo.
+
+---
+
+## TL;DR
+
+**Recommend: yfinance (Yahoo Finance) as the single primary source for both US and IDX.**
+It is the only free source that survives a ~6,000-symbol nightly pull, and — the material finding —
+**it serves IDX and US from one client, one schema, one code path** (`BBCA.JK` alongside `AAPL`),
+including sector/industry for both. That collapses the two-market design into one ingester.
+
+Measured: **full 5,711-symbol US universe, 2 years of daily bars, in 8.5 minutes with zero HTTP 429s**
+at a self-imposed 12 req/s cap.
+
+**Fallback: Polygon — now Massive — free "Basic" tier**, whose whole-market grouped-daily endpoint
+returns every US ticker for a date in *one* request. It is sanctioned, has a real ToS, and covers
+delisted names — but it is **US-only** (so it does not solve IDX) and capped at **2 years** of history.
+
+Three honest problems with the recommendation, detailed below: **Yahoo's ToS**; **survivorship bias**
+(delisted US names are largely purged from Yahoo); and a **partial live bar** for any in-progress
+session, which will silently corrupt volume and range math unless explicitly guarded against.
+
+Also note two traps that would bite a naive implementation: an **unthrottled** full pull silently loses
+~47% of the universe while reporting the losses as "possibly delisted", and **Stooq is now blocked** by
+an anti-bot wall that returns HTTP 200 with HTML.
+
+---
+
+## Comparison table
+
+| Source | Free-tier limit | Nightly 6k feasible? | History | Raw + adjusted? | Delisted | Sector | IDX too? | Sanctioned |
+|---|---|---|---|---|---|---|---|---|
+| **yfinance / Yahoo** | Undocumented; empirically ~12 req/s sustained OK, ~75 req/s fails | **Yes — 8.5 min measured** | To 1980 for AAPL; 22y for BBCA.JK | **Yes** — OHLC raw + `Adj Close` + `Dividends` + `Stock Splits` in one call | **Mostly no** | Yes, via `.info` | **Yes** (`.JK`) | **No** — unofficial |
+| **Polygon / Massive (Basic)** | 5 API calls/min | **Yes** — 1 call/day covers whole market | **2 years** | `adjusted=true|false` param | **Yes** (`active=false`, `delisted_utc`) | Not in tickers endpoint | **No** — US only | Yes |
+| **Nasdaq Trader symbol files** | None (public FTP/HTTPS) | N/A — reference only | N/A | N/A | No (current listings only) | No | No | Yes |
+| **SEC `company_tickers*.json`** | Fair-access policy (UA required) | N/A — reference only | N/A | N/A | Registrants only | SIC via submissions API | No | Yes |
+| **Stooq** | — | **No — blocked** | — | — | — | — | — | **Dead end** |
+| **Alpha Vantage** | **25 requests/day** | No | — | — | — | — | — | Yes |
+| **Tiingo (Starter)** | **500 unique symbols/month**, 50 req/hr, 1000/day | No | — | — | — | — | — | Yes |
+| **FMP (Basic)** | **250 requests/day**, US only | No | 5y | — | — | — | No | Yes |
+| **EODHD (Free)** | **20 calls/day**, 1 year range | No | 1y | — | — | — | — | Yes |
+
+---
+
+## 1. The metered APIs are all dead on arrival
+
+Every keyed free tier fails on arithmetic alone against a ~6,000-symbol nightly pull. Numbers taken
+verbatim from vendor pricing pages:
+
+- **Alpha Vantage — 25 API requests per day.** "the majority of our API endpoints can be accessed for
+  free" with a limit of **"25 API requests per day"**. Source: <https://www.alphavantage.co/premium/>.
+  At 25/day, one pass over 6,000 symbols takes 240 days. Not viable at any batching.
+- **Tiingo Starter (free) — 500 unique symbols per month.** The pricing table lists "Unique Symbols
+  per Month: 500", "Max Requests Per Hour: 50", "Max Requests Per Day: 1000", "Max Bandwidth Per
+  Month: 1 GB". Source: <https://www.tiingo.com/about/pricing>. The *symbol* cap is the binding one —
+  6,000 symbols is 12x the monthly allowance. Also marked **"Internal Use Only"**, footnoted as "you
+  may only use the data for your own personal use and you may not display or share the data with
+  another person or organization."
+- **EODHD Free — 20 API calls/day, "Past year" of data, "Personal use".** Source:
+  <https://eodhd.com/pricing>. A 500-call welcome bonus does not change the steady state.
+- **FMP Basic — 250 requests/day, US exchanges only.** FMP's own site states the free plan allows
+  "up to 250 market data API requests per day" and covers "all stocks within the US exchanges", with
+  global exchanges requiring an upgrade. Sources: <https://site.financialmodelingprep.com/pricing-plans>,
+  <https://site.financialmodelingprep.com/faqs>.
+  *Caveat on citation:* both FMP pages return **HTTP 403 to programmatic fetches**; these figures come
+  from FMP-authored page content surfaced via search rather than a direct read. **Treat as
+  first-party-but-not-directly-verified.** An unauthenticated probe of
+  `financialmodelingprep.com/api/v3/historical-price-full/AAPL?apikey=demo` returns
+  `{"Error Message": "Invalid API KEY..."}` — there is no usable demo key.
+
+None of these can be rescued by clever batching, because the limits are on *symbols* or *calls*, not
+bandwidth.
+
+## 2. Stooq is a dead end (this is a change from its historical reputation)
+
+Stooq's CSV endpoint is frequently recommended as the no-key fallback, and `pandas-datareader` ships a
+Stooq reader. **It no longer works unattended.**
+
+`https://stooq.com/q/d/l/?s=aapl.us&i=d` returns **HTTP 200 with an HTML anti-bot interstitial**, not
+CSV — a JavaScript proof-of-work challenge:
+
+> `<noscript>This site requires JavaScript to verify your browser. Please enable JavaScript and reload.</noscript>`
+> followed by a script that brute-forces a SHA-256 hash with a 4-hex-zero prefix and POSTs the nonce to `/__verify`.
+
+Verified 2026-08-04 for both `aapl.us` and `bbca.jk`. Because the failure is a 200 with an HTML body,
+naive clients will silently parse garbage rather than raise. Additionally, the installed
+`pandas-datareader` exposes no working Stooq path (`data_source='stooq' is not implemented`;
+`pandas_datareader.stooq` does not import). **Rule Stooq out.**
+
+## 3. Universe enumeration — solved, free, and reliable
+
+The Nasdaq Trader symbol directory is the right answer. Both transports work:
+
+- FTP: `ftp://ftp.nasdaqtrader.com/SymbolDirectory/nasdaqlisted.txt` and `.../otherlisted.txt`
+- **HTTPS (preferred, works from restricted hosts):**
+  `https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt` — verified HTTP 200, 345,641 bytes,
+  byte-identical line count to the FTP copy.
+
+Pipe-delimited, with the fields the ticket asks for. `nasdaqlisted.txt` header:
+`Symbol|Security Name|Market Category|Test Issue|Financial Status|Round Lot Size|ETF|NextShares`.
+`otherlisted.txt` header: `ACT Symbol|Security Name|Exchange|CQS Symbol|ETF|Round Lot Size|Test Issue|NASDAQ Symbol`.
+
+**Measured composition (2026-08-04), after dropping `Test Issue == Y` (8 Nasdaq + 25 other):**
+
+| Slice | Count |
+|---|---|
+| nasdaqlisted rows | 5,568 |
+| otherlisted rows | 7,524 |
+| Nasdaq, ETF=N | 4,307 |
+| NYSE (`N`), ETF=N | 2,850 |
+| NYSE American/AMEX (`A`), ETF=N | 308 |
+| NYSE Arca (`P`), ETF=N | 17 |
+| Cboe BZX (`Z`), ETF=N | 4 |
+| **Nasdaq + NYSE + AMEX, ETF=N** | **7,465** |
+| **After stripping warrants/rights/units/preferreds/notes and `$`/`.` symbols** | **5,711** |
+
+The **`ETF` flag separates funds cleanly** — 1,253 on Nasdaq, 4,320 on the other-listed file — which is
+exactly what the ticket needs (stocks universe; ETFs retained separately as sector proxies). Arca and
+BZX are almost entirely ETFs (2,693 and 1,573 of them), so excluding those venues costs ~21 real stocks.
+
+5,711 matches the ticket's "~6,000 symbols" premise well. Note the residual junk: my name-based filter
+left rights like `AACBR` (the security name says "Rights", my regex tested `\bRight\b`) — a real
+implementation should filter on the security-name suffix more carefully, and cross-check `quoteType`
+from Yahoo.
+
+**SEC reference data** also works and is a good CIK cross-walk, but requires a descriptive `User-Agent`
+(WebFetch and bare curl get **HTTP 403**; curl with a UA gets 200):
+
+- `https://www.sec.gov/files/company_tickers.json` — **10,432 entries**, fields `cik_str, ticker, title`.
+- `https://www.sec.gov/files/company_tickers_exchange.json` — **10,411 rows**, fields `cik, name, ticker, exchange`.
+  Exchange distribution: Nasdaq 4,342, NYSE 3,309, **OTC 2,542**, null 191, CBOE 27.
+
+SEC is *not* a substitute for the Nasdaq files for this purpose: it includes 2,542 OTC names we don't
+want, has no ETF flag, and no price data. Use it only if CIK linkage or SIC codes are later needed.
+
+## 4. yfinance — measured behaviour, including the rate-limit cliff
+
+This is where the empirical work matters most, because Yahoo publishes **no rate limits at all**. What
+follows is observed, not documented.
+
+### Throughput and the cliff
+
+`yf.download` issues **one HTTP request per symbol** (measured by patching `curl_cffi.Session.request`;
+1,095 requests for 1,000 symbols — the ~95 extra are cookie/crumb handshakes).
+
+| Test | Rate cap | Result |
+|---|---|---|
+| 10 syms, `period=max` | none | 0.98 s |
+| 200 syms, 2y | none | 2.9 s, 200/200 |
+| 1,000 syms, 2y | none | 13.3 s (75.3 sym/s), 1,000/1,000, **0 × 429** |
+| **5,711 syms (full), 2y** | **none** | **75.6 s but only 3,020/5,711 (52.9%) — 5,374 × HTTP 429** |
+| 300 syms, 2y | 5 req/s | 62.7 s, 299/300, 1 × 429 |
+| 400 syms, 2y | 10 req/s | 43.5 s, 400/400, 0 × 429 |
+| 400 syms, 2y | 20 req/s | 22.9 s, 400/400, 0 × 429 |
+| **5,711 syms (full), 2y** | **12 req/s** | **511.9 s (8.5 min), 5,707/5,711 (99.93%), 0 × 429** |
+
+**The headline risk and its mitigation.** Unthrottled, the full pull *appears* fast (75 s) but is a
+silent disaster: **47% of symbols came back empty**, and yfinance reports the failures as
+`"$TICKER: possibly delisted; no price data found"` — a message that looks like a data condition, not a
+throttling condition. Anyone building this without a rate cap will ship a screener that quietly drops
+half the universe and blames delisting. **A client-side rate limiter is mandatory, not an optimisation.**
+
+At **12 req/s the full universe completes in 8.5 minutes with zero rejections** — comfortably inside a
+nightly window. Bursts to ~20 req/s were fine over 400 requests but were not validated at scale;
+12 req/s is the rate I would actually ship.
+
+Once rate-limited, Yahoo stays hostile for minutes: subsequent calls raise
+`yfinance.exceptions.YFRateLimitError: Too Many Requests` from the cookie/crumb handshake, and a later
+500-symbol run returned nothing until a multi-minute cooldown. Build in backoff and a "did we get
+≥95% of the universe?" assertion before publishing a night's screen.
+
+**Caveat — these numbers are from a residential IP.** Yahoo is materially more aggressive toward
+datacenter ranges, which is exactly where a free hosting tier lives. **The 12 req/s figure should be
+re-validated from the actual host before it is treated as settled.** Treat it as an upper bound.
+
+### Fields, history, adjustment
+
+One `yf.download(..., auto_adjust=False, actions=True)` call returns all eight columns:
+
+`Open, High, Low, Close, Adj Close, Volume, Dividends, Stock Splits`
+
+This **satisfies the ticket's raw-and-adjusted requirement in a single request** — raw OHLC for ADR and
+gap math, `Adj Close` for return math, plus the split/dividend events to do your own adjustment.
+
+History is deep: `AAPL` returns **11,501 rows from 1980-12-12** to 2026-08-03 on `period="max"`.
+
+### Sector / industry
+
+Available per symbol via `Ticker(s).info` (~0.15 s each), on **Yahoo's own taxonomy** (roughly 11
+sectors / ~145 industries — the specific counts are **not verified here**):
+
+| Symbol | sector | industry |
+|---|---|---|
+| AAPL | `Technology` | `Consumer Electronics` |
+| XOM | `Energy` | `Oil & Gas Integrated` |
+| BBCA.JK | `Financial Services` | `Banks - Regional` |
+| TLKM.JK | `Communication Services` | `Telecom Services` |
+
+Two practical notes: `.info` is a **separate request per symbol** (so a full-universe refresh roughly
+doubles the request budget — cache it and refresh weekly, not nightly), and it also yields
+`quoteType` (`EQUITY`) and `exchange` (`NMS`/`NYQ`/`JKT`), giving a second, independent ETF filter to
+cross-check the Nasdaq `ETF` flag against.
+
+### Survivorship — the real weakness
+
+Delisted and acquired US names are **largely purged from Yahoo**. Measured:
+
+| Symbol | Fate | `period="max"` result |
+|---|---|---|
+| TWTR | acquired 2022 | **0 rows** |
+| ATVI | acquired 2023 | **0 rows** |
+| VMW | acquired 2023 | **0 rows** |
+| SIVBQ | failed 2023 | **0 rows** |
+| FRCB | failed 2023 | 3,934 rows, 2010-12-09..2026-08-03 |
+
+Only `FRCB` survives, and probably only because the ticker still quotes OTC. **Any backtest built on a
+yfinance history will be survivorship-biased upward**, and this bears directly on the map's open
+"Validation / backtest" item. If historical replay is going to be used to calibrate star thresholds,
+that calibration will be optimistic. Mitigations, in order of cost: (a) snapshot the Nasdaq listing
+file nightly from day one, so that *going forward* you accumulate your own point-in-time universe —
+cheap, and worth starting immediately even before backtesting is designed; (b) use Massive's
+`active=false` ticker history for the last 2 years; (c) accept the bias and state it.
+
+### Freshness
+
+**Yahoo emits a partial, live bar for the in-progress session. Confirmed empirically, and this is a
+correctness trap for the whole screen.**
+
+Measured at **2026-08-04 13:44 UTC = 09:44 ET — 14 minutes after the US open**:
+
+| Symbol | Last bar date | Close | Volume |
+|---|---|---|---|
+| AAPL | **2026-08-04** (today, market open) | 303.57 | **8,538,070** |
+| MSFT | **2026-08-04** (today, market open) | 485.65 | **6,686,919** |
+| BBCA.JK | 2026-08-04 (IDX closed) | 6,500.00 | 138,953,100 |
+
+AAPL's "2026-08-04" bar is **14 minutes of trading**, not a day. Its close is the last trade, its high
+and low cover minutes, and its volume is a small fraction of a session. An earlier run the same day had
+shown AAPL's last bar as 2026-08-03 — the bar *appeared* the moment the session opened.
+
+Consequences for a nightly EOD job:
+
+- Any ADR, gap, range-tightness or volume calculation that consumes the final bar will be **silently
+  wrong** if the job runs while a session is open anywhere. Volume-based liquidity floors would reject
+  nearly the whole universe.
+- The two markets have **disjoint sessions**, so there is no single safe wall-clock time: 09:44 ET is
+  safe for IDX (closed) and unsafe for US (open).
+- **Mitigation:** do not trust the run time. Per market, drop any bar whose date equals the current
+  local trading date unless that market's session is confirmed closed, and prefer scheduling each
+  market's ingest after its own close. A cheap sanity assertion — final-bar volume within a plausible
+  band of the trailing median — would catch this class of bug directly.
+
+### Storage
+
+At 5,711 symbols × ~502 bars/year:
+
+| Window | Rows | Uncompressed (float32 OHLCV+adj) |
+|---|---|---|
+| 2 years | ~2.87 M | ~86 MB |
+| 10 years | ~14.3 M | ~430 MB |
+
+Parquet typically compresses this 3–5x. This comfortably fits free-tier object storage; it does **not**
+comfortably fit the row limits of some free hosted Postgres tiers at 10 years, which is a consideration
+for the architecture ticket. The in-memory pandas frame for the 2-year full pull measured **161 MB**,
+which *is* a real constraint on a 512 MB free dyno — stream and write per-chunk rather than
+materialising the whole universe.
+
+## 5. Polygon → Massive — the strongest sanctioned fallback
+
+**Polygon.io rebranded to Massive.com effective 2025-10-30 16:00 ET.** Existing API keys, accounts and
+the `api.polygon.io` base URL continue to work, with `api.massive.com` running in parallel.
+Sources: <https://massive.com/blog/polygon-is-now-massive>, corroborated by
+<https://natlawreview.com/press-releases/polygonio-now-massive>. All `polygon.io` doc and pricing URLs
+now 301 to `massive.com`. **Anything in the codebase or in older research citing polygon.io pricing
+should be re-checked against massive.com.**
+
+Free "Basic" Stocks tier, verbatim from <https://massive.com/pricing>:
+
+- **"5 API Calls / Minute"**
+- **"2 Years Historical Data"**
+- **"End of Day Data"**
+
+The reason this survives 5 calls/min where Alpha Vantage does not is the **grouped daily / daily market
+summary** endpoint, which returns "daily OHLC (open, high, low, close), volume, and volume-weighted
+average price (VWAP) data for **all U.S. stocks** on a specified trading date" in a single call, and is
+**"Included in all Stocks plans"** including Basic.
+Source: <https://massive.com/docs/rest/stocks/aggregates/daily-market-summary>.
+
+Consequences:
+
+- **Nightly cost: 1 request.** Not 6,000. This is by far the most robust nightly story of any source.
+- **Backfill cost:** 2 years ≈ 500 trading days ≈ 500 calls ≈ **100 minutes** at 5/min. One-time.
+- Split adjustment is a parameter: `adjusted` defaults to true, `false` gives unadjusted — so raw and
+  adjusted are both obtainable, though at the cost of a second pass.
+- **Delisted tickers are available**: the tickers endpoint supports `active=false` and returns
+  `delisted_utc`. Source: <https://massive.com/docs/rest/stocks/tickers/all-tickers>. Better
+  survivorship than Yahoo, within the 2-year window.
+
+Why it is the fallback and not the primary:
+
+1. **US-only.** It does nothing for IDX, so choosing it means building and maintaining a second,
+   entirely different IDX ingester. That is the single biggest strike against it.
+2. **2 years of history** on Basic. Adequate for the method's 1/3/6-month momentum lookbacks and a
+   200-day MA, thin for any meaningful backtest.
+3. **No sector/industry** in the tickers endpoint (SIC is not documented as returned), so sector
+   leadership and rotation would still need a second source.
+
+**Not empirically verified.** I did not create a Massive account, so the 5/min limit, the grouped-daily
+payload shape, and Basic-tier access to it are **documented-only**. Given it is the designated fallback,
+a 10-minute spike with a real free key would be worth doing before the architecture ticket closes.
+
+## 6. Can one source serve both IDX and US? — Yes, and only one can
+
+This was the ticket's flagged question, and it has a clean answer.
+
+**yfinance covers IDX via the `.JK` suffix with the same client, same call, same schema, same
+adjustment fields, and same sector taxonomy as US.** Measured 2026-08-04:
+
+- A single `yf.download` over `["BBCA.JK","BBRI.JK","TLKM.JK","ASII.JK","GOTO.JK","ANTM.JK","MDKA.JK","BREN.JK","UNVR.JK","ICBP.JK"]`
+  returned **479 rows each** over 2 years, 2024-08-05..2026-08-04, with sane closes and volumes
+  (e.g. BBCA close 6,500, volume 138,953,100).
+- Deep history: `BBCA.JK` `period="max"` gives **5,463 rows from 2004-06-08**, with **2 splits and 46
+  dividends** recorded — corporate actions are present, not just prices. `GOTO.JK` gives 1,032 rows
+  from its 2022-04-11 IPO, correctly.
+- Sector/industry resolve on the same Yahoo taxonomy (see table above), so **cross-market sector
+  leadership and rotation are directly comparable** — no mapping layer between two vendors' taxonomies.
+  This is a larger simplification than it first appears.
+
+**No other candidate does this.** FMP free is explicitly US-only. Massive is US equities. Alpha Vantage,
+Tiingo and EODHD are eliminated on volume regardless of coverage. Stooq nominally carries `.jk` symbols
+but is blocked. So the choice is genuinely: **one source (Yahoo), or two ingesters.**
+
+Open IDX gaps this note does *not* close, and which belong to the IDX ticket:
+
+- **IDX universe enumeration is unsolved here.** The Nasdaq files obviously don't cover IDX, and Yahoo
+  offers no listing endpoint. A separate source for the ~900 IDX tickers is still needed. **Unverified.**
+- The map's suspected IDX data-quality issues (ARA/ARB limit days, suspensions, no-trade days) were
+  **not** examined. Yahoo returning 479 identical row counts across ten liquid names is encouraging but
+  says nothing about thin ones.
+
+## 7. ToS and stability — the honest problems
+
+**yfinance is not a sanctioned API.** Its README states it is "**not** affiliated, endorsed, or vetted
+by Yahoo, Inc. It's an open-source tool that uses Yahoo's publicly available APIs", is "intended for
+research and educational purposes", and — explicitly — "Remember - the Yahoo! finance API is intended
+for **personal use only**." Source:
+<https://raw.githubusercontent.com/ranaroussi/yfinance/main/README.md>.
+
+Yahoo's own API terms (<https://legal.yahoo.com/us/en/yahoo/terms/product-atos/apiforydn/index.html>)
+prohibit, verbatim:
+
+- **"Sell, lease, share, transfer, or sublicense the Yahoo APIs or access or access codes thereto or derive income from the use or provision of the Yahoo APIs"**
+- **"Use the Yahoo APIs in a manner that exceeds reasonable request volume, constitutes excessive or abusive usage"**
+- Yahoo reserves the right to impose rate limits **"at Yahoo's absolute and sole discretion"**.
+
+Assessment against this project's actual shape — **single user, personal, non-commercial, not
+redistributing, ~6k requests once nightly**:
+
+- The **"derive income"** and sharing prohibitions are **not** implicated. This is a personal tool.
+- The **"reasonable request volume"** clause is the live one and is deliberately vague. 6,000 requests
+  once a night at 12 req/s is modest by any absolute measure, but it is unambiguously automated bulk
+  access, and Yahoo is the sole judge. **There is no reading under which this is explicitly
+  permitted** — the honest characterisation is "tolerated in practice, not authorised."
+- The terms' **24-hour data-retention clause** applies to *Yahoo user data*, not market data. It is
+  **not obviously applicable** to OHLCV bars, but I am flagging it because a strict reading would
+  forbid the historical store this project depends on. **This is my interpretation, not a verified
+  legal position.**
+
+**Practical stability risk.** yfinance breaks when Yahoo changes its endpoints — the cookie/crumb
+handshake visible in the stack traces above exists precisely because Yahoo added anti-automation
+measures that the library had to work around. Historically this has meant periodic outages until a new
+release lands. Plan for it: pin the version, keep the ingester behind an interface so the fallback can
+be swapped in, and alert on the "≥95% of universe" assertion rather than discovering breakage in the
+screen output.
+
+Given the constraints are fixed at *free sources only* and *single user*, and the alternative is a
+US-only vendor plus a separate IDX ingester, **yfinance is the right call — but it should be chosen
+with the ToS ambiguity acknowledged in the spec, not silently.**
+
+---
+
+## Recommendation
+
+1. **Primary: yfinance**, for both markets, with a **client-side cap of 12 req/s** and mandatory
+   backoff. Full US universe in ~8.5 min; IDX adds negligible time.
+2. **Universe: Nasdaq Trader `nasdaqlisted.txt` + `otherlisted.txt` over HTTPS**, filtering
+   `Test Issue == N`, `ETF == N`, and name-suffix junk → ~5,700 symbols. **Snapshot these files nightly
+   from day one** to build a point-in-time universe and blunt survivorship bias later.
+3. **Sector/industry: cached `Ticker.info`**, refreshed weekly, not nightly — it is a second request
+   per symbol.
+4. **Fallback: Massive (ex-Polygon) Basic**, grouped-daily, 1 request/night, for US. Keep the ingester
+   behind an interface so this is a swap, not a rewrite. Accept that IDX would need its own path.
+5. **Reject outright:** Alpha Vantage, Tiingo, FMP, EODHD (volume limits), Stooq (anti-bot wall).
+
+### Things a build session must not assume from this note
+
+- The 12 req/s ceiling was measured **from a residential IP**. Re-validate from the deployment host.
+- **Massive's free tier was not exercised with a real key** — documented-only.
+- **IDX universe enumeration is unsolved.**
+- IDX data-quality behaviour (ARA/ARB, suspensions, thin names) was not tested.
+- Yahoo's 24-hour retention clause and its applicability to market data is my reading, not legal advice.
+
+---
+
+## Sources
+
+Primary, fetched 2026-08-04:
+
+- <https://www.alphavantage.co/premium/> — Alpha Vantage limits
+- <https://www.tiingo.com/about/pricing> — Tiingo Starter limits
+- <https://eodhd.com/pricing> — EODHD free plan
+- <https://massive.com/pricing> — Massive (ex-Polygon) Basic tier
+- <https://massive.com/docs/rest/stocks/aggregates/daily-market-summary> — grouped daily endpoint
+- <https://massive.com/docs/rest/stocks/tickers/all-tickers> — tickers/delisted
+- <https://massive.com/blog/polygon-is-now-massive> — rebrand
+- <https://legal.yahoo.com/us/en/yahoo/terms/product-atos/apiforydn/index.html> — Yahoo API ToS
+- <https://raw.githubusercontent.com/ranaroussi/yfinance/main/README.md> — yfinance disclaimer
+- <https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt>, `.../otherlisted.txt`
+- <https://www.sec.gov/files/company_tickers.json>, <https://www.sec.gov/files/company_tickers_exchange.json>
+- <https://stooq.com/q/d/l/?s=aapl.us&i=d> — anti-bot interstitial
+
+Secondary / weaker citation, flagged in text:
+
+- <https://site.financialmodelingprep.com/pricing-plans> and `/faqs` — FMP-authored but 403 to direct fetch
+- <https://natlawreview.com/press-releases/polygonio-now-massive> — corroborates rebrand date

--- a/.scratch/screening-dashboard/research/03-sector-taxonomy.md
+++ b/.scratch/screening-dashboard/research/03-sector-taxonomy.md
@@ -1,0 +1,408 @@
+# Free sector/industry classification for IDX and US
+
+Research for ticket `03-sector-taxonomy-sources.md`. Date: 2026-08-04.
+
+Constraints assumed from `map.md`: free sources only, both IDX and US, EOD nightly, Python backend.
+
+**Convention note:** this repo had no `research/` directory content before this file; `.scratch/screening-dashboard/research/`
+already existed as an empty directory, so findings go here.
+
+---
+
+## TL;DR
+
+- **One free source covers both markets with one taxonomy**: Yahoo Finance (Morningstar GECS — 11 sectors / 145
+  industries) returns the *same* sector and industry strings for `.JK` tickers as for US tickers. Empirically verified:
+  **319/320 sampled tickers resolved a sector (99.7%)**, with the single miss being a delisted/suspended name.
+  Cross-market comparability on one sector axis is therefore **achievable**, not aspirational.
+- **IDX-IC is effectively not obtainable in bulk by a nightly job.** `idx.co.id` is behind Cloudflare bot
+  protection and returns HTTP 403 to plain HTTP clients — including `robots.txt`. Verified below.
+- **GICS is licensed and cannot be used.** S&P DJI / MSCI's own disclaimer explicitly forbids reproduction,
+  redissemination, and derivative works (including databases and analytics) without written permission.
+- **SIC via SEC is free, bulk, and legally clean — but US-only and coarse.** Verified working.
+- **Theme layer**: several free options exist for US. For **IDX there is essentially no free theme layer** —
+  no thematic ETFs exist on IDX, and the offshore thematic ETFs that would proxy one hold almost no IDX names.
+  Only LLM-tagging of company descriptions or hand-curation is viable for IDX themes. Flag as scope risk.
+
+---
+
+## 1. What each source actually is (primary sources)
+
+### 1.1 IDX-IC — the exchange's own taxonomy
+
+IDX's own press release states: *"Starting from January 25, 2021, IDX implements the new classification sector and
+industry of IDX listed company called 'Indonesia Stock Exchange Industrial Classification' or IDX-IC."*
+([IDX press release 1456](https://www.idx.co.id/en/news/press-release/1456), via search index — see §1.1.1 on
+direct-fetch failure.)
+
+The same IDX source states the classification basis: *"The determination of sectors, subsectors, industries or
+sub-industries are based on the market exposure of the company"*, and notably: *"IDX have rights to determine listed
+companies' classification based on IDX evaluation and justification."* That last clause matters — IDX-IC assignment is
+discretionary exchange judgment, not a reproducible rule you could re-derive from filings.
+
+Structure: **4 levels — 12 sectors, 35 sub-sectors, 69 industries, 130 sub-industries.**
+
+> ⚠️ **The ticket says 11 sectors; the correct figure is 12.** The 12th is the *Listed Investment Products* sector
+> (ETFs, REITs/DIRE, and other listed investment vehicles), which is not an operating-company sector. For an equity
+> screener the operating universe is the other 11 — so the ticket's "11" is right in spirit but wrong on the raw count.
+> **Partially unverified**: the 12/35/69/130 counts come from Indonesian secondary write-ups
+> ([InvestasiKu](https://www.investasiku.id/eduvest/investasi/klasifikasi-idx-ic)), not from an IDX-hosted document I
+> could open — see §1.1.1. IDX's own canonical PDF is
+> [`gopublic.idx.co.id/media/1404/daftar-sektor_web-go-public_en.pdf`](https://gopublic.idx.co.id/media/1404/daftar-sektor_web-go-public_en.pdf),
+> which is indexed by search engines but 403s on fetch.
+
+IDX also publishes **monthly trading statistics broken down by IDX-IC classification**
+(`idx.co.id/en/market-data/statistical-reports/digital-statistic/monthly/equity-trading-by-industry/trading-summary-by-industry-classification`) —
+useful in principle for sector rotation, but on the same blocked host.
+
+#### 1.1.1 Empirical: idx.co.id is not machine-accessible
+
+Tested 2026-08-04 from this machine, `curl` with a full Chrome UA + browser headers (`Accept`, `Accept-Language`,
+`Sec-Fetch-*`, `Upgrade-Insecure-Requests`, `--compressed`):
+
+| URL | Result |
+|---|---|
+| `https://www.idx.co.id/en/listed-companies/idx-industrial-classification/` | **403** — Cloudflare "Attention Required!" interstitial |
+| `https://www.idx.co.id/robots.txt` | **403** — even robots.txt is blocked |
+| `https://idx.co.id/` | **403** |
+| `https://www.idx.co.id/primary/StockData/GetSecuritiesStock?...` (JSON API) | **403** |
+| `https://www.idx.co.id/primary/ListedCompany/GetCompanyProfiles?...` (JSON API) | **403** |
+| `https://gopublic.idx.co.id/media/1404/daftar-sektor_web-go-public_en.pdf` | **403** |
+| Text-extraction proxy (`r.jina.ai`) over the same page | Returns *"Performing security verification … may require CAPTCHA"* |
+
+WebFetch (a different egress IP) also returned 403 on all of the above. So this is not one blocked IP — `idx.co.id`
+serves a Cloudflare challenge to non-browser clients generally.
+
+**Implication for the build:** a nightly Python job cannot rely on scraping `idx.co.id`. Getting IDX-IC in bulk would
+require a headless browser that solves the JS challenge (fragile, arguably against the site's intent, and a hosting
+cost on a free tier), or a manual periodic download by a human. **IDX-IC is realistically a hand-curated, occasionally
+refreshed static file, not a live feed.**
+
+#### 1.1.2 Third-party API that does expose IDX-IC: sectors.app
+
+[Sectors (Supertype Pte Ltd)](https://sectors.app/) exposes the full IDX-IC hierarchy over a REST API. Its
+[Companies Screener docs](https://docs.sectors.app/api-references/v2/indonesia/screener/companies) list direct fields:
+`sector` ("IDX sector classification"), `sub_sector`, `industry` ("IDX industry classification"), `sub_industry`, plus
+helper endpoints (`/v2/subsectors/`, `/v2/industries/`, `/v2/subindustries/`) that enumerate every sector/subsector,
+industry, and sub-industry pair as kebab-case slugs. Verified: `https://api.sectors.app/v2/companies/` requires an
+`Authorization: <api-key>` header; v1 was discontinued 2026-05-11 (endpoint returns HTTP 410 with a migration notice —
+confirmed by direct request).
+
+**Unverified / likely blocking:** I could not load `sectors.app/api` (Vercel bot checkpoint, HTTP 429), so I could not
+confirm pricing. A search-index snippet of their docs says *"API access requires an Insider plan account"*, which
+suggests **paid**. Under the free-sources-only constraint this probably disqualifies it. Someone should open
+`https://sectors.app/api` in a browser and check for a free tier before writing it off entirely.
+
+### 1.2 GICS — confirmed unusable
+
+Owned jointly by S&P Dow Jones Indices and MSCI. Structure: **11 sectors, 25 industry groups, 74 industries,
+163 sub-industries** (current structure effective after close 2023-03-17).
+
+The licensing position is unambiguous in S&P DJI/MSCI's own words. From the joint press release
+[`GICS_Press_Release_31_March_2022.pdf`](https://www.msci.com/documents/1296102/29559863/GICS_Press_Release_31_March_2022.pdf/f0ac4118-d6c3-4456-3c7b-2b0174099e4e?t=1648760411652)
+(text extracted from the PDF directly):
+
+> "All of the information contained herein … is the property of MSCI, S&P Dow Jones Indices, or their respective
+> affiliates. **The Information may not be reproduced or redisseminated in whole or in part without prior written
+> permission from MSCI and S&P Dow Jones Indices.**"
+>
+> "**The Information may not be used to create derivative works** or to verify or correct other data or information.
+> For example (but without limitation), the Information **may not be used to create indices, databases, risk models,
+> analytics, software**, or in connection with the issuing, offering, sponsoring, managing or marketing of any
+> securities, portfolios, financial products or other investment vehicles utilizing or based on, linked to, tracking or
+> otherwise derived from the Information."
+
+The 2026 consultation press release
+([S&P Global, 2026-07-17](https://press.spglobal.com/2026-07-17-S-P-DOW-JONES-INDICES-AND-MSCI-ANNOUNCE-CONSULTATION-ON-POTENTIAL-CHANGES-TO-THE-GLOBAL-INDUSTRY-CLASSIFICATION-STANDARD-GICS-R))
+carries the identical disclaimer and adds: *"'Global Industry Classification Standard (GICS)' is a service mark of MSCI
+and S&P."*
+
+**Verdict: GICS is out.** Building a sector database keyed to GICS labels is *exactly* the "create … databases,
+analytics" derivative-work case the disclaimer names. Note also: `spglobal.com` and `msci.com` both bot-block
+(HTTP 403 / "Challenge Validation"), so even reading the methodology is friction.
+
+*Corollary risk:* Wikipedia's S&P 500 constituents table carries GICS sector/sub-industry columns and is a commonly
+used free shortcut. That data is GICS regardless of where it's copied from — treat it as licensed, not free.
+
+### 1.3 Yahoo Finance / Morningstar GECS
+
+Yahoo Finance's own [sectors page](https://finance.yahoo.com/sectors/) states plainly: **"Sectors: 11", "Industries: 145"**,
+and lists them: Technology, Financial Services, Industrials, Consumer Cyclical, Communication Services, Healthcare,
+Energy, Consumer Defensive, Basic Materials, Real Estate, Utilities.
+
+Those numbers and names are Morningstar's **Global Equity Classification Structure (GECS)**: a hierarchical four-tier
+taxonomy of 145 industries → 55 industry groups → 11 sectors → 3 super sectors, where each security is mapped to the
+industry reflecting its largest source of revenue and income. (Yahoo does not name Morningstar on the sectors page; the
+1:1 match on counts, sector names, and industry names is what identifies it. **Mildly unverified** — I could not open
+Morningstar's own GECS page directly. This matters only for provenance, not for usability.)
+
+**Licensing status: unverified and worth a moment's thought.** Yahoo Finance has no public API and no published terms
+permitting bulk redistribution; `yfinance` scrapes undocumented endpoints. For a single-user private dashboard this is
+the same posture as every other free-data hobby project, but it is not a *licensed* free source the way SEC data is.
+
+### 1.4 SEC SIC codes — free, bulk, legally clean, US-only
+
+Verified working 2026-08-04 with the SEC-required descriptive User-Agent:
+
+| Endpoint | Result |
+|---|---|
+| `https://www.sec.gov/search-filings/standard-industrial-classification-sic-code-list` | **200** — HTML table, **444 SIC codes** parsed, columns `SIC Code / Office / Industry Title` (e.g. `100 / Industrial Applications and Services / AGRICULTURAL PRODUCTION-CROPS`) |
+| `https://data.sec.gov/submissions/CIK0000320193.json` | **200** — returns `{'sic': '3571', 'sicDescription': 'Electronic Computers', 'tickers': ['AAPL'], 'exchanges': ['Nasdaq']}` |
+| `https://www.sec.gov/files/company_tickers.json` | **200** — 798 KB, full ticker↔CIK map |
+
+So the full US ticker→SIC join is buildable from first-party SEC data with zero licensing questions. Caveats:
+
+- **US-only.** IDX issuers do not file with the SEC.
+- **Coarse and dated.** SIC is a 1987-vintage taxonomy. It has no "Semiconductors vs. Software" nuance matching how
+  momentum sectors actually rotate, and no concept of Communication Services.
+- **Self-reported and stale.** The SIC on a filing is what the registrant selected; it is frequently wrong for
+  companies that pivoted.
+- **Per-CIK API calls.** `company_tickers.json` has no SIC; only `data.sec.gov/submissions/CIK*.json` does, one CIK per
+  request. For a bulk join, the quarterly [Financial Statement Data Sets](https://www.sec.gov/data-research/sec-markets-data/financial-statement-data-sets)
+  `sub.txt` carries SIC per filer in one download (**unverified** — I did not download and parse one).
+
+**Best role for SIC**: a licensing-clean *cross-check* on Yahoo's US sectors, and a fallback for US names Yahoo misses.
+Not a primary sector axis.
+
+### 1.5 Stockbit
+
+The ticket names Stockbit. It is a retail broker/social app with no public API and terms that do not contemplate
+scraping. **Not investigated further** — treated as unavailable.
+
+---
+
+## 2. Empirical verification: what a free source actually returns
+
+Method: temp venv under `$CLAUDE_JOB_DIR/tmp` (nothing installed into the project), `yfinance` latest, calling
+`Ticker(t).info` and reading `sector`, `industry`, `longBusinessSummary`. Four samples.
+
+### 2.1 Coverage
+
+| Sample | n | sector present | industry present | business summary >50 chars |
+|---|---:|---:|---:|---:|
+| IDX liquid/large-cap (hand-picked, `.JK`) | 100 | 99 (99%) | 99 | 99 |
+| US liquid/large + thematic names | 100 | 99 (99%) | 99 | 99 |
+| IDX random sample from the small-cap half of the exchange | 60 | **60 (100%)** | — | 60 |
+| US random sample from the small-cap half | 60 | **60 (100%)** | — | 60 |
+| **Total** | **320** | **319 (99.7%)** | | |
+
+The two misses were `SRIL.JK` (Sri Rejeki Isman — suspended/insolvent) and `X` (US Steel — acquired/delisted).
+**Missing sector is a delisting signal, not a coverage gap.** For a screener that already filters on liquidity and
+recent price history, these names are excluded upstream anyway.
+
+The small-cap samples were drawn from the exchange-wide list, so this is not a large-cap-only result — the tail is
+covered as well as the head.
+
+### 2.2 Universe enumeration
+
+`yfinance.screen(EquityQuery("eq", ["region", "id"]))` returns a total of **840** IDX-listed instruments; `region=us`
+returns **19,940**. So Yahoo can also enumerate the universe, not just annotate known tickers.
+
+⚠️ **The screener payload does NOT carry sector/industry.** I dumped the full key set of 840 IDX and 1,250 US quote
+records: `sector`, `industry`, `sectorDisp`, `industryDisp` were present in **0%** of them. Sector must be fetched
+per-ticker from `Ticker().info` (the `quoteSummary`/`assetProfile` module). That's one HTTP request per symbol.
+
+Also note **840 < the ~950 companies listed on IDX** — Yahoo's Indonesian universe is not complete. Worth a
+reconciliation against a ticker list from elsewhere before treating 840 as the universe.
+
+### 2.3 Rate limiting — the real operational constraint
+
+This bit at me during testing and will bite the nightly job. After roughly 200 `.info` calls plus ~6 screener pages in a
+few minutes, **every subsequent `.info` call raised `YFRateLimitError: Too Many Requests`** — for about 5 minutes,
+including for `AAPL`. A naive 90-ticker sample came back "0% sector coverage" purely from throttling; the same sample
+with a 2-second delay and 30s-backoff retries came back **100%**.
+
+**This is the single most important operational finding for the sector layer.** Any spec must assume:
+
+- ~1–2 s between per-ticker `.info` calls, with exponential backoff on 429.
+- 840 IDX + a liquidity-filtered US universe (say 2,000–4,000) → **1–2 hours of wall clock** for a full refresh.
+- Therefore: sector must be **cached persistently and refreshed incrementally** (new listings + a slow rolling
+  re-check), never re-fetched wholesale nightly. Sector assignment changes on the order of months, not days — this is
+  fine, but it must be designed in from the start rather than discovered in production.
+- The rate-limit error surfaces as *empty data*, not an exception, if you swallow it. Any implementation must
+  distinguish "no sector" from "throttled" or it will silently write nulls over good data.
+
+### 2.4 Accuracy spot-check on IDX
+
+Yahoo/Morningstar applies its global taxonomy to Indonesian names, and mostly sensibly:
+
+| Ticker | Yahoo sector | Yahoo industry | Comment |
+|---|---|---|---|
+| `ADRO.JK`, `PTBA.JK`, `AADI.JK`, `CUAN.JK` | Energy | Thermal Coal | Correct and useful — coal is the dominant IDX momentum complex |
+| `ANTM.JK`, `INCO.JK`, `NCKL.JK`, `MDKA.JK` | Basic Materials | Other Industrial Metals & Mining | Correct sector; **nickel is not separable at industry level** |
+| `BREN.JK`, `PGEO.JK` | Utilities | Utilities - Renewable | Reasonable |
+| `PGAS.JK`, `RAJA.JK` | Utilities | Utilities - Regulated Gas | Reasonable |
+| `BBCA.JK`, `ARTO.JK` | Financial Services | Banks - Regional/Diversified | Correct |
+| `JSMR.JK` | Industrials | Infrastructure Operations | Toll roads |
+| `TOWR.JK` | Real Estate | Real Estate Services | **Questionable** — tower operator classed as real estate |
+| `GOTO.JK` | Technology | Software - Infrastructure | **Questionable** — ride-hailing/e-commerce as infra software |
+
+Two structural divergences to be aware of, and they cut in favor of using Yahoo rather than IDX-IC:
+
+- **IDX-IC has an "Infrastructures" sector** that absorbs telecoms, toll roads, and utilities. Yahoo splits these across
+  Communication Services / Industrials / Utilities. Yahoo's split is the one that matches how a US-comparable rotation
+  view would read.
+- **IDX-IC has a separate "Transportation & Logistics" sector**; Yahoo folds shipping/airlines into Industrials.
+
+So IDX-IC and GICS/Morningstar are **not 1:1 mappable at sector level** — a hand-built crosswalk would have to split
+IDX-IC's Infrastructures sector across three Morningstar sectors on a per-company basis. That's real work for no gain
+when Yahoo already emits the Morningstar label directly.
+
+### 2.5 Industry granularity actually observed
+
+Across the two 100-name samples: **47 distinct industries in the US sample, 43 in the IDX sample**, out of Yahoo's 145.
+Both markets land on the same vocabulary (`Gold`, `Specialty Chemicals`, `Advertising Agencies`, `Diagnostics &
+Research`, `Beverages - Non-Alcoholic` all appear in both lists). US-only industries in the sample include `Uranium`,
+`Semiconductors`, `Solar`, `Biotechnology`; IDX-only include `Thermal Coal`, `Marine Shipping`, `Farm Products`. That
+asymmetry is real economic structure, not a data defect.
+
+---
+
+## 3. Cross-market comparability verdict
+
+**One sector axis is viable, using Yahoo/Morningstar's 11 sectors for both markets.** Evidence:
+
+1. Identical taxonomy applied to both markets — same 11 sector strings, same 145-industry vocabulary.
+2. ~100% coverage on both, across the whole market-cap range.
+3. No mapping table to build, no mapping errors to maintain, no licensing exposure to GICS.
+
+**But** three caveats belong in the sector model ticket:
+
+- **Sector composition differs radically by market.** In the (non-random, momentum-leaning) 100-name samples:
+  Technology was 27% of the US sample and 1% of the IDX sample; Consumer Defensive was 18% of IDX vs 7% of US; Real
+  Estate was 7% of IDX and 0% of the US sample. Consequence: **cross-market sector *strength* comparisons are close to
+  meaningless.** "Technology is leading" on IDX is a statement about one or two stocks. Sector rotation should be
+  computed **per market** and *displayed* on a shared axis — not pooled into one cross-market ranking. This is
+  consistent with the map's existing "top decile is ranked per market" decision.
+- **Small IDX sectors will be statistically noisy.** Some Morningstar sectors have a handful of IDX constituents.
+  Whatever the rotation metric is, it needs a minimum-constituent floor or those sectors will dominate the leaderboard
+  on single-stock moves.
+- **Yahoo's IDX universe (840) is incomplete** vs. ~950 listed. Names missing from Yahoo are missing from the sector
+  layer entirely.
+
+**If IDX-IC is wanted anyway** (for a natively-Indonesian view a local user recognizes), the realistic shape is a
+hand-maintained static CSV refreshed manually every few months, kept as a *secondary* label alongside the Yahoo sector —
+not as the primary rotation axis, and not fetched nightly.
+
+---
+
+## 4. Theme layer — option survey (scouting, not choosing)
+
+None of "AI", "nickel downstream", "GLP-1", "uranium" exist in any standard taxonomy. Yahoo's `Uranium` industry is the
+one lucky exception. Everything below is a way of manufacturing a theme layer.
+
+### Option A — Thematic ETF holdings as a proxy (US only)
+
+Treat "the holdings of ARKQ" as the definition of the robotics theme, etc.
+
+**Empirically tested 2026-08-04:**
+
+| Issuer | Endpoint | Result |
+|---|---|---|
+| ARK | `https://assets.ark-funds.com/fund-documents/funds-etf-csv/ARK_INNOVATION_ETF_ARKK_HOLDINGS.csv` | ✅ **200, plain CSV, same-day data** (`date,fund,company,ticker,cusip,shares,market value ($),weight (%)` — first row dated `08/04/2026`). No auth, no headers needed. |
+| ARK (other funds) | guessed ARKQ/ARKG filenames | ❌ 404 — exact filenames must be discovered per fund, not constructed |
+| State Street SPDR | `.../holdings-daily-us-en-xlk.xlsx` | ✅ **200, real XLSX, 22 KB** |
+| iShares | `.../1467271812596.ajax?fileType=csv&fileName=IRBO_holdings&dataType=fund` | ⚠️ **200 but returns HTML** — a region-selection interstitial, not CSV. `Content-Type` lies (`text/csv`). Needs a cookie/JS step. |
+| Global X | `https://www.globalxetfs.com/funds/lit/?download_full_holdings=true` | ⚠️ **200 but returns the SPA HTML shell** — JS-rendered |
+| VanEck | `https://www.vaneck.com/api/us/fundholdings/csv/?ticker=SMH` | ⚠️ **302 redirect, 0 bytes** |
+
+**Cost:** free. **Freshness:** daily, same-day for the issuers that work. **Maintenance:** *per-issuer bespoke and
+brittle* — three of six issuers tested need cookie/JS handling, and even ARK requires knowing exact filenames. Every
+issuer redesign breaks one scraper independently. Also: the theme↔fund mapping is a human judgment you maintain
+(which fund *is* the AI theme?), and a fund's holdings drift with the manager's opinion, not with a stable definition.
+
+**Universal fallback:** SEC **Form N-PORT-P**. Confirmed present via EDGAR (`browse-edgar?type=NPORT-P&output=atom`
+returns "Monthly Portfolio Investments Report on Form N-PORT (Public)" filings). Legally clean, covers every registered
+fund, no scraping fragility. But it is **quarterly-published with up to a 60-day lag** — far too stale to define a
+tradeable theme, though fine as a backfill/repair source. (The quarterly ZIP URL pattern I guessed 404'd; the real
+location is under `sec.gov/data-research/sec-markets-data/form-n-port-data-sets` — **unverified**, that page 403'd on
+fetch.)
+
+### Option B — Curated public lists
+
+Wikipedia index-constituent tables, community-maintained GitHub theme lists, etc.
+
+**Cost:** free. **Freshness:** whatever a volunteer last did. **Maintenance:** you inherit someone else's staleness and
+have no SLA. **Licensing:** Wikipedia is CC BY-SA — usable with attribution, *except* where the content is itself GICS
+(the S&P 500 table's sector columns), which the CC license does not launder. **IDX applicability:** essentially none —
+no maintained public IDX theme lists found.
+
+### Option C — Correlation clustering
+
+Derive themes bottom-up: cluster the return series, name the clusters.
+
+**Cost:** free — needs only the price history you already have for the screen; no new data source and no new
+scraper. **Freshness:** as fresh as your bars. **Maintenance:** the code, plus a rerun cadence; no external
+dependency to break. **Works identically on IDX and US** — this is the *only* option in this list that does.
+
+Honest problems: clusters are unnamed and unstable (they change composition as correlations shift), they conflate
+"same theme" with "same beta/sector/market-cap bucket", and a human must still look at each cluster and decide it
+means "nickel downstream". Also needs a decent lookback, which the data-source ticket hasn't settled yet.
+
+### Option D — LLM tagging of company business descriptions
+
+Yahoo's `longBusinessSummary` is present for **>99% of both markets** in every sample above — so the *input* for this
+approach is already free, already fetched alongside sector, and already covers IDX.
+
+**Cost is small but nonzero, and it is a paid API — a real tension with the free-sources-only constraint.** Sizing:
+~840 IDX + a liquidity-filtered US universe (~2,000–4,000) ≈ 5,000 names; ~400 input tokens per description, ~60 output.
+That's ~2M input / 0.3M output tokens per full pass. At Claude Haiku 4.5 pricing ($1/MTok in, $5/MTok out) a full pass
+is **≈ $3.50**, or **≈ $1.75 via the Batch API** (50% discount, results within ~1 hour — a good fit for a nightly EOD
+job). Incremental refresh — only newly listed names and changed descriptions — would be cents per night.
+
+**Freshness:** business descriptions are updated on a filings cadence (quarterly-ish), so tags go stale slowly, which
+is fine for structural themes and *bad* for narrative themes ("AI" membership in 2026 is a market-narrative fact, not a
+10-K fact). **Maintenance:** you own the theme vocabulary and the prompt; adding a theme means one re-tag pass. Tags
+are non-deterministic run-to-run unless you pin and cache them.
+
+**This is the only option that plausibly produces IDX themes** ("nickel downstream", "coal", "digital bank") from data
+that actually exists for IDX today.
+
+### Is a free theme layer viable for IDX at all? — plainly
+
+**No, not from ETF holdings.** IDX has no thematic ETF layer to proxy from. The IDX ETF universe is index- and
+sector-tracking, not thematic: Premier ETF LQ-45 (`R-LQ45X`), Premier ETF IDX30 (`XIIT`), Premier ETF SRI-KEHATI
+(`XISR`, ESG), Premier ETF Indonesia Consumer (`XIIC`), Premier ETF Indonesia Financial (`XIIF`), Premier ETF Indonesia
+State-Owned Companies (`XISC`). OJK records 60+ active ETF products on IDX, but there is **no nickel ETF, no EV-battery
+ETF, no AI ETF**. And the offshore Indonesia ETF (iShares `EIDO`) is a broad country fund, not a theme fund.
+(Sources: [Reku](https://reku.id/en/campus/9-etf-indonesia-terbaik),
+[Yahoo XIIC](https://finance.yahoo.com/quote/XIIC.JK/), [iShares EIDO](https://www.ishares.com/us/products/239661/ishares-msci-indonesia-etf).
+Also **unverified**: Indonesian ETF issuers appear to publish holdings only as PDF fund fact sheets, not machine-readable files.)
+
+So for IDX, a v1 theme layer means **LLM tagging (Option D), correlation clustering (Option C), or hand-curation** —
+and hand-curation of a market this size is a real ongoing chore for a single-user app.
+
+**Scope-risk framing for the map:** a *US-only* theme layer is buildable for free at moderate maintenance cost. A
+*both-markets* theme layer at parity is not free-and-easy — it requires either accepting a paid LLM line item (small:
+single-digit dollars/month) or accepting hand-curation. Given the map's "both markets from day one" standing
+constraint, **theme parity across markets is the thing at risk, and it should be flagged as such rather than assumed.**
+
+---
+
+## 5. Summary table
+
+| Source | IDX | US | Bulk? | Free? | Cadence | Verdict |
+|---|---|---|---|---|---|---|
+| Yahoo / Morningstar GECS (11 sec / 145 ind) | ✅ 99–100% | ✅ 99–100% | Per-ticker only, rate-limited | ✅ (unlicensed scrape) | Cache + incremental | **Primary sector axis, both markets** |
+| IDX-IC (12 / 35 / 69 / 130) | ✅ native | ❌ | ❌ Cloudflare-blocked | ✅ | Manual only | Optional secondary label, static file |
+| sectors.app (IDX-IC via API) | ✅ | ❌ | ✅ | ❓ likely paid | API | Check pricing; probably out |
+| SEC SIC (444 codes) | ❌ | ✅ | ✅ | ✅ licensed-clean | Filing-driven | US cross-check / fallback |
+| GICS | — | — | — | ❌ **licensed** | — | **Excluded** |
+| Thematic ETF holdings | ❌ none exist | ✅ partial | Per-issuer | ✅ | Daily | US theme proxy, brittle |
+| SEC N-PORT-P | ❌ | ✅ | ✅ | ✅ | Quarterly, ~60d lag | Backfill only, too stale |
+| Correlation clustering | ✅ | ✅ | ✅ | ✅ | Any | Only both-market free theme option |
+| LLM tagging of descriptions | ✅ | ✅ | ✅ | ~$2–4/full pass | Any | Only both-market *named*-theme option |
+
+---
+
+## 6. Open questions for the sector-model ticket
+
+1. Does sectors.app have a free tier? (Blocked by bot protection here; needs a browser.) If yes, IDX-IC becomes
+   cheaply available and the calculus on a secondary IDX-native label changes.
+2. What reconciles Yahoo's 840 IDX instruments against ~950 listed? Which 110 are missing, and do any matter after
+   liquidity filtering?
+3. Is a paid-but-tiny LLM tagging line item acceptable against "free data sources only"? The constraint was written
+   about *market data feeds*; an LLM classification pass is arguably a different category. Worth an explicit ruling
+   rather than an assumption.
+4. What is the minimum constituent count for a sector to appear in the rotation view, given how thin some Morningstar
+   sectors are on IDX?

--- a/.scratch/screening-dashboard/research/04-hosting-and-scheduling.md
+++ b/.scratch/screening-dashboard/research/04-hosting-and-scheduling.md
@@ -1,0 +1,401 @@
+# Free-tier hosting and scheduling for a Python nightly job + TS frontend
+
+Research note for ticket `04-free-tier-hosting-and-scheduling.md`.
+
+**As-of date: 2026-08-04.** Every number below was read from the vendor's own docs/pricing page on this
+date. Free-tier terms change frequently — treat anything older than ~3 months as stale and re-verify
+before committing. Claims that could **not** be confirmed against a primary source are marked
+**[UNVERIFIED]**.
+
+---
+
+## 0. TL;DR
+
+1. **No hosted free-tier row store is big enough** for years of daily bars across thousands of symbols.
+   Neon 0.5 GB, Supabase 500 MB, Cloudflare D1 500 MB/database. The footprint estimate is ~2 GB in
+   Postgres for 10y × 7,000 symbols. This forces a **file-based columnar store (Parquet/DuckDB) on
+   object storage** for the bar history. Turso (5 GB) is the one hosted SQL exception, and it breaks on
+   *write quota* during backfill rather than on size.
+2. **Almost every serverless free tier's execution timeout is a hard blocker**: Netlify scheduled
+   functions 30 s, Supabase Edge Functions 150 s, Vercel Hobby functions 300 s, Cloudflare Workers free
+   10 ms *CPU*. Only **GitHub Actions (6 h/job)** and **Cloud Run Jobs (up to 168 h)** comfortably fit a
+   multi-minute nightly pull.
+3. **GitHub Actions is viable as the scheduler**, with two caveats that both have workarounds: cron
+   timing is explicitly best-effort (delays are documented, worst around the top of the hour), and
+   scheduled workflows in **public** repos auto-disable after 60 days of no repository activity. For an
+   EOD job, timing slop of tens of minutes is harmless.
+4. Recommended stack: **GitHub Actions (private repo) → Parquet/DuckDB in Cloudflare R2 → precomputed
+   JSON → static TS frontend on Vercel Hobby, protected by Vercel Authentication.** Cost $0. First
+   thing to break: the 2,000 Actions minutes/month private-repo budget.
+
+---
+
+## 1. The two hard blockers, measured
+
+### 1.1 Maximum execution time for a scheduled job, per free tier
+
+| Platform | Scheduled-job mechanism | Max execution time (free) | Python? | Source |
+|---|---|---|---|---|
+| **GitHub Actions** | `on: schedule` cron | **6 hours per job** (GitHub-hosted runners) | Yes, any | [Actions limits](https://docs.github.com/en/actions/reference/limits) |
+| **Google Cloud Run Jobs** | Cloud Scheduler → job | **168 hours (7 days)** max task timeout, 10 min default | Yes, any container | [Task timeout](https://docs.cloud.google.com/run/docs/configuring/task-timeout) |
+| **Render cron jobs** | Native cron service | 12 h, but **min $1/month per cron job service** — not free | Yes | [Render cron jobs](https://render.com/docs/cronjobs) |
+| **Vercel Hobby** | Vercel Cron → Function | **300 s** (Hobby default *and* maximum) | Yes (Python runtime) | [Function limits](https://vercel.com/docs/functions/limitations) |
+| **Supabase** | `pg_cron` → Edge Function | **150 s** wall clock (free), 2 s CPU, 256 MB | No — Deno/TS only | [Edge Function limits](https://supabase.com/docs/guides/functions/limits) |
+| **Netlify** | Scheduled functions | **30 s** ("Background functions are more appropriate for tasks that must run longer" — but background functions are *not* schedulable) | No — JS/TS, Go | [Scheduled functions](https://docs.netlify.com/build/functions/scheduled-functions/) |
+| **Cloudflare Workers (free)** | Cron Triggers | 15 min wall clock but **10 ms CPU per Cron Trigger invocation** | Python Workers = Pyodide, restricted packages | [Workers limits](https://developers.cloudflare.com/workers/platform/limits/) |
+| **Cloudflare Containers** | — | **No free tier** — "does not include any billable resources for vCPU, memory, or disk"; requires Workers Paid $5/mo | Yes | [Containers pricing](https://developers.cloudflare.com/containers/pricing/) |
+| **Fly.io** | Machines / `fly machine run` | **No free tier for new orgs.** "Fly.io no longer offers plans to new customers"; free allowances only grandfathered for pre-2024-10-07 Hobby/Launch/Scale orgs. Card required. | Yes | [Fly pricing](https://fly.io/docs/about/pricing/) |
+| **Railway** | Cron service | Free plan gives **$1/month usage credit**, 1 vCPU / 0.5 GB / 1 replica | Yes | [Railway pricing](https://railway.com/pricing), [plans](https://docs.railway.com/reference/pricing/plans) |
+
+**Verdict on the timeout blocker.** A nightly pull of thousands of symbols is network-bound and will
+plausibly take 5–30 minutes even with batched requests and concurrency. That rules out Netlify (30 s),
+Supabase Edge Functions (150 s), Cloudflare Workers free (10 ms CPU), and makes Vercel Hobby (300 s)
+uncomfortably marginal — you would have to shard the universe across multiple cron invocations, and
+Hobby crons are capped at **once per day each** (see §1.3), so sharding means N separate daily crons at
+fixed hours. Workable but fragile.
+
+GitHub Actions' 6-hour job budget makes the timeout question disappear entirely. That is the single
+biggest architectural fact in this ticket.
+
+**Railway free-plan cost model** (rates: $10/GB-RAM/month, $20/vCPU/month, $0.15/GB-month volume,
+$0.05/GB egress — [Railway pricing reference](https://docs.railway.com/reference/pricing)):
+a 15-min nightly job × 2 markets × 30 days = 900 min/month ≈ $0.42 CPU + $0.10 RAM ≈ **$0.52/month**,
+which does fit inside the $1 credit. But a 24/7 frontend service at 0.5 GB would cost ≈ $5/month —
+5× the credit. So Railway free can host *the job* or *nothing else*, and with essentially no headroom.
+
+### 1.2 GitHub Actions as scheduler — the specific risks
+
+Primary-source facts:
+
+- **Cron is best-effort.** "The `schedule` event can be delayed during periods of high loads of GitHub
+  Actions workflow runs. High load times include the start of every hour."
+  ([Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows))
+- **Finest granularity is 5 minutes.** "The shortest interval you can run scheduled workflows is once
+  every 5 minutes." (same source)
+- **Public repos auto-disable after 60 days.** "In a public repository, scheduled workflows are
+  automatically disabled when no repository activity has occurred in 60 days."
+  ([Disable and enable workflows](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/disable-and-enable-workflows))
+  Note the doc scopes this to **public** repositories; nothing equivalent is stated for private ones.
+- **Scheduled workflows only run on the default branch**, on its latest commit.
+- **Minutes:** public repos on standard GitHub-hosted runners are **free**: "GitHub Actions usage is
+  free for self-hosted runners and for public repositories that use standard GitHub-hosted runners."
+  Private repos on the Free plan get **2,000 minutes/month**, 500 MB artifact storage, 10 GB cache/repo.
+  ([Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions))
+- **Concurrency:** 20 concurrent jobs on Free.
+
+**[UNVERIFIED]** Whether a commit pushed *by the workflow itself* (using `GITHUB_TOKEN`) counts as
+"repository activity" for the 60-day timer is not stated in GitHub's docs. Community reports suggest
+bot-authored commits may not reset it. Do not rely on the nightly data commit to keep a public repo's
+schedule alive; either use a private repo, or add a monthly human commit / `workflow_dispatch` ping.
+
+**Is this viable?** Yes, for an EOD screener. The failure mode of cron slop is "the leaderboard is ready
+at 22:40 UTC instead of 22:05 UTC", which is irrelevant for a once-a-day user. Mitigations:
+
+- Schedule at an odd minute well away from `:00` (e.g. `17 22 * * 1-5`) to dodge the documented
+  top-of-hour load spike.
+- Make the job idempotent and add a `workflow_dispatch` trigger so a missed/failed run can be replayed.
+- Have the job assert "did yesterday's bars land?" and self-heal by backfilling gaps, so a skipped run
+  costs nothing.
+- Prefer a **private** repo: it sidesteps the 60-day disable rule entirely, at the cost of the 2,000
+  min/month budget.
+
+### 1.3 Two market calendars
+
+- **GitHub Actions**: a workflow may declare multiple `schedule` entries, or you can use two workflow
+  files. There is no quota on *number of schedules* — only on minutes consumed, so two runs/day
+  doubles minute usage but not any other limit. IDX close 16:00 WIB = 09:00 UTC; US close 16:00 ET =
+  20:00 UTC (21:00 UTC during EST). Give each a couple of hours of settle time.
+- **Vercel Hobby**: 100 cron jobs per project, but **"Hobby accounts are limited to cron jobs that run
+  once per day"** and scheduling precision is **per-hour (±59 min)** — "a cron job configured as
+  `0 1 * * *` will trigger anywhere between 1:00 am and 1:59 am."
+  ([Cron usage & pricing](https://vercel.com/docs/cron-jobs/usage-and-pricing)). Two daily crons is
+  fine; ±59 min is fine for EOD.
+- **Cloudflare Workers**: max **5 Cron Triggers per account** on free. Two is fine.
+- **Cloud Scheduler**: **3 jobs/month free per billing account**, $0.10/job/month after.
+  ([Cloud Scheduler pricing](https://cloud.google.com/scheduler/pricing)). Two is fine; the third is
+  your headroom.
+- **Supabase Cron (pg_cron)**: jobs "can run anywhere from every second to once a year"; guidance is
+  "Each Job should run no more than 10 minutes" and "no more than 8 Jobs run concurrently".
+  ([Supabase Cron](https://supabase.com/docs/guides/cron)). **[UNVERIFIED]** the Supabase pricing page
+  does not state Cron plan availability; the extension is Postgres-level so it is expected to work on
+  Free, but confirm before depending on it.
+
+Nothing about two calendars doubles a *quota* except compute minutes.
+
+---
+
+## 2. Persistence: footprint vs. free caps
+
+### 2.1 The footprint estimate
+
+Assumptions (adjust once the data-source ticket lands):
+
+- US tradeable universe after liquidity filtering: ~3,000–6,000 symbols. Full listed universe incl.
+  ETFs is larger (~8,000+ tickers).
+- IDX: ~950 listed companies.
+- Worst case combined: **~7,000 symbols**.
+- 252 trading days/year.
+
+| History | Rows (7,000 symbols) |
+|---|---|
+| 5 years | ~8.8 M |
+| 10 years | ~17.6 M |
+| 20 years | ~35 M |
+
+Per-row on-disk cost (OHLCV + volume + symbol + date), engineer's estimates:
+
+| Format | Bytes/row (incl. index) | 10y × 7,000 symbols |
+|---|---|---|
+| PostgreSQL heap + PK btree | ~110–130 | **~2.0–2.3 GB** |
+| SQLite / libSQL (D1, Turso) | ~45–60 | **~0.8–1.1 GB** |
+| Parquet (zstd, dictionary + delta) | ~8–20 | **~150–350 MB** |
+
+These are my calculations from format overheads, not vendor figures — **[UNVERIFIED]**, but the
+order-of-magnitude conclusion is robust: Postgres is ~5–10× larger than Parquet for this shape of data.
+
+### 2.2 Free storage caps
+
+| Store | Free cap | Verdict for full bar history | Source |
+|---|---|---|---|
+| **Cloudflare R2** | **10 GB-month storage, 1 M Class A ops, 10 M Class B ops, egress free** | ✅ 30× headroom for Parquet. Zero egress fees is the standout. | [R2 pricing](https://developers.cloudflare.com/r2/pricing/) |
+| **GitHub Releases** | 2 GiB per file; **"There is no limit on the total size of a release, nor bandwidth usage"**; 1,000 assets/release | ✅ Effectively unlimited free object store. | [About releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases) |
+| **Turso** | **5 GB storage**, 100 databases, **500 M rows read/mo**, **10 M rows written/mo**, 3 GB syncs | ⚠️ Size fits; **write quota does not** — a 17.6 M-row backfill exceeds a month's writes in one shot. | [Turso pricing](https://turso.tech/pricing) |
+| **Cloudflare D1** | **500 MB per database**, 5 GB per account, 10 DBs, 50 queries/invocation, 30 s query timeout | ❌ 500 MB/DB ≈ 5–6 years at best; would require manual sharding across 10 DBs. | [D1 limits](https://developers.cloudflare.com/d1/platform/limits/) |
+| **Neon** | **0.5 GB/project**, 100 CU-hours/project/mo, 5 GB egress, autosuspend after 5 min (**"cannot disable"** on Free) | ❌ ~1.5–2 years of the full universe. Writes fail when over cap. | [Neon plans](https://neon.com/docs/introduction/plans), [pricing](https://neon.com/pricing) |
+| **Supabase** | **500 MB database**, 1 GB file storage, 5 GB egress, 2 active projects, **"Free projects are paused after 1 week of inactivity"** | ❌ Same as Neon. File storage 1 GB is also thin for Parquet. | [Supabase pricing](https://supabase.com/pricing) |
+| **Google Cloud Storage** | Always Free: **5 GB-months regional (US only)**, 5,000 Class A, 50,000 Class B, 100 GB egress from NA | ✅ for Parquet; needs a billing account. | [GCP Free Tier](https://docs.cloud.google.com/free/docs/free-cloud-features) |
+| **Git repo (files in-tree)** | 100 MiB hard block per file; **"repositories remain small, ideally less than 1 GB, and less than 5 GB is strongly recommended"** | ⚠️ Only for small precomputed artifacts, never the full history — and daily commits of a binary blob balloon git history. | [Large files](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github) |
+| **Actions artifacts** | 500 MB on Free plan | ❌ Too small, and artifacts expire. | [Actions limits](https://docs.github.com/en/actions/reference/limits) |
+| **Render free Postgres** | 1 GB, **"expire 30 days after creation"**, 14-day grace then deleted | ❌ Self-destructs monthly. | [Render free](https://render.com/docs/free) |
+| **Plain SQLite on disk** | Render free has **no persistent disks**; Fly volumes are $0.15/GB-mo (no free tier for new orgs); Railway free volume 0.5 GB | ❌ as a *server-attached* disk. ✅ as a **SQLite/DuckDB file pulled from object storage at job start and pushed back at job end**. | [Render free](https://render.com/docs/free), [Fly pricing](https://fly.io/docs/about/pricing/) |
+
+**Answer to the ticket's question: yes, storage forces a file-based store.** No free hosted row store
+holds 10 years × 7,000 symbols. The sane shape is:
+
+- **Bars → Parquet (partitioned by market/year) in R2**, read by the nightly job with DuckDB/Polars.
+- **Precomputed outputs → small JSON/Parquet artifacts** (leaderboards, star scores, sector rotation,
+  chart series for the ~100–300 surfaced candidates). This is a few MB, servable statically.
+- **App state (watchlist, marked names, run metadata) → tiny SQL DB**, where 500 MB is absurdly
+  generous. Turso, D1, Neon, or Supabase all work here. Or just a JSON blob in R2.
+
+The crucial design move: **the frontend never queries the bar history.** It reads precomputed
+artifacts. That removes the need for a queryable hosted DB over 17 M rows, which is exactly the thing
+no free tier provides.
+
+Rough artifact sizing: 300 candidates × 250 daily bars × ~40 bytes of JSON ≈ **3 MB**. Trivially inside
+Vercel's 100 GB Fast Data Transfer or Netlify's 100 GB bandwidth.
+
+---
+
+## 3. Python + TS on one platform, or split?
+
+Nothing free hosts both well:
+
+- **Vercel** has a Python runtime for Functions, so a single repo *could* hold both — but the 300 s cap
+  and Hobby's once-per-day cron make the nightly job awkward, and Hobby is **non-commercial only**:
+  "the Hobby plan restricts users to non-commercial, personal use only"
+  ([Hobby plan](https://vercel.com/docs/plans/hobby)). A personal trading screener is fine; a paid
+  product is not.
+- **Netlify** functions are JS/TS and Go — **no Python at all**. Netlify is a frontend host only here.
+- **Cloudflare** Python Workers are **open beta**, Pyodide-based: "Python Workers support pure and
+  PyEmscripten Python packages on PyPI" plus Pyodide-bundled packages; you **cannot install arbitrary
+  PyPI packages**, and only async HTTP clients (aiohttp/httpx) work
+  ([Python Workers](https://developers.cloudflare.com/workers/languages/python/),
+  [packages](https://developers.cloudflare.com/workers/languages/python/packages/)). Combined with the
+  10 ms free CPU cap, Cloudflare is a **storage + edge + auth** layer on free, not a Python runner.
+- **Hugging Face Spaces** — previously a common free Python host — is now out: "Gradio and Docker
+  Spaces run on compute and **require a paid plan** to create"; only Static Spaces are free.
+  ([Spaces overview](https://huggingface.co/docs/hub/spaces-overview))
+
+**So a split deploy is unavoidable.** The complexity cost is small if you split along the artifact
+boundary: the Python job's only contract with the frontend is "write these JSON/Parquet files to this
+bucket with this schema". No shared runtime, no RPC, no CORS-authenticated DB from the browser. Version
+the artifact schema and stamp each with a `generated_at` and `schema_version`.
+
+---
+
+## 4. Cold starts, sleeping, eviction
+
+For a once-a-day user, sleeping is nearly a non-issue — but eviction is not.
+
+| Platform | Behaviour | Matters? |
+|---|---|---|
+| Render free web service | Spins down after **"15 minutes without receiving any inbound traffic"**, **"about one minute"** to spin back up; 750 free instance hours/month/workspace | One-minute wait once a day. Annoying but survivable. |
+| Neon free | Autosuspend **after 5 min**, "Always on for Free", cannot disable. Data is not deleted. | Sub-second-to-seconds resume. Fine. |
+| Supabase free | **Projects paused after 1 week of inactivity**; 2 active projects | Fine while the nightly job touches it daily; a 2-week holiday pauses it. |
+| Render free Postgres | **Deleted 30 days after creation** (+14-day grace) | **Disqualifying.** |
+| Vercel Hobby | Static assets on CDN; functions cold-start | Negligible. |
+| Cloudflare Pages/Workers/R2 | No sleep concept | Negligible. |
+| GitHub Actions (public repo) | Schedule disabled after **60 days** no repo activity | Real risk — see §1.2. |
+| Fly.io | Machines auto-stop/suspend to save cost — but there is no free tier to save into | N/A. |
+
+**Static-first frontends (Vercel/Cloudflare Pages/Netlify) have no sleep problem at all**, which is
+another argument for the precomputed-artifact architecture.
+
+---
+
+## 5. Auth — cheapest way to keep a public URL private for one user
+
+| Option | Cost | Notes |
+|---|---|---|
+| **Vercel Authentication** (deployment protection) | **Free on Hobby** | Listed under Deployment Protection for Hobby: "Vercel Authentication". Password Protection is a **Pro add-on**. Requires you to be logged into the Vercel account that owns the project. Zero code. ([Hobby plan](https://vercel.com/docs/plans/hobby)) |
+| **Cloudflare Access** (Zero Trust) | Free plan exists; **[UNVERIFIED]** the widely-cited 50-seat free cap is not restated on any current `developers.cloudflare.com` page I could find — only in Cloudflare blog/community posts. Docs confirm a "Zero Trust Free plan" exists and that Access covers "SaaS, self-hosted, and non-HTTP applications" with One-time PIN login. ([Cloudflare One setup](https://developers.cloudflare.com/cloudflare-one/setup/), [Access policies](https://developers.cloudflare.com/cloudflare-one/policies/access/)) | Works in front of *any* origin proxied through Cloudflare, including Pages and a Worker API. One-time-PIN to your email, or Google/GitHub IdP. The most portable option. |
+| **Netlify password protection** | **Paid** | Not on Free. |
+| **GitHub Pages private sites** | Enterprise only | Out. |
+| **Roll your own** (signed cookie / shared secret in Worker or Next middleware) | Free | ~30 lines. Adequate for one user, but you own the security. Use for the API layer if Access/Vercel Auth already covers the UI. |
+
+Recommendation: **Vercel Authentication** if the frontend is on Vercel (zero effort), **Cloudflare
+Access** if anything is on Cloudflare or you want one gate across multiple origins. Do not put secrets
+in the frontend; the R2 bucket should either be private (proxied through an authenticated route) or
+hold only non-sensitive derived data.
+
+---
+
+## 6. Three end-to-end stacks
+
+### Stack A — Actions + R2 + Vercel  *(recommended)*
+
+| Layer | Choice | Free-tier headroom |
+|---|---|---|
+| Job runner | **GitHub Actions**, private repo, `ubuntu-latest` | 6 h/job cap (never binding); 2,000 min/mo |
+| Scheduler | Two `schedule` crons in one workflow (IDX ~11:00 UTC, US ~22:00 UTC), off-the-hour minutes, plus `workflow_dispatch` | No quota on schedule count |
+| Bar store | **Cloudflare R2**, Parquet partitioned by market/year; job pulls with DuckDB/Polars, writes back | 10 GB free vs ~300 MB used; egress free |
+| Output artifacts | Small JSON (leaderboards, scores, chart series) written to R2 or committed to repo | few MB |
+| App state | JSON blob in R2, or Turso if you want SQL | trivial |
+| Frontend | **Next.js/TS static + a few routes on Vercel Hobby** | 100 GB transfer, 1 M invocations |
+| Auth | **Vercel Authentication** (free on Hobby) | — |
+| **Total cost** | **$0** | |
+
+**Tradeoffs.** Simplest thing that clears both hard blockers. No hosted DB to outgrow. The frontend
+cannot do ad hoc queries over history — everything must be precomputed nightly, which constrains
+interactive features (e.g. "re-rank with a different lookback on the fly" needs to be enumerated
+ahead of time). Debugging a job means reading Actions logs.
+
+**First thing that breaks as the universe/history grows:** the **2,000 private-repo Actions minutes per
+month**. Two runs/day × 30 days leaves ~33 min average per run; add retries, backfills, and a widening
+universe and you hit it. Escapes, in order of preference: (a) flip the repo public → unlimited standard-
+runner minutes, accepting the 60-day inactivity rule and public code; (b) move only the heavy pull to
+Cloud Run Jobs; (c) trim the universe with a liquidity pre-filter so you only fetch names that can
+possibly qualify.
+
+Second thing to break: R2 Class A (write) operations at 1 M/month — only if you write one object per
+symbol per day (7,000 × 2 × 30 = 420 k, still inside, but a per-symbol-per-day layout is the wrong
+choice anyway; partition by year).
+
+### Stack B — Actions + Turso + Cloudflare Pages
+
+| Layer | Choice |
+|---|---|
+| Job runner + scheduler | **GitHub Actions** (same as A) |
+| Store | **Turso** — 5 GB, 100 DBs, 500 M rows read/mo, 10 M rows written/mo |
+| Frontend | **Cloudflare Pages** + a Worker API querying Turso over HTTP |
+| Auth | **Cloudflare Access** |
+| **Total cost** | **$0** |
+
+**Tradeoffs.** You get real SQL at the edge, so the UI *can* do ad hoc ranking and drill-down without
+precomputing every view. Costs: a second vendor, and the Worker API sits inside the free Workers
+envelope (100 k req/day, 10 ms CPU, 50 subrequests/request) — fine for one user, but the 10 ms CPU cap
+means the Worker must be a thin proxy, not a compute layer.
+
+**First thing that breaks:** **Turso's 10 M rows written per month.** A single full historical backfill
+(~17.6 M rows for 10y × 7,000 symbols) blows through a whole month's write quota in one run. You would
+have to backfill across two calendar months, or backfill into Parquet and only keep a recent window
+(e.g. 2 years ≈ 3.5 M rows) in Turso. Steady-state nightly writes (~7,000 rows/day ≈ 210 k/month) are
+nowhere near the limit — it is purely a cold-start / re-backfill problem. Second to break: the 500 M
+rows-read budget, if the UI does full-universe scans (a 1-year × 7,000-symbol scan reads ~1.76 M rows,
+so ~280 such scans/month).
+
+### Stack C — Cloud Run Jobs + GCS + Vercel
+
+| Layer | Choice |
+|---|---|
+| Job runner | **Cloud Run Jobs** — task timeout up to 168 h; Always Free 180,000 vCPU-s, 360,000 GiB-s, 2 M requests/month |
+| Scheduler | **Cloud Scheduler** — 3 jobs/month free (we need 2) |
+| Store | **GCS** 5 GB Always Free (US regions) as Parquet, or R2 |
+| Frontend | **Vercel Hobby** static + routes |
+| Auth | **Vercel Authentication** |
+| **Total cost** | **$0**, but a **credit card is required**: "A Google Cloud billing account is required to access the Google Cloud Free Tier" |
+
+**Tradeoffs.** The most generous compute ceiling by far — 180,000 vCPU-s = 50 vCPU-hours/month, against
+a nightly need of maybe 15 h. Real container images, real dependency management, real logs. The costs
+are operational: GCP setup (project, service account, Artifact Registry, IAM) is materially more work
+than a `.github/workflows/*.yml`, and unlike every other option here, **overrunning the free tier bills
+you rather than stopping you**. Set a budget alert and a hard `--max-retries` on the job.
+
+**[UNVERIFIED]:** whether the Cloud Run Always Free allowance applies to **Jobs** as well as Services.
+The GCP Free Tier page lists Cloud Run without distinguishing the two, and I could not fetch the full
+Cloud Run pricing page (truncated/redirect-looped) to confirm. Verify before relying on it.
+
+**First thing that breaks:** GCS Always Free is **5 GB in US regions only** and 5,000 Class A ops/month
+— the op count is the sharper edge (a per-symbol-per-day write layout would exceed it immediately).
+After that, the 180,000 vCPU-s compute allowance at ~35 min/run × 60 runs.
+
+---
+
+## 7. Recommendation
+
+**Stack A.** Reasons, in order:
+
+1. It is the only stack where the nightly job's runtime is a **non-question** (6 h budget vs a job that
+   should take under 30 min), and job timeout was the ticket's stated hard blocker.
+2. It requires **no credit card anywhere** and cannot silently bill.
+3. Parquet-in-R2 has ~30× headroom on the realistic footprint, so the storage blocker is also
+   answered outright, and it is the format DuckDB/Polars are fastest against — which matters for the
+   compute half of the nightly job (indicators over 17 M rows).
+4. Auth is one toggle (Vercel Authentication), not an IdP integration.
+5. Every piece is independently replaceable: swap Vercel for Cloudflare Pages, swap R2 for GCS, swap
+   Actions for Cloud Run Jobs — the contract between layers is "files in a bucket".
+
+**Add Stack B's Turso later, not now**, and only if the dashboard turns out to need interactive queries
+that cannot be precomputed. Keep it as a *hot window* (last 1–2 years) alongside the Parquet archive of
+record, which sidesteps the 10 M-writes/month backfill wall.
+
+**Do not** build on: Netlify (30 s scheduled functions, no Python), Supabase or Neon as the bar store
+(500 MB), Render free Postgres (deleted after 30 days), Fly.io (no free tier for new orgs),
+Cloudflare Containers (paid only), Hugging Face Spaces (now paid for Docker/Gradio).
+
+---
+
+## 8. Open items to re-verify before build
+
+- **[UNVERIFIED]** Does a `GITHUB_TOKEN`-authored commit reset the 60-day public-repo schedule timer?
+  (Moot if the repo is private.)
+- **[UNVERIFIED]** Does Cloud Run's Always Free tier cover Jobs, not just Services?
+- **[UNVERIFIED]** Cloudflare Zero Trust free seat count (widely reported as 50; not found on a current
+  primary docs page today).
+- **[UNVERIFIED]** Supabase Cron / pg_cron availability specifically on the Free plan.
+- **[UNVERIFIED]** All per-row storage estimates in §2.1 are my own arithmetic from format overheads,
+  not vendor figures. Measure with a real 1,000-symbol sample before committing to a store.
+- The real universe size and history depth are still open (`map.md` §"Not yet specified"). If the data
+  source only gives 2–5 years, Turso and even D1-with-sharding come back into play and Stack B becomes
+  more attractive.
+- Netlify's free plan has moved to a **credits** model ("300 credit limit") whose conversion rates I
+  could not read from a primary page today; the commonly cited legacy figures are 100 GB bandwidth /
+  300 build minutes / 125,000 function invocations. **[UNVERIFIED]** — but Netlify is disqualified on
+  the 30 s scheduled-function limit and lack of Python regardless.
+
+## Sources
+
+- [GitHub Actions limits](https://docs.github.com/en/actions/reference/limits)
+- [GitHub Actions: events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+- [GitHub Actions: disable and enable workflows](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/disable-and-enable-workflows)
+- [GitHub Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+- [GitHub: about large files](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-large-files-on-github)
+- [GitHub: about releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases)
+- [Cloudflare Workers limits](https://developers.cloudflare.com/workers/platform/limits/)
+- [Cloudflare D1 limits](https://developers.cloudflare.com/d1/platform/limits/)
+- [Cloudflare R2 pricing](https://developers.cloudflare.com/r2/pricing/) / [R2 limits](https://developers.cloudflare.com/r2/platform/limits/)
+- [Cloudflare Pages limits](https://developers.cloudflare.com/pages/platform/limits/)
+- [Cloudflare Containers pricing](https://developers.cloudflare.com/containers/pricing/)
+- [Cloudflare Python Workers](https://developers.cloudflare.com/workers/languages/python/) / [packages](https://developers.cloudflare.com/workers/languages/python/packages/)
+- [Cloudflare One setup](https://developers.cloudflare.com/cloudflare-one/setup/) / [Access policies](https://developers.cloudflare.com/cloudflare-one/policies/access/)
+- [Vercel function limits](https://vercel.com/docs/functions/limitations) / [Vercel limits](https://vercel.com/docs/limits) / [Hobby plan](https://vercel.com/docs/plans/hobby) / [cron usage & pricing](https://vercel.com/docs/cron-jobs/usage-and-pricing)
+- [Netlify scheduled functions](https://docs.netlify.com/build/functions/scheduled-functions/) / [Netlify pricing](https://www.netlify.com/pricing/)
+- [Render free tier](https://render.com/docs/free) / [Render cron jobs](https://render.com/docs/cronjobs)
+- [Railway pricing](https://railway.com/pricing) / [plans](https://docs.railway.com/reference/pricing/plans) / [rates](https://docs.railway.com/reference/pricing)
+- [Fly.io pricing](https://fly.io/docs/about/pricing/)
+- [Neon plans](https://neon.com/docs/introduction/plans) / [Neon pricing](https://neon.com/pricing)
+- [Supabase pricing](https://supabase.com/pricing) / [Edge Function limits](https://supabase.com/docs/guides/functions/limits) / [Supabase Cron](https://supabase.com/docs/guides/cron)
+- [Turso pricing](https://turso.tech/pricing)
+- [Google Cloud Free Tier](https://docs.cloud.google.com/free/docs/free-cloud-features) / [Cloud Run task timeout](https://docs.cloud.google.com/run/docs/configuring/task-timeout) / [Cloud Scheduler pricing](https://cloud.google.com/scheduler/pricing)
+- [Hugging Face Spaces overview](https://huggingface.co/docs/hub/spaces-overview)


### PR DESCRIPTION
Resolves the **Market regime filter** ticket on the Qullamaggie Screening Dashboard v1 wayfinder map.

> **Note on the diff:** `.scratch/` was untracked in the working copy, so every map file shows as new here. The only files this session actually changed are:
> - `.scratch/screening-dashboard/issues/10-market-regime-filter.md` — the resolution
> - `.scratch/screening-dashboard/map.md` — Decisions-so-far entry + validation fog patch
> - tickets `05`, `08`, `11`, `12` — dependency notes appended
>
> Merge this only if you want the map tracked in git. Otherwise copy those files back into your checkout and close it.

## The decision

Three states per market, from one index each — US `^IXIC`, IDX `^JKSE` — on simple `SMA10`/`SMA20` of daily closes (§2 fixes daily MAs as simple).

Slope is **sign-only**: `SMA[t] > SMA[t-5]` is rising. The whole filter therefore has **zero tunable parameters**, which is deliberate — delisted names return zero rows on Yahoo, so any historical series is survivorship-biased upward and no threshold is calibratable today.

- `HOSTILE` — SMA10 falling AND SMA20 falling AND SMA10 < SMA20 (§10 verbatim)
- `FRIENDLY` — close above both AND both rising
- `CHOPPY` — the residual

§10's two named conditions aren't complements; the gap between them *is* chop. Defining it as the residual adds no parameters and fails safe. The three are mutually exclusive by construction, so no precedence rule is needed.

## Effect

Advisory only — a persistent banner per market with a sizing posture (full / reduced / sit out), no computed position size since §8 is out of scope. The candidate list is identical in all three states, and the regime never touches the star score.

- **Breadth** is displayed beside the banner but does not gate — it's the measure survivorship bias corrupts most directly.
- **Breakout follow-through** is captured nightly from day one but neither shown nor gated in v1. It's the only unbiased regime signal available and it cannot be backfilled from Yahoo, so the clock has to start at launch.

## Handed onward

- **05** owns the market-calendar rule for "last closed session"
- **08** owes a defined trigger level per detected setup
- **11** carries the two banners
- **12** owes the nightly setup-snapshot table and index-bar ingestion

🤖 Generated with [Claude Code](https://claude.com/claude-code)
