### PR TITLE
Resolve wayfinder ticket 08: setup detection algorithm

### DIFF
--- a/.scratch/screening-dashboard/issues/08-setup-detection-algorithm.md
+++ b/.scratch/screening-dashboard/issues/08-setup-detection-algorithm.md
@@ -1,7 +1,7 @@
 # Setup detection algorithm — making the breakout/continuation computable
 
 Type: grilling
-Status: open
+Status: resolved
 Blocked by: 05
 
 ## Question
@@ -76,3 +76,282 @@ Resolve against `references/qullamaggie-method.md` §3, §6, §7. Expect this to
 detected setup — the price the breakout keys on. Ticket 10 records it nightly from launch so a
 follow-through series accumulates forward; without a stable definition here there is nothing to record
 against, and the capture cannot be backfilled later.
+
+---
+
+## Answer
+
+The breakout/continuation setup is computable from daily bars, and the resulting detector has **zero
+tunable parameters**. That was not the expected outcome — the ticket was flagged as the highest-risk on
+the map precisely because §3.5 double-weights the two dimensions least amenable to automation. Both turned
+out to be measurable, but only after the base-finding problem was solved in a way that made them
+measurable *fairly*.
+
+### D1. Detection emits a state, not an event
+
+Nightly, the detector emits every name **currently sitting in a valid base**, each with a star score and a
+trigger level, regardless of whether anything happened today. The breakout is then a **state transition**
+(`WATCHING` → `TRIGGERED`) on a name already known to the system, not a separate detector.
+
+This is forced by ticket 10, which records a trigger level nightly from launch so a follow-through series
+accumulates forward: you cannot record a trigger for a breakout that has already happened. It also matches
+§3.1, whose preconditions describe a base forming rather than a break, and §3.2's stated purpose for the
+line ("hang a price alert on the line").
+
+Consequence: detection runs against **every universe member every night**, not just recent movers.
+
+### D2. The base is found by an end-anchored backward search — no pivot detection anywhere
+
+The base **always ends on the most recent bar**. There is no such thing as a base that ended last week,
+because the detector reports state as of tonight. Only the start is unknown, so it is searched: evaluate
+every candidate length L from 3 upward, ending today.
+
+This eliminates swing/pivot detection entirely, which matters more than it sounds. §3.2 is explicit that
+undercuts and overshoots are **desirable** — *"you want those false breakdowns and false breakouts, that's
+where you build setup strength"* — so a pivot detector fights the method at exactly the bars that
+distinguish the best setups. The search restates §3.2's inversion as an algorithm: anchor on the recent
+tight cluster, extrapolate backwards over the prior highs.
+
+### D3. Every valid window is retained
+
+The search does not collapse to one window. The **set** of passing windows is itself evidence: a base valid
+at L=3,4,5…14 is a nested, coherent contraction, while one valid only at L=7 is an artifact. This set later
+turns out to be what makes contraction measurable (D7).
+
+### D4. The primary window is the shortest valid one
+
+Two designation rules were tried and rejected in session before this one was settled. The reasoning is
+recorded because the failures are reusable:
+
+**Every distance quantity over an end-anchored window is monotone in L.** Window low is a running minimum,
+so it only falls as L grows; window high is a running maximum, so it only rises. Therefore:
+
+- ranking windows by **raw tightness** collapses to L=3 — a 3-bar window is mechanically tighter than a
+  14-bar one, having had fewer chances to move;
+- ranking by **MA proximity** collapses to L=3 for the identical reason, since both the low and the trigger
+  drift away from the MA as L grows.
+
+Any argmax over a monotone quantity degenerates. Rather than correcting the monotonicity (a √L
+normalisation and a mean-of-lows statistic were both considered), the degeneracy is **accepted**: primary
+is the shortest valid window. This is defensible on the method's own terms — the shortest window yields the
+**earliest, nearest-the-MA trigger**, which is the entry §3.2 spends its longest passage arguing for, and
+which is what makes the §7 stop affordable. The base-length signal is not lost; it comes from the retained
+set (D3) instead.
+
+### D5. The trigger is the lower of a flat and a sloped level
+
+`trigger = min(max high of the primary window, fitted descending line at today)`.
+
+The sloped component is the high-side fit already computed for validity (D9). Taking the lower of the two
+biases the trigger toward the earlier, more affordable entry in every case, and gives a base that goes
+quiet a trigger that **descends each night it sits** — which is the behaviour §3.2 describes and the reason
+the trendline break and the swing-high break are different days.
+
+Accepted cost: the trigger's binding rule varies name to name, and it front-runs — more signals, more false
+breaks. The false breaks are partly a feature per §3.2, but this is the decision most likely to need
+revisiting after ticket 09 looks at real charts.
+
+### D6. Stop is estimated at the base low, and unaffordable candidates are rejected
+
+Detection fires before any entry exists, so §7's "low of the day on the entry day" is unavailable. The EOD
+proxy is the **low of the primary window**:
+
+```
+implied stop width = (trigger − base low) ÷ trigger
+reject when width > 1 × ADR
+```
+
+This is honest rather than convenient — §7 says to cut if price falls back into the range, so the base low
+is where the stop actually goes. It is a **hard rejection, not a flag**, because §7 is unambiguous: wider
+than 1×ADR means no trade. It is also the only mechanism that enforces §6's "shortest timeframe whose stop
+you can afford" without intraday data, and it composes with D4 — the shortest valid window has the tightest
+base low, so the gate systematically favours the near-MA setups the method wants.
+
+This gate is what §3.4's first auto-reject ("loose, wide-range consolidation") looks like in numbers.
+
+### D7. Contraction — the ×2 tightness dimension — is the range(L) curve against a √L baseline
+
+The affordability gate (D6) already measures `(trigger − base low) ÷ ADR`, which **is** the primary window's
+range in ADR units. So "narrow" is already pass/fail, and scoring narrowness again would put the ×2 weight
+on a quantity that is already gated. §3.5 asks for two things — range is *narrow* **and** *narrowing* — and
+the gate has the first. Tightness therefore scores only the second.
+
+The retained window set (D3) gives `range(L)` for every candidate length: a curve, already computed. Under
+a random walk that curve grows as √L. A contracting base grows **flatter** than √L, because the older bars
+are wide and the recent ones are tight. Contraction is scored as how far below the √L baseline the observed
+curve sits.
+
+Length-fair by construction, needs no new data or new window, and degrades gracefully — a name with a
+single valid window scores neutral rather than erroring.
+
+### D8. Orderliness — the other ×2 dimension — is the churn ratio
+
+`churn = Σ(daily ranges over the base) ÷ (base high − base low)`. A smooth drift traverses its range once
+or twice; a barcode crosses it every session. This is §3.3's own image ("it looks like a barcode") made
+numeric, and it is parameter-free and scale-free.
+
+**The ticket's own candidate list was wrong here and the correction is the substance of this decision.**
+"Ratio of net drift to path length" — the efficiency ratio — does not work: a base is *sideways by
+definition*, so net drift is near zero for every good setup and the measure would score the tightest bases
+as maximally disorderly. Dividing path length by the **envelope** rather than by net drift fixes this
+completely while keeping the same intuition. R² of a linear fit to closes fails for the same reason.
+
+Measured on the **longest** valid window, not the primary: on the primary it reduces to roughly L ÷ the
+affordability width, which would double-count the §7 gate for a third time.
+
+So orderliness **is** scorable — the ticket's open question of whether this is where the human takes over
+resolves to no.
+
+### D9. Validity is the triangle test
+
+A window is valid when:
+
+- a line fitted to its **highs** has slope ≤ 0, and
+- a line fitted to its **lows** has slope ≥ 0, and
+- L ≥ 3 (§3.1's minimum).
+
+This is §3.2's gate sentence executed literally: *"connect the lower highs with a descending line; connect
+the higher lows with a rising line. If you cannot draw a triangle, there is no setup. Full stop."*
+
+Crucially it defuses the higher-lows trap **by construction**. A fit is not a monotonic test, so individual
+bars may sit above or below either line without invalidating the window — which is not a tolerated
+exception but the stated ideal. Every alternative considered (monotone lows with a tolerance band, a
+containment cap on how far bars may pierce) reintroduces the trap with padding: the bar that breaks the
+tolerance is usually the false breakdown that built the setup.
+
+§3.5's "higher lows intact" dimension is therefore the **low-side fit slope**, already computed here — a
+gate for validity, with its magnitude available as a score input.
+
+Rising channels and parallel-boundary ranges are **excluded** by requiring the highs fit to be non-rising,
+notwithstanding §3.2's "same treatment" aside, because the gate sentence he repeats verbatim is
+specifically about the triangle.
+
+### D10. MA catch-up is one number, and the 20-over-10 preference falls out of it
+
+`ma_dist_adr = (base low − SMA20) ÷ (ADR × price)`, with SMA20 required to be rising.
+
+"Rising" is tested **sign-only** — `SMA20[t]` vs `SMA20[t−5]` — reusing the exact convention ticket 10
+settled for the regime filter. This keeps the map internally consistent and adds no tunable parameter,
+which ticket 10 argued for on the grounds that survivorship bias makes any threshold uncalibratable.
+
+§3.1's stated preference for 20-day-based setups over 10-day ones needs **no second rule**: a name still
+riding well above its 20-day scores a large distance, while a genuine 20-day-based setup scores near zero.
+SMA10 and SMA50 distances are chart context and score nothing.
+
+### D11. Volume scores dry-up only in v1
+
+`dryup = median base volume ÷ median volume over the 50 bars preceding the base`.
+
+D1's state framing creates an asymmetry: dry-up is measurable every night, but **expansion only exists at
+the break** — so half of §3.5's volume dimension is unmeasurable for exactly the names on the watchlist.
+Scoring both would make a name's star score change at the moment it triggers with no change to its base,
+forcing ticket 09 to calibrate two variants (`WATCHING` and `TRIGGERED`).
+
+Resolved by scoring dry-up alone. Break-day expansion **is computed and persisted nightly** — ticket 10's
+follow-through stream needs it — but never touches the score. The star score stays one number meaning the
+same thing in every state.
+
+Accepted cost: §3.5's volume dimension is permanently half-measured, and confirmation on the break is the
+half he actually watches.
+
+Both quantities are ratios, so ticket 01's shares-not-lots quirk on IDX cancels, and ticket 05 has already
+dropped the phantom zero-volume bars that would otherwise crater every dry-up ratio.
+
+### D12. §5's backside veto is knowingly left unenforced
+
+The frontside/backside test needs 60-minute bars (10/20/65 EMA flipping to resistance), which an EOD app
+does not have. A daily-65-EMA substitute was available and considered — §2 already places exactly one
+exponential on the daily chart, the 65 EMA, and defines frontside/backside in those terms — but **no
+substitute gates anything**.
+
+The 65 EMA is still drawn on the chart per §2, and the missing check is surfaced as a standing caveat.
+§5's auto-reject is therefore absent from v1. The known weakness of a caveat shown on every candidate is
+that it is a caveat shown on none; this is accepted rather than solved.
+
+This interacts with D15: excluding the 12m window from the prior-move gate removes the most likely route
+for a rolled-over name to reach the candidate list, which is the same population the veto would have
+caught. That is partial cover, not a substitute.
+
+### D13. IDX limit days are knowingly unhandled
+
+Ticket 05 (D10) established that limit-day detection is a dead end on free data — the auto-reject band is
+tiered by price and board with the table behind Cloudflare, and raw IDX prices are unrecoverable so the
+bands cannot be inferred from history. This ticket was handed the remaining question: whether
+contraction/tightness must handle it at all.
+
+**It does not, in v1.** The exposure is real and is stated plainly: a limit-locked bar has a collapsed
+high/low range, which **flatters both ×2 dimensions simultaneously** — extreme contraction (D7), minimal
+churn (D8). A dead stock can therefore score as a textbook base.
+
+A generic liveness floor was available (invalidate a window whose median daily range falls below a fraction
+of the name's longer-run ADR — market-agnostic, catches truncated as well as fully-locked bars, and
+subsumes a zero-range test). It was declined in favour of relying on ticket 05's 80%/3-session density
+gate, accepting that density catches *missing* bars rather than *present-but-flat* ones.
+
+**Carried to ticket 09** as an explicit calibration item: it is the ticket that sits with real charts and
+is the place this would surface empirically.
+
+### D14. There is no Lmax — the triangle test self-caps
+
+The search was originally specified with one free parameter: a cap stopping the base from swallowing the
+momentum leg. **That parameter does not need to exist.**
+
+Validity requires the highs fit to slope ≤ 0. Extending the window backwards into the momentum leg adds
+**older bars with lower highs**, which tips that fit from descending to rising — so the window goes invalid
+the moment the leg bleeds in. §3.1's "consolidation *after* the move" is already enforced by the geometry,
+with no prior-move-high computation and nothing to tune.
+
+What remains is a pure compute bound (search L up to ~60 bars and stop). It is not a modelling parameter:
+it never binds, because validity fails long before it.
+
+### D15. The prior-move gate is top-decile in any of 1m / 3m / 6m
+
+Read from ticket 06's rank table — 06 established ranking as a **shared service** and §3.1's gate must not
+define strength a second time. But only three of 06's five windows are read, and the two exclusions are for
+stated reasons:
+
+- **1w** is a momentum *burst*, not §3.1's "big prior move" — and it is the board 06 measured turning over
+  16 of 30 rows nightly.
+- **12m** is stale enough that a stock which topped out months ago still carries it, which is the backside
+  case D12 no longer catches.
+
+This narrows 06's ~29% union without touching its definitions. Detection remains a consumer.
+
+### D16. Output is a score plus a chart evidence bundle
+
+The emitted interface is the star score and the artifacts needed to draw the chart — the fitted lines, the
+retained window set, the MAs, the trigger, the state. The raw signal vector is **internal**.
+
+*Internal is not discarded.* The raw measurements are **persisted to the nightly stream**, because ticket 09
+must be able to recalibrate over history rather than only forward, and because tickets 06 and 10 both
+established that the nightly streams store raw numbers precisely so a later change can be replayed
+backwards. This was reconciled in session rather than put as a separate question.
+
+Accepted cost: the bundle is being designed against a consumer that does not exist yet — ticket 11 has not
+decided what the chart shows. The bundle's *contents* should be treated as provisional and settled by 11.
+
+### Owed to ticket 10, discharged
+
+Detection emits a **stable trigger level** per detected setup: `min(max high of primary window, fitted
+descending line at today)`, defined for every name in the `WATCHING` state. Ticket 10 can record it nightly
+from launch.
+
+### Two properties of the result
+
+**Zero tunable parameters.** Every threshold that was reached for got removed: Lmax dissolved into the
+triangle test (D14), "rising" is sign-only per ticket 10 (D10), the √L baseline is a random-walk null rather
+than a fitted constant (D7), and churn is a bare ratio (D8). The only numeric constants are the method's
+own — L ≥ 3 (§3.1) and 1×ADR (§7). This matches ticket 10's argument that on survivorship-biased data an
+uncalibratable threshold is worse than none.
+
+**Every scored quantity is a ratio.** Contraction, churn, MA distance, dry-up and stop width are all
+dimensionless. Ticket 05 predicted this would make ticket 01's unrecoverable raw IDX prices cost nothing,
+and it holds: nothing in detection is anchored to an absolute price level, on either market.
+
+### What this leaves for ticket 09
+
+Beyond its own scope, three items land on it from here:
+
+1. **D5's trigger rule** — the min-of-two is the decision most likely to look wrong against real charts.
+2. **D13's limit-day flattery** — whether locked IDX bars manufacture false five-star setups in practice.
+3. **D11's half-measured volume dimension** — whether dry-up alone carries §3.5's volume point.

--- a/.scratch/screening-dashboard/issues/09-star-score-calibration.md
+++ b/.scratch/screening-dashboard/issues/09-star-score-calibration.md
@@ -27,3 +27,28 @@ sit with it and disagree with it. Specifically:
 
 Output: a calibrated rubric with concrete thresholds, plus a record of the disagreements — the failure
 cases are as valuable as the parameters. Link the prototype rather than pasting it here.
+
+## Added by ticket 08
+
+Ticket 08 resolved and made every §3.5 dimension computable. Three items land here beyond this ticket's
+original scope, all of them things only a session sitting with real charts can settle:
+
+- **The trigger rule (08 D5).** The trigger is `min(max high of primary window, fitted descending line)` —
+  chosen to bias toward the earliest, nearest-the-MA entry, with the accepted cost of more signals and more
+  false breaks. 08 flags this as the decision most likely to look wrong against real charts. Check whether
+  the early trigger is buying strength or noise.
+- **IDX limit-day flattery (08 D13).** No ARA/ARB handling ships in v1. A limit-locked bar has a collapsed
+  high/low range, which flatters BOTH ×2 dimensions at once — extreme contraction and minimal churn — so a
+  dead stock can score as a textbook base. A generic liveness floor (median base daily range vs the name's
+  longer-run ADR) was designed and declined; adopt it if the prototype shows false five-star IDX setups.
+- **Half-measured volume (08 D11).** Only dry-up is scored; break-day expansion is persisted but never
+  touches the score, so §3.5's volume dimension carries half its intended content. Check whether dry-up
+  alone discriminates, or whether the score needs a `TRIGGERED` variant after all.
+
+Also relevant to this ticket's "booleans or continuous values" question: 08 D16 keeps the raw signal vector
+internal but **persists it nightly**, specifically so recalibration here can be replayed over accumulated
+history rather than only applied forward.
+
+Two properties of 08's output shape this ticket inherits: the detector has **zero tunable parameters** (the
+only numeric constants are the method's own — L ≥ 3 and 1×ADR), and **every scored quantity is a ratio**, so
+per-market calibration is not forced by scale differences alone.

--- a/.scratch/screening-dashboard/issues/13-assemble-v1-spec.md
+++ b/.scratch/screening-dashboard/issues/13-assemble-v1-spec.md
@@ -2,7 +2,7 @@
 
 Type: grilling
 Status: open
-Blocked by: 06, 07, 08, 09, 10, 11, 12
+Blocked by: 06, 07, 08, 09, 10, 11, 12, 14
 
 ## Question
 

--- a/.scratch/screening-dashboard/issues/14-alerting-and-trigger-notification.md
+++ b/.scratch/screening-dashboard/issues/14-alerting-and-trigger-notification.md
@@ -1,0 +1,39 @@
+# Alerting on the trigger level
+
+Type: grilling
+Status: open
+Blocked by: 08, 11
+
+## Question
+
+Does v1 notify you when something crosses its trigger, and through what channel?
+
+This graduated from the map's fog once ticket 08 defined a **stable trigger level** per detected setup —
+`min(max high of the primary window, fitted descending line at today)`, emitted nightly for every name in
+the `WATCHING` state. Until that existed there was nothing to hang an alert on. §3.2 is explicit that
+hanging a price alert on the line is one of the trendline's only two jobs, so this is the method's own use
+of the number ticket 08 now produces.
+
+What has to be decided:
+
+- **Does v1 alert at all**, or is the nightly dashboard review (§1: "nightly review, ~10 minutes") the whole
+  interaction? An EOD app has no intraday leg to stand on, so an alert can only ever fire after the close —
+  which is exactly when you would be looking at the dashboard anyway.
+- **What event fires it.** Ticket 08's `WATCHING` → `TRIGGERED` transition is the obvious candidate, but
+  ticket 08 (D5) chose the *lower* of a flat and a sloped level deliberately to trigger early, and noted the
+  accepted cost is more signals and more false breaks. Decide whether alerting fires on every transition or
+  on some narrower subset (star threshold, market regime, breadth).
+- **The trigger descends nightly.** Because ticket 08's sloped component keeps falling while a base sits, a
+  name can trigger without moving — the line came down to meet it. Decide whether that counts as an alert or
+  is a distinct, weaker event, because it is the case a human would not have spotted on the chart.
+- **The channel.** The map's standing constraint is that v1 **runs locally**, single user, which narrows
+  this sharply: a desktop notification or a nightly digest file, not a push service. Hosting is out of scope,
+  so nothing that assumes a server.
+- **New-setup alerts vs trigger alerts.** A name *entering* the `WATCHING` state at 4–5 stars may be more
+  actionable than one triggering, since §3.2's whole argument is that the setup is at the MA, days before
+  the obvious break.
+
+Blocked on ticket 11 as well as 08: whether alerting is a separate channel or simply a state in the
+dashboard depends on what the dashboard is.
+
+Resolve against `references/qullamaggie-method.md` §1, §3.2, §6.

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -30,6 +30,10 @@ is written during wayfinding.
   - "Top decile" is ranked against the whole tradeable universe **per market**, not within sector.
 - **Known risk carried into the map**: §3.5 double-weights *tightness* and *orderliness*, the two
   dimensions least amenable to automation. Setup detection is the highest-risk ticket on this map.
+  **Discharged by ticket 08** — both dimensions proved scorable (contraction against a √L baseline;
+  churn ratio for orderliness), and the resulting detector has **zero tunable parameters**. The residual
+  risk moved rather than vanished: it now sits in ticket 09, which is where a human eye first meets the
+  computed score.
 - **Standing property of the data layer** (found independently by tickets 01, 02 and 03): **Yahoo fails
   as silence.** Throttled requests return empty results — and for price history, the literal message
   "possibly delisted; no price data found". Every ingestion path must distinguish throttling from
@@ -108,6 +112,34 @@ is written during wayfinding.
   twice. Rank history persists nightly on a **rolling 2-year window**. The session also **reproduced
   ticket 05's universe exactly (1,966 / 288) from its written decisions alone**.
 
+- [Setup detection algorithm](issues/08-setup-detection-algorithm.md) — **the highest-risk ticket resolved with
+  zero tunable parameters**, which was not the expected outcome. Detection emits a **state, not an event**:
+  every name currently in a valid base, nightly, with the breakout as a `WATCHING`→`TRIGGERED` transition —
+  forced by ticket 10, since you cannot record a trigger for a break that already happened. The base is found
+  by an **end-anchored backward search** (always ends on the last bar, only the start is searched), which
+  **eliminates pivot detection** — the trap, because §3.2 says undercuts and overshoots are *desirable*, so a
+  pivot detector fights the method at exactly the bars that mark the best setups. Validity is **§3.2's triangle
+  test executed literally**: highs fit slopes ≤ 0, lows fit slopes ≥ 0, L ≥ 3 — and because a *fit* is not a
+  monotonic test, piercing bars are the stated ideal rather than a tolerated exception. That test also
+  **self-caps the search**, deleting the one free parameter: reaching back into the momentum leg tips the highs
+  fit positive, so §3.1's "consolidation *after* the move" is enforced by geometry. **Every distance quantity
+  over an end-anchored window is monotone in L**, so ranking windows by tightness *or* by MA proximity both
+  collapse to L=3; the degeneracy is accepted rather than corrected — primary is the **shortest valid window**,
+  which yields the earliest, nearest-the-MA trigger §3.2 argues for. Trigger is the **lower of the flat max-high
+  and the fitted descending line**, so a base that sits still eventually triggers on its own. §7 gets teeth:
+  stop estimated at the **base low**, and width > 1×ADR **rejects outright**. Both ×2 dimensions turned out
+  scorable: **contraction** = how far the retained set's `range(L)` curve sits below its **√L random-walk
+  baseline** (the affordability gate already measures *narrow*, so tightness scores only *narrowing*), and
+  **orderliness** = **churn ratio**, Σ daily ranges ÷ envelope — which required correcting the ticket's own
+  candidate: net-drift efficiency scores every good base as maximally disorderly, because a base is sideways by
+  definition. MA catch-up is **one number** carrying §3.1's 20-over-10 preference for free. **Three knowing
+  omissions**: §5's backside veto is unenforced (needs 60-min bars; a daily-65-EMA substitute was declined),
+  IDX limit days are unhandled (they flatter *both* ×2 dimensions at once — carried to ticket 09), and only
+  **dry-up** is scored, since expansion exists only at the break and scoring it would make the score
+  state-dependent. Gate is **top decile in any of 1m/3m/6m** off ticket 06's rank table — 06's 1w and 12m
+  windows excluded as burst and stale. **Every scored quantity is a ratio**, confirming ticket 05's prediction
+  that ticket 01's unrecoverable raw IDX prices cost nothing.
+
 ## Not yet specified
 
 - **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
@@ -130,9 +162,15 @@ is written during wayfinding.
   the stored ranks carry a **~1.5% noise floor** from denominator churn (30 US / 8 IDX names entering or
   leaving the universe overnight even with D11's hysteresis), so small percentile moves are not
   necessarily price moves. Whatever validation becomes possible has to be robust to both.
-- **Alerting.** He hangs price alerts on the trendline. Whether v1 notifies at all, and through what
-  channel, waits on detection being defined. Running locally narrows the options — a desktop
-  notification or a nightly digest, not a push service.
+  **Ticket 08 adds a fifth stream** — the raw signal vector behind every detected setup, persisted nightly
+  even though the emitted interface only carries the score and the chart bundle. It exists for the same
+  reason as the other four: it is the only way a later recalibration can be replayed *backwards* over
+  accumulated history rather than merely applied forward. It also sharpens what validation must eventually
+  measure, because ticket 08 shipped three knowing omissions — the unenforced backside veto, unhandled IDX
+  limit days, and a half-measured volume dimension — each of which is a hypothesis about what does not
+  matter, and none of which can be tested until there is something to test against.
+  <!-- "Alerting" graduated into ticket 14: ticket 08 defined a stable trigger level per detected setup,
+       which is the thing an alert hangs on. It is now a channel-and-threshold decision, not fog. -->
 - **Watchlist persistence and user state.** Whether the app remembers names you've marked, and what
   storage that implies, waits on the architecture ticket.
 - **Chart rendering approach.** Library and how the detected trendline / MA context is drawn — waits


### PR DESCRIPTION
Resolves [Setup detection algorithm](.scratch/screening-dashboard/issues/08-setup-detection-algorithm.md) on the [Qullamaggie Screening Dashboard v1](.scratch/screening-dashboard/map.md) map — the ticket the map itself flagged as its highest risk, because §3.5 double-weights the two dimensions least amenable to automation.

Both proved scorable, and the resulting detector has **zero tunable parameters**.

## What was decided

- **State, not event.** Detection emits every name currently in a valid base, nightly; the breakout is a `WATCHING`→`TRIGGERED` transition. Forced by ticket 10 — you cannot record a trigger for a break that already happened.
- **End-anchored backward search.** The base always ends on the last bar; only the start is searched. This eliminates pivot detection, which is the trap: §3.2 says undercuts and overshoots are *desirable*, so a pivot detector fights the method at exactly the bars that mark the best setups.
- **Validity = §3.2's triangle test, literally.** Highs fit slopes ≤ 0, lows fit slopes ≥ 0, L ≥ 3. Because a *fit* is not a monotonic test, piercing bars are the stated ideal rather than a tolerated exception. The test also **self-caps the search** — reaching back into the momentum leg tips the highs fit positive — which deleted the one free parameter the design had.
- **Monotonicity finding.** Every distance quantity over an end-anchored window is monotone in L, so ranking windows by tightness *or* by MA proximity both collapse to L=3. The degeneracy is accepted rather than corrected: primary is the shortest valid window, which yields the earliest, nearest-the-MA trigger §3.2 argues for.
- **§7 gets teeth.** Stop estimated at the base low; implied width > 1×ADR rejects outright.
- **Contraction** = how far the retained window set's `range(L)` curve sits below its √L random-walk baseline. The affordability gate already measures *narrow*, so tightness scores only *narrowing*.
- **Orderliness** = churn ratio, Σ daily ranges ÷ envelope. This required correcting the ticket's own candidate list: net-drift efficiency scores every good base as maximally disorderly, because a base is sideways by definition.

## Three knowing omissions

§5's backside veto is unenforced (needs 60-min bars), IDX limit days are unhandled (they flatter *both* ×2 dimensions at once), and only volume dry-up is scored. All three are recorded as accepted risks and carried to ticket 09, which is where a human eye first meets the computed score.

## Map changes

- Ticket 08 resolved, with the full decision record (D1–D16) on the ticket.
- **Alerting** graduated from fog into ticket 14, now that a stable trigger level exists to hang an alert on.
- Ticket 09 gained three calibration items; ticket 13 gained ticket 14 as a blocker.
- The map's "known risk" note is marked discharged — the residual risk moved to ticket 09 rather than vanishing.

Frontier is now **Sector/theme and rotation model**, **Star score calibration**, and **Architecture and deployment**.

Planning only — no production code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)