### PR TITLE
Resolve wayfinder ticket 07: sector/theme leadership and rotation model

### DIFF
--- a/.scratch/screening-dashboard/issues/06-ranking-and-decile-model.md
+++ b/.scratch/screening-dashboard/issues/06-ranking-and-decile-model.md
@@ -1,7 +1,7 @@
 # Ranking and decile model
 
 Type: grilling
-Status: open
+Status: resolved
 Blocked by: 05
 
 ## Question
@@ -38,3 +38,379 @@ Settled during charting: ranking is against the **whole tradeable universe, per 
 
 This ticket also feeds the sector model — decide whether sector strength is aggregated from these same
 member ranks or computed independently.
+
+## Answer
+
+Resolved 2026-08-04 in a grilling session. Twelve decisions below. Every number in the "Measured"
+section was produced during this session against live Yahoo data (`yfinance 1.5.2`, throwaway venv in
+the job scratch dir, nothing installed into the project), applying the ticket-05 rule stack exactly as
+written.
+
+**The rule stack is reconstructible.** Rebuilding ticket 05's universe from its written decisions
+alone reproduced its numbers exactly — **1,966 US / 288 IDX**. That is a check on the map itself, not
+just on this ticket: the decisions are specified well enough that an independent session gets the same
+population.
+
+One principle runs through the answers: **the ranking model reports, it does not judge.** R8 (ADR does
+nothing), R9 (pure return), R10 (no smoothing) and R12 (flag, don't promote) are all instances. Every
+place where a filter, a normalisation or a damping could have been folded into the rank, it was instead
+made a visible column, badge or toggle. The rank answers exactly one question — who moved most — and
+every other judgement stays separable and inspectable. This is deliberate: §3.5 already scores quality
+and ticket 08 already detects setups, so a ranking that also judged would be the third opinion in the
+system and the only one you couldn't see inside.
+
+### R1 — The §3.1 gate and the §1 leaderboard are two different cuts
+
+Ticket 05 handed this over as urgent ("a decile of 1,966 is ~197, unreviewable"). The premise
+conflated two consumers of the ranking:
+
+- **The gate** feeds setup detection (ticket 08). Nothing human reads it. Its job is **recall** — never
+  lose a real leader on a technicality — and 197 names passing is a compute cost, not a review cost.
+- **The leaderboard** is read by a human in ~10 minutes and must be short.
+
+Once separated, the "unreviewable" objection only ever applied to the leaderboard, and the two can take
+different cuts without contradiction. Everything below follows from this split.
+
+### R2 — Gate = union of top deciles across **1w / 1m / 3m / 6m / 12m**, per market
+
+Any-of, not a composite. Each decile computed within that lookback's own population (D5).
+
+Wider than §3.1's literal "1–6 month" on both ends, chosen deliberately: **1w** is §1's own scan #1
+("up ≥ 30% in the past 5 days"); **12m** catches the long grinder that has been basing for a quarter
+and whose short lookbacks have gone flat.
+
+Rationale for any-of over a composite:
+- A composite smears the horizons into one number, and the names it loses relative to the union are
+  precisely the **sharp recent movers** — 85th percentile on 1m, 50th on 3m, 40th on 6m composites to
+  nothing, but that is a stock that just woke up, which is what the method trades.
+- **D5 makes a composite structurally awkward:** a 90-day-old IPO is *absent* from the 6m population,
+  so a composite would need either to drop it or to fudge the weights around a missing leg. Under
+  any-of it simply qualifies via 1m or 3m. The method explicitly wants freshly-listed movers.
+
+**⚠ "Top decile" does not mean 10% and the spec must say so.** Unioned across five windows the gate
+passes **~29% of the universe** (566 US / 82 IDX, measured). Anyone reading "top decile of 1–6 month
+returns" will build for a tenth of the load and be wrong by 3×.
+
+**No lookback is a passenger** — every one admits names no other does (measured below), so the
+five-window choice is not padded.
+
+### R3 — Five separate boards per market, not one merged board
+
+Ten boards total. A merged board with per-lookback columns was proposed and **rejected by the trader**.
+
+Recorded because it has a consequence: the merged design carried a signal — *how many windows a name
+leads simultaneously* — that separate boards destroy. That signal is restored explicitly in R11 rather
+than lost.
+
+### R4 — Every board is **top 30**, constant in count
+
+Not a percentile. The number is over-determined in a way worth recording:
+- §1's own definition — a momentum leader is the **top 1–2% of gainers** — is 20–39 names on 1,966.
+- IDX's natural decile is **29**.
+
+So one constant serves both markets and is justified from the reference on both, rather than by
+convenience. Measured, the distinct-name load across five top-30 boards is **112 US / 88 IDX** — a
+genuine ten-minute pass, against 566/82 if the boards were deciles.
+
+**Named cost:** on IDX a top-30 board and a top-decile board nearly coincide; on US they differ by 6×.
+Accurate — it reflects the markets' real sizes — but it will feel inconsistent when switching markets.
+
+### R5 — Rank history persists nightly, on a rolling **2-year** window
+
+One row per (name, lookback, night), carrying **percentile rank and raw return**, for **every universe
+member** — not only board members, or a name's history has holes exactly on the nights it was
+interesting-but-not-quite.
+
+Percentile rather than ordinal position, because ordinal rank is not comparable across nights when the
+denominator moves — and D5 and D11 both move it.
+
+This is the map's **fourth irrecoverable nightly stream** (with D11 universe membership, ticket 12
+listing files, ticket 10 detected setups). Last night's ranks cannot be reconstructed later because the
+universe they were ranked against is gone — hysteresis, sticky membership and the density gate together
+make it unreproducible from today's data.
+
+**It is also the first stream that discards.** Unbounded retention was recommended (~50 MB/year, and
+locally there is no storage ceiling); the trader chose a bounded 2-year window. At steady state that
+always covers the longest lookback twice over, so no in-app feature ever outruns it. **The sole casualty
+is a future multi-year validation study** — and validation is already unsolved fog on the map. Cheap
+hedge if it ever matters: a coarser permanent archive (weekly, or board members only) at a few MB/year.
+Recorded as an accepted cost, not a gap.
+
+### R6 — Ranking is a **shared service**; sector strength aggregates over it
+
+The ranking emits a percentile rank per (name, lookback, night) — the R5 table — and ticket 07 defines
+sector strength as an aggregation over it. There is to be no second, divergent notion of "strong."
+
+Rationale:
+- **Share-of-members-in-top-decile beats an index return**, and the difference is the whole point. A
+  sector of 40 names where 8 are ripping and 32 are flat has a mediocre equal-weighted index return but
+  a high share of top-decile members. That is exactly the sector to surface — leadership concentrates
+  before it broadens, and the method trades leaders, not averages. An index dilutes the signal being
+  hunted.
+- **It erases a market asymmetry for free.** Per D1, IDX has essentially no sector-ETF reference set,
+  so an index-based approach needs a computed index on IDX and could use a real ETF on US — two
+  different metrics on two markets. Aggregating member ranks is identical on both by construction.
+
+**Recommended primary metric for ticket 07: share of members in the top decile.** Ticket 07 still owns
+the rotation definition and the exact aggregation; this ticket only guarantees the substrate and
+forbids a competing definition.
+
+**Named cost:** sector strength inherits every quirk of the ranking model — per-lookback denominators
+(D5), the hysteresis band (D11). A sector whose membership shifts for liquidity reasons will show a
+small strength move with no price action behind it.
+
+### R7 — Returns are **calendar-anchored**, and this narrows D6
+
+`return(D, L) = AdjClose(last final bar on or before D) / AdjClose(last final bar on or before D − L) − 1`,
+with L in calendar terms (1w = 7 days, 1m/3m/6m/12m = calendar months). Adjusted closes per D9.
+
+**This is a deliberate narrowing of D6**, which currently reads as universal ("windows count traded
+bars, not calendar days"). D6 was aimed at ADR and median dollar volume, where "the last 20 days this
+thing actually traded" is the right question. Returns are a different kind of window:
+
+- **A board must compare like with like.** Under traded-bar counting, "3-month return" spans 3 calendar
+  months for a name that trades every session and ~3.5 months for one missing 15% of sessions. They sit
+  adjacent on the same board measured over different amounts of real time — and the longer window has
+  more time to accumulate return, so **illiquid names are systematically flattered**.
+- **The density gate bounds this but does not remove it.** D6 guarantees ≥ 16 of the last 20 sessions —
+  a *recent*-window guarantee. Over 252 bars a name can carry a long past suspension and still qualify
+  today, making its "12-month return" reach back 15 calendar months.
+- **The distortion is worst on IDX**, where phantom bars live (ticket 01: 4% of bars).
+
+So: **traded-bar windows for rolling statistics, calendar anchoring for returns.** The "last bar on or
+before" rule handles weekends, holidays and phantom-dropped bars uniformly and needs no calendar
+table — it falls out of the observed session set D6 already builds.
+
+**D5's eligibility rule reads better under this**: a name is ranked in a lookback if it has a bar on or
+before `D − L` — i.e. it was actually listed and trading that long ago. That is a truer statement of
+"has that much history" than a bar count, and it stops a name with a sparse history from qualifying for
+the 12m board on 252 bars spread over two years.
+
+*Caveat on the measurements below: they were computed under traded-bar counting, before this decision.
+The effect of calendar anchoring is a re-ordering at the margin, not a change in gate width.*
+
+### R8 — ADR does **nothing** by default; one toggle, off, on both surfaces
+
+ADR is a **column**. No filtering, no greying, no de-emphasis. A toggle hides sub-4% names; it is the
+same control on the leaderboards and on the detected-candidate list, and it defaults **off** on each.
+
+D3 left "post-rank filter" ambiguous once boards became constant-length — filter-then-take-30 (always
+30 rows, but the market's biggest gainer silently absent if it is a 3-ADR name) versus
+take-30-then-filter (honest, but variable length, possibly 12 rows).
+
+Both were rejected. **Filtering before the cut reintroduces the exact failure D3 exists to prevent:**
+D3 refused ADR as a universe gate because "a 3.5-ADR name that starts moving is a name whose ADR is
+*becoming* 8," and gating evicts it on the eve of the move. A name that just ripped 40% in a week is by
+construction a name whose trailing 20-day ADR has not caught up yet. Filtering the board commits that
+error one stage later.
+
+A split default was recommended (off on leaderboards, on for candidates) and **rejected by the trader
+in favour of off everywhere** — one behaviour to remember instead of two. Nothing is ever hidden unless
+the user hides it.
+
+### R9 — Rank on **pure return**. No volatility adjustment
+
+Measured, this is a large lever, not a refinement: normalising by ADR **replaces up to 20 of 30 rows**
+on the US boards.
+
+Rejected on three grounds:
+1. **It answers a question the method does not ask.** §1's scans are "biggest gainers"; §3.1's gate is
+   "top decile of returns." Both raw, consistently. The quantity hunted is *a big prior move*, not a
+   big risk-adjusted move — the flag that forms afterwards does not care how volatile the ride was.
+2. **ADR is already priced twice** — §3.5 scores it, R8 filters on it. Normalising would make it a third
+   input and the only one **invisible**, buried inside the sort key. No row could be explained.
+3. **It inverts his stated preference.** He explicitly takes the 7.6-ADR name over the 2.4-ADR ETF.
+   Dividing return by ADR systematically demotes high-ADR names in favour of low-ADR names that moved
+   less — the 3-ADR name that somehow gained 300% would top the board, and it is the name he rejects on
+   sight.
+
+**Named cost, to be written into the spec so nobody "fixes" it later:** the boards *will* be dominated
+by high-volatility names, and a quiet 2-ADR mega-cap making a genuinely unusual 40% move may never
+appear. Per point 3 this is the correct bias, but it is a real blind spot.
+
+### R10 — No smoothing anywhere; new entrants carry a `NEW` marker
+
+Measured churn is not one phenomenon:
+
+- **Return churn** — the 1w board turns over **16 of 30 overnight on US**; every other board moves 1–4
+  rows. The 1w figure is *honest*: one session is 20% of a five-day window. Smoothing it would lag the
+  fastest signal in the system, and §1's scan #1 exists precisely to catch things the day they happen.
+- **Denominator churn** — the universe moved under the ranking: **30 US and 8 IDX names** entered or
+  left overnight, *even with D11's hysteresis band already damping it*. Pure artefact — a name's rank
+  moves because 30 other names appeared.
+
+Decision: no smoothing of returns, including on the 1w board. Instead a **`NEW` marker** on rows absent
+from that board last session — which converts churn from noise-you-diff-by-eye into the most
+informative thing on the page. On the 1w board, the 16 new names *are* tonight's news.
+
+Denominator churn is **not corrected but is recorded**: ranks are computed against that night's
+universe, and D11's membership snapshot already records what it was, so any future analysis can
+reconstruct it. Holding the denominator fixed would mean ranking against a stale universe — worse.
+
+**⚠ Consequence for future validation:** stored percentile ranks carry a **~1.5% noise floor** from
+denominator churn. "This name's 3m percentile fell from 94 to 92" may be denominator, not price.
+
+### R11 — Breadth badge `k/5` on every row
+
+The count of lookbacks in which the name is currently top-decile. Free to compute — the gate (R2)
+already computes all five deciles.
+
+This restores the signal R3 destroyed. On separate boards, a name at #7 on the 3m board looks identical
+whether it is a one-window spike or one of the three names leading every window at once — and those are
+very different stocks. Measured, the distinction is real and non-degenerate: **55% of qualifying US
+names are `1/5`, 111 are `≥3/5`, and only 3 of 1,964 are `5/5`.**
+
+**Named cost:** it measures persistence, not magnitude, so it will sometimes disagree with intuition —
+a name can be `1/5` and still be the biggest gainer of the week. It is **not** a quality score and must
+not be presented as one.
+
+### R12 — §1's "up ≥ 30% in 5 days" is a **flag on the 1w board**, not a separate board
+
+Measured tonight: **20 US / 5 IDX** names clear the threshold, and **all of them are already on the 1w
+top-30 board** — zero missed. So the flag captures the scan exactly, keeps the constant-30 rule intact,
+and keeps ten boards from becoming twelve.
+
+It is an absolute threshold rather than a rank, which is why it cannot *be* a board without breaking
+R4: in a dead tape it returns zero rows, in a hot one it returns a hundred.
+
+**⚠ Accepted failure mode, explicitly chosen.** The US 1w board's cutoff is **26.2%**, and 20 of its 30
+slots are already ≥30% names. In a hot tape more than 30 names clear 30% in five days and those ranked
+below 30 **vanish silently** — the flag under-reports exactly when the scan matters most. Tonight's
+zero-missed is a quiet-tape result, not a structural guarantee. An overflow rule (show the top 30 *or*
+all names ≥30%, whichever is longer) was offered and **the trader chose to accept the failure mode
+instead**, keeping the constant-count rule without exception.
+
+---
+
+## Measured — live Yahoo data, 2026-08-04, `yfinance 1.5.2`
+
+Universe rebuilt from ticket 05's written decisions: **1,966 US / 288 IDX** — matching it exactly.
+(The probe-2 run reports 1,964 / 286: it applies an explicit `≥ 20 bars` guard that ticket 05's script
+left implicit. A two-name difference, noise not signal.)
+
+### Gate width — union of top deciles
+
+| | US | IDX |
+|---|---|---|
+| universe | 1,966 | 288 |
+| **union of 5 deciles (1w/1m/3m/6m/12m)** | **566 — 28.8%** | **82 — 28.5%** |
+| union of §3.1's 3 (1m/3m/6m) | 427 — 21.7% | 59 — 20.5% |
+| cost of adding 1w and 12m | +139 (+33%) | +23 (+39%) |
+| union of five **top-30** boards | 112 | 88 |
+
+**The 28.8% / 28.5% agreement across two markets differing 7× in size is not coincidence** — a
+percentile gate is self-normalising by construction. This is the measured form of R1's argument for
+keeping the *gate* a percentile while the *board* is a count.
+
+Per-lookback populations and decile cutoffs:
+
+| lookback | US pop | US decile | US cutoff | IDX pop | IDX decile | IDX cutoff |
+|---|---|---|---|---|---|---|
+| 1w | 1,966 | 197 | +13.3% | 288 | 29 | +13.0% |
+| 1m | 1,965 | 196 | +15.8% | 282 | 28 | +35.8% |
+| 3m | 1,954 | 195 | +36.9% | 282 | 28 | +23.1% |
+| 6m | 1,939 | 194 | +55.2% | 281 | 28 | +33.5% |
+| 12m | 1,912 | 191 | +124.8% | 275 | 28 | **+285.7%** |
+
+Two observations:
+- **Populations shrink with the lookback** (1,966 → 1,912 on US), which is D5 working as designed.
+- **IDX's 12m decile cutoff is +285.7%** — at the decile boundary an IDX 12-month leader has nearly
+  quadrupled, against +124.8% on US. IDX momentum is far more extreme at the top than US.
+
+Marginal contribution — names *only* that lookback admits:
+
+| lookback | US unique / shared | IDX unique / shared |
+|---|---|---|
+| 1w | 70 / 127 | 11 / 18 |
+| 1m | 101 / 95 | 10 / 18 |
+| 3m | 58 / 137 | 3 / 25 |
+| 6m | 32 / 162 | 9 / 19 |
+| 12m | 49 / 142 | 9 / 19 |
+
+### Breadth — top-decile in k of 5 lookbacks (R11)
+
+| k | US | IDX |
+|---|---|---|
+| 1 | 311 (54.9%) | 42 (51.2%) |
+| 2 | 144 (25.4%) | 26 (31.7%) |
+| 3 | 74 (13.1%) | 10 (12.2%) |
+| 4 | 34 (6.0%) | 3 (3.7%) |
+| **5** | **3 (0.5%)** | **1 (1.2%)** |
+
+### Volatility adjustment — top-30 overlap, raw return vs return/ADR (R9)
+
+| lookback | US | IDX |
+|---|---|---|
+| 1w | 10/30 | 19/30 |
+| 1m | 17/30 | 17/30 |
+| 3m | 12/30 | 23/30 |
+| 6m | 12/30 | 21/30 |
+| 12m | 18/30 | 27/30 |
+
+Normalising is a different product, not a refinement — and it bites hardest on US, the market with the
+wider ADR spread.
+
+### Churn — top-30 turnover vs the previous session (R10)
+
+| lookback | US | IDX |
+|---|---|---|
+| 1w | **16 in / 16 out** | 10 in / 10 out |
+| 1m | 4 | 4 |
+| 3m | 2 | 2 |
+| 6m | 4 | 2 |
+| 12m | 1 | 2 |
+| universe membership change | **30 names** | **8 names** |
+
+### §1 scan #1 — "up ≥ 30% in the past 5 days" (R12)
+
+| | US | IDX |
+|---|---|---|
+| 1w top-30 cutoff | +26.2% | +12.8% |
+| up ≥ 20% in 5 bars | 80 (**50 missed** by the board) | 13 (0 missed) |
+| **up ≥ 30% in 5 bars** | **20 (0 missed)** | **5 (0 missed)** |
+| up ≥ 50% in 5 bars | 4 (0 missed) | 3 (0 missed) |
+
+The ≥20% row is the warning: at a slightly lower threshold the board already misses 50 of 80 US names.
+The ≥30% flag works tonight because only 20 names clear it — see R12's accepted failure mode.
+
+## An operational note worth carrying forward
+
+Probe 2 lost a completed 5,467-symbol US pull because the IDX screener rate-limited immediately
+afterwards and the cache was written only after *both* markets had been fetched. This is **ticket 05's
+D7 hazard biting a first-party script**, not a third-party surprise: the pull succeeded, the process
+died, the work evaporated.
+
+**Hand to ticket 12:** the nightly pipeline must **persist each market's pull the moment it completes**,
+not at the end of the run. Two markets in one run means one market's rate limit can otherwise discard
+the other's completed work — and D7's run-level completeness gate would then quarantine a run whose
+data had actually been fetched successfully.
+
+## Findings handed to other tickets
+
+- **→ Ticket 07 (sector/theme and rotation):** ranking is a shared service (R6). Sector strength is an
+  aggregation over the (name, lookback, night) percentile-rank table, with **share of members in the
+  top decile** the recommended primary metric — it surfaces concentrated leadership, which an
+  equal-weighted index return dilutes. Ticket 07 still owns rotation and the exact aggregation.
+- **→ Ticket 08 (setup detection):** the §3.1 precondition gate is the **union of top deciles across
+  1w/1m/3m/6m/12m**, which passes **~29% of the universe (566 US / 82 IDX)** — not 10%. Size the
+  detection pass for that load.
+- **→ Ticket 11 (dashboard IA):** ten boards (5 lookbacks × 2 markets), 30 rows each; every row carries
+  ADR, the `k/5` breadth badge, a `NEW` marker, and a ≥30%-in-5-days flag on the 1w board; one
+  ADR-toggle control, default off. Distinct-name load per market is 112 US / 88 IDX.
+- **→ Ticket 12 (architecture):** persist rank history nightly — (name, lookback, night) with percentile
+  and raw return, all universe members, **rolling 2-year window**. Plus the operational note above:
+  persist each market's pull as it completes.
+- **→ Ticket 13 (v1 spec):** two things must be stated explicitly or they will be misread — **"top
+  decile" passes ~29%, not 10%** (R2), and **the boards are deliberately biased toward high-ADR names**
+  (R9).
+
+## Amendment to a ticket-05 decision
+
+**D6 is narrowed by R7.** "Windows count traded bars, not calendar days" applies to rolling statistics
+(ADR, median dollar volume) — its original target. **Returns are calendar-anchored.** Ticket 05's D6
+should be read with this qualification.
+
+## Probe scripts
+
+Disposable, in the job scratch dir — `rank_union.py`, `rank_probe2.py`, `scan1.py`, plus cached bar
+pickles. Throwaway venv; nothing installed into the project.

--- a/.scratch/screening-dashboard/issues/07-sector-theme-and-rotation-model.md
+++ b/.scratch/screening-dashboard/issues/07-sector-theme-and-rotation-model.md
@@ -50,8 +50,10 @@ Every number below is **measured**, not estimated. The session rebuilt the unive
 written decisions alone (median-20d `close × volume` ≥ Rp 1B / $20M, phantom `volume == 0` bars dropped,
 ≥ 20 non-phantom bars) and got **290 IDX / 1,896 US** against ticket 05's 288 / 1,966 — within 1% and 4%.
 That is the third independent session to reproduce the universe. It then pulled sector *and* industry for
-every surviving name, and computed ticket 06's calendar-anchored returns and per-lookback deciles on top,
-so the share figures below are the real distribution rather than arithmetic on assumed sector sizes.
+**every** surviving name — **289 of 290 IDX and 1,893 of 1,896 US carry a sector** (the 4 misses are
+ticket 03's delisting signal, not coverage gaps) — and computed ticket 06's calendar-anchored returns and
+per-lookback deciles on top. The share figures below are therefore the real distribution over the whole
+universe, not arithmetic on assumed sector sizes or extrapolation from a sample.
 
 ### S1 — **Industry *is* the theme layer.** The parity dilemma is dissolved, not decided
 
@@ -121,12 +123,12 @@ caveat in the UI.
 ### S4 — No sector is ever hidden, but **`k ≥ 2` is required to top the rotation board**
 
 **Measured: quantization is an IDX problem and it lands squarely on S3's default sort.** IDX's smallest
-Morningstar sectors are Technology and Utilities at **9 members each**, the largest Industrials at 33 —
-so there is nothing thin enough to *exclude*, and an exclusion floor is moot. But one name entering the
-decile moves **Technology's share by 11.1pp** and Industrials' by 3.0pp. In the measured snapshot
-Technology topped the IDX rotation differential at **+22.2pp**, which is literally **two stocks** in the
-1w decile against zero in the 6m. Sorted freely, the IDX rotation board would be led by its two smallest
-sectors on most nights.
+Morningstar sector is Utilities at **10 members**, then Technology and Healthcare at 14; the largest is
+Industrials at 43 — so nothing is thin enough to *exclude*, and an exclusion floor is moot. But one name
+entering the decile moves **Utilities' share by 10.0pp** and Technology's by 7.1pp, against Industrials'
+2.3pp. In the measured snapshot **Technology topped the IDX rotation differential at +21.4pp**, which is
+**three stocks** in the 1w decile against zero in the 6m. Sorted freely, the IDX rotation board would be
+led by its smallest sectors on most nights.
 
 So: **a sector needs at least 2 members in the shorter lookback's decile to be eligible for the top of
 the rotation board.** Single-name sectors sort into a separate group below it, still visible with their
@@ -139,24 +141,26 @@ sector rotating.**
 **Rejected: shrinkage toward the 10% baseline.** That is a smoothing parameter on the noisiest input on
 the map, and ticket 06 already rejected smoothing on the same grounds.
 
-On US the rule is nearly a no-op — one name moves a US sector share by only **0.5–3.2pp** — which is the
-correct behaviour for a rule that exists to catch thin markets.
+On US the rule is nearly a no-op — the smallest US sector is Utilities at 59 members and the largest
+Technology at 340, so one name moves a US sector share by only **0.3–1.7pp** — which is the correct
+behaviour for a rule that exists to catch thin markets.
 
 ### S5 — **One industry board**, and a ranked industry needs `n ≥ 10`
 
-**IDX cannot support an industry leaderboard on its own numbers**: 75 industries across its universe,
-**median size 2**, **32 industries with exactly one member**, only 4 with ten or more. The shares are
-noise by construction — Real Estate Services reads 66.7% on 1m, which is 4 names of 6.
+**IDX cannot support an industry leaderboard on its own numbers**: **87 industries** across its 289
+names, **median size 2**, **38 industries with exactly one member**, only 7 with ten or more. The shares
+are noise by construction — Real Estate Services reads **57.1% on 1m, which is 4 names of 7**.
 
-**US can**: ~135 industries with a median size of 5 and a long tail of real mass — Biotechnology 58,
-Software-Application 49, Banks-Regional 49, Software-Infrastructure 37.
+**US can**: **139 industries, median size 9, only 5 singletons, and 63 at ten or more** — with real mass
+in the head: Biotechnology 107, Software-Application 85, Banks-Regional 80, Software-Infrastructure 75,
+Semiconductors 44.
 
 The ruling is **one rule applied identically to both markets: an industry is ranked if it has ≥ 10
-members.** That yields roughly 55 rows on US and exactly **4 on IDX** (Banks-Regional 18, Farm Products
-14, Real Estate-Development 12, Thermal Coal 10). **Parity of rule, not parity of result** — the market's
-own data density decides the yield and no market is special-cased. An IDX industry board reading Thermal
-Coal / Farm Products / Banks / Real Estate is not degenerate; those are close to the actual Indonesian
-themes.
+members.** That yields **63 rows on US and exactly 7 on IDX** (Banks-Regional 19, Farm Products 18,
+Real Estate-Development 17, Thermal Coal 15, Packaged Foods 12, Marine Shipping 12, Other Industrial
+Metals & Mining 10). **Parity of rule, not parity of result** — the market's own data density decides the
+yield and no market is special-cased. An IDX industry board reading Thermal Coal / Farm Products / Marine
+Shipping / Other Industrial Metals is not degenerate; those are close to the actual Indonesian themes.
 
 **`n ≥ 10` is derived, not picked**: it is exactly the point at which one name can move the share by at
 most 10pp — the decile baseline itself. Below it, a single stock can swing an industry by more than its
@@ -177,10 +181,10 @@ denominator — fixes it exactly, dropping the rule to a **stable 52% on IDX acr
 one point out of ten, firing about half the time is where a binary belongs.
 
 **Rejected: the industry-peer rule** ("at least one *other* name in this stock's industry is also in the
-decile"). It is closer to §10's "strength clusters," but it measured **24–55% on IDX against 79–86% on
-US** — a ~3× swing, so the same rubric line would mean genuinely different things in the two markets. It
-is also **structurally unavailable to a third of IDX names**: 32 IDX industries have exactly one member,
-so those stocks could never earn the point however strong their theme.
+decile"). It is closer to §10's "strength clusters," but it measured **24–55% on IDX against a flat
+88–89% on US** — so the same rubric line would be a coin-flip in one market and nearly free in the other.
+It is also **structurally unavailable to many IDX names**: 38 IDX industries have exactly one member, so
+those stocks could never earn the point however strong their theme.
 
 **1m rather than the lookback the stock qualified on**, because §3.5 already scores the stock's own
 momentum separately under "prior move strength (top decile 1–6m)". This dimension asks whether the
@@ -189,9 +193,9 @@ momentum separately under "prior move strength (top decile 1–6m)". This dimens
 **Industry appears on the candidate row as context** — "Thermal Coal, 20% of members in the 1m decile" —
 but **does not score**, so no name is penalised for being alone in its industry.
 
-**Named cost, accepted:** the rule is not symmetric across markets. It fires **52% on IDX but 63–77% on
-US**. It still discriminates on both (the all-names baseline is 33–46%), and it is far more stable than
-the industry-peer alternative it replaced.
+**Named cost, accepted:** the rule is not symmetric across markets. It fires **52% on IDX — identical on
+1m, 3m and 6m — but 61–79% on US**. It still discriminates on both (the all-names baseline is 36–46%),
+and it is far more stable than the industry-peer alternative it replaced.
 
 ### S7 — §10's "pullbacks are information" is **emergent**, not a feature
 
@@ -229,8 +233,9 @@ first. The note states this.
 ### S9 — Sector/industry cache: new names block, 1/30th rolls nightly, a failed fetch never nulls
 
 Ticket 03 established that sector costs **one request per symbol**. This session measured the full
-universe at **1.2s spacing with zero throttling across ~1,900 consecutive calls** — so ticket 03's 2s
-recommendation was conservative, and a full pass is ~45 minutes rather than 75. Still far too long for
+universe at **1.2s spacing with zero throttling across ~1,850 consecutive calls** (every row returned
+`ok`; the only non-`ok` values were the 4 genuine `no_sector` delistings) — so ticket 03's 2s
+recommendation was conservative, and a full pass is ~48 minutes rather than 75. Still far too long for
 the nightly job.
 
 - **New names block.** A symbol entering the universe has sector/industry fetched *before* it can appear

--- a/.scratch/screening-dashboard/issues/07-sector-theme-and-rotation-model.md
+++ b/.scratch/screening-dashboard/issues/07-sector-theme-and-rotation-model.md
@@ -1,7 +1,7 @@
 # Sector/theme leadership and rotation model
 
 Type: grilling
-Status: open
+Status: resolved
 Blocked by: 03, 06
 
 ## Question
@@ -43,3 +43,216 @@ How does the app decide what is leading, and what does "where the rotation goes"
   must define it precisely enough to be computed as a boolean.
 
 Resolve against `references/qullamaggie-method.md` §1 and §10.
+
+## Answer
+
+Every number below is **measured**, not estimated. The session rebuilt the universe from ticket 05's
+written decisions alone (median-20d `close × volume` ≥ Rp 1B / $20M, phantom `volume == 0` bars dropped,
+≥ 20 non-phantom bars) and got **290 IDX / 1,896 US** against ticket 05's 288 / 1,966 — within 1% and 4%.
+That is the third independent session to reproduce the universe. It then pulled sector *and* industry for
+every surviving name, and computed ticket 06's calendar-anchored returns and per-lookback deciles on top,
+so the share figures below are the real distribution rather than arithmetic on assumed sector sizes.
+
+### S1 — **Industry *is* the theme layer.** The parity dilemma is dissolved, not decided
+
+Ticket 03 escalated a four-way choice — US-only ETF holdings (breaks "both markets"), LLM tagging (a paid
+line item in a free-data v1), correlation clustering (unnamed, unstable), or hand-curation — and all four
+are now moot. Yahoo returns **`industry` in the same `.info` request as `sector`**, at no additional cost:
+145 industries under the 11 GECS sectors, identical vocabulary on `.JK` and US. Ticket 03 noticed
+`Uranium` as "one lucky exception"; it is not an exception, it is the level the whole taxonomy sits at —
+`Thermal Coal`, `Solar`, `Semiconductors`, `Biotechnology`, `Gold`, `Steel`, `Marine Shipping`.
+
+So the theme layer is **free, both markets, one request, no scraper, no LLM, no curation, no staleness**,
+and v1 stays entirely free-data.
+
+**A stock has exactly one industry**, assigned by Yahoo — so the ticket's "one theme or many?" question
+does not arise, and there is no curation backlog.
+
+**Named cost, accepted:** an industry is not a *narrative*. "Nickel downstream" spans Other Industrial
+Metals, Steel and Auto Parts; "GLP-1" spans two drug makers plus device names; "AI" spans Semiconductors,
+Software-Infrastructure and Utilities. Industry catches a theme when the theme happens to *be* an
+industry — which is most of the time on IDX (coal, nickel, gold, banks, agri) and less often on US, where
+the loudest themes are cross-industry. A narrative theme layer is therefore **ruled out of scope for v1**
+(see the map's Out of scope). You will see the constituent industries move together and read the
+narrative yourself.
+
+### S2 — Sector strength = **share of members in that lookback's top decile**, five numbers per sector
+
+One per **1w / 1m / 3m / 6m / 12m** — the same five boards ticket 06 defined — aggregated over its
+(name, lookback, night) rank table per R6, so there is **no second definition of "strong."**
+
+**Per-lookback deciles, not the §3.1 union gate.** Ticket 06 measured the union gate at ~29% of the
+universe, so a share-of-gate-members metric would sit near 29% for every sector and discriminate poorly.
+A per-lookback decile makes **10% the fair share** by construction, so 25–30% is visibly leading and 0%
+is visibly dead.
+
+**Rejected:** an equal- or cap-weighted sector index return, and the US sector-ETF proxy. Ticket 06's R6
+already gave the reason — a sector where 8 of 40 names are ripping and 32 are flat has a mediocre index
+return but is exactly the sector to surface, because leadership concentrates before it broadens. The ETF
+route would additionally have needed a *different* metric per market, since IDX has no thematic or
+sector-ETF reference layer worth using. Member-rank aggregation is identical on both by construction.
+
+### S3 — Rotation is **two sortable columns**, not a sparkline and not a composite
+
+The session first proposed leaving rotation to the eye — the shape across lookbacks, read off a
+sparkline. **The trader overruled it: rotation must be computed and sortable.** Delivered as two columns,
+because one number cannot carry both readings:
+
+- **Shape differential** — `share(1w) − share(6m)`, in percentage points. **Zero tunable parameters, no
+  history required**, and it cannot drift from ticket 06's definition of strong because it is arithmetic
+  on two numbers already on the row. Positive = rotating in, negative = rotating out. **This is the
+  default sort.**
+- **Temporal delta** — `share(1m, tonight) − share(1m, 20 sessions ago)`. The 20 is **inherited, not
+  invented**: §2 puts the daily chart on the 10/20 MAs and §3.5 scores MA support on the 10 and 20, so
+  the method already fixes 20 as its swing horizon.
+
+They disagree usefully, which is why both exist: a sector can be structurally hot (high differential)
+while its share has been *falling* for a month — a rotation that already happened and is decaying. The
+differential alone cannot separate genuine fresh leadership from a one-week dead-cat bounce in a sector
+dead for six months.
+
+**No composite of the two, and no threshold on either** — they are columns you sort, not a verdict.
+
+**Named cost:** the temporal delta is the noisiest column on the board. Ticket 06 measured a ~1.5pp noise
+floor from denominator churn alone, and on a thin sector one name entering the universe moves the share
+several points by itself. Twenty sessions averages some of that out, but not to zero. It carries a noise
+caveat in the UI.
+
+### S4 — No sector is ever hidden, but **`k ≥ 2` is required to top the rotation board**
+
+**Measured: quantization is an IDX problem and it lands squarely on S3's default sort.** IDX's smallest
+Morningstar sectors are Technology and Utilities at **9 members each**, the largest Industrials at 33 —
+so there is nothing thin enough to *exclude*, and an exclusion floor is moot. But one name entering the
+decile moves **Technology's share by 11.1pp** and Industrials' by 3.0pp. In the measured snapshot
+Technology topped the IDX rotation differential at **+22.2pp**, which is literally **two stocks** in the
+1w decile against zero in the 6m. Sorted freely, the IDX rotation board would be led by its two smallest
+sectors on most nights.
+
+So: **a sector needs at least 2 members in the shorter lookback's decile to be eligible for the top of
+the rotation board.** Single-name sectors sort into a separate group below it, still visible with their
+numbers intact. **Every row carries `k/n` beside the share** — `2/9` reads as fragile where `22.2%` reads
+as leadership, the same device ticket 06 used with its `k/5` breadth badge.
+
+`k ≥ 2` is not a tuned threshold; it is **§10's "strength clusters" stated literally — one stock is not a
+sector rotating.**
+
+**Rejected: shrinkage toward the 10% baseline.** That is a smoothing parameter on the noisiest input on
+the map, and ticket 06 already rejected smoothing on the same grounds.
+
+On US the rule is nearly a no-op — one name moves a US sector share by only **0.5–3.2pp** — which is the
+correct behaviour for a rule that exists to catch thin markets.
+
+### S5 — **One industry board**, and a ranked industry needs `n ≥ 10`
+
+**IDX cannot support an industry leaderboard on its own numbers**: 75 industries across its universe,
+**median size 2**, **32 industries with exactly one member**, only 4 with ten or more. The shares are
+noise by construction — Real Estate Services reads 66.7% on 1m, which is 4 names of 6.
+
+**US can**: ~135 industries with a median size of 5 and a long tail of real mass — Biotechnology 58,
+Software-Application 49, Banks-Regional 49, Software-Infrastructure 37.
+
+The ruling is **one rule applied identically to both markets: an industry is ranked if it has ≥ 10
+members.** That yields roughly 55 rows on US and exactly **4 on IDX** (Banks-Regional 18, Farm Products
+14, Real Estate-Development 12, Thermal Coal 10). **Parity of rule, not parity of result** — the market's
+own data density decides the yield and no market is special-cased. An IDX industry board reading Thermal
+Coal / Farm Products / Banks / Real Estate is not degenerate; those are close to the actual Indonesian
+themes.
+
+**`n ≥ 10` is derived, not picked**: it is exactly the point at which one name can move the share by at
+most 10pp — the decile baseline itself. Below it, a single stock can swing an industry by more than its
+entire fair share.
+
+Industries below the floor are **not hidden** — they remain as the per-candidate tag (S6), just unranked.
+
+### S6 — §3.5 sector/theme confirmation = **leave-one-out sector share ≥ 10% on the 1m lookback**
+
+The measurement caught a trap that would otherwise have shipped. The obvious rule — "the candidate's
+sector share is ≥ the 10% baseline" — fires **77–90%** of the time, and not because sectors are hot: it
+is a **selection effect**. The stock being tested is itself in the top decile, and its own membership
+inflates its own sector's share. The point would be nearly free, and a dimension that fires 90% of the
+time carries no information in a 10-point rubric.
+
+Computing the share **leave-one-out** — excluding the candidate from its own sector's numerator *and*
+denominator — fixes it exactly, dropping the rule to a **stable 52% on IDX across 1m, 3m and 6m**. For
+one point out of ten, firing about half the time is where a binary belongs.
+
+**Rejected: the industry-peer rule** ("at least one *other* name in this stock's industry is also in the
+decile"). It is closer to §10's "strength clusters," but it measured **24–55% on IDX against 79–86% on
+US** — a ~3× swing, so the same rubric line would mean genuinely different things in the two markets. It
+is also **structurally unavailable to a third of IDX names**: 32 IDX industries have exactly one member,
+so those stocks could never earn the point however strong their theme.
+
+**1m rather than the lookback the stock qualified on**, because §3.5 already scores the stock's own
+momentum separately under "prior move strength (top decile 1–6m)". This dimension asks whether the
+*sector* is hot now, and 1m is the shortest read that is not 1w noise.
+
+**Industry appears on the candidate row as context** — "Thermal Coal, 20% of members in the 1m decile" —
+but **does not score**, so no name is penalised for being alone in its industry.
+
+**Named cost, accepted:** the rule is not symmetric across markets. It fires **52% on IDX but 63–77% on
+US**. It still discriminates on both (the all-names baseline is 33–46%), and it is far more stable than
+the industry-peer alternative it replaced.
+
+### S7 — §10's "pullbacks are information" is **emergent**, not a feature
+
+A decile is **cross-sectional** — always a ranking against the rest of the market, never against zero.
+So in a market that fell 8% over the past month, the names in the 1m top decile *are* the names that held
+up. **The sector shares computed on a falling tape already are the pullback-RS reading.** There is
+nothing to add and nothing to tune.
+
+Making it explicit would have required detecting "the most recent pullback," which needs a drawdown
+threshold and a window — and ticket 10 drove the regime filter to *zero* tunables precisely because
+survivorship bias makes thresholds like that uncalibratable.
+
+**Surfaced as copy, not computation:** when ticket 10's regime banner reads `CHOPPY` or `HOSTILE`, the
+sector board carries a one-line note that these shares are reading relative strength through a decline.
+
+**Named limit:** §10 also says the *deep washout* case inverts — the first bounce is led by the most
+beaten-down junk, not the RS names. The shares cannot distinguish a mild pullback from a washout, because
+that requires measuring drawdown depth, which ticket 10 deliberately declined to measure. So in a washout
+the board points at RS names during the exact regime where §10 says RS names are not the ones that bounce
+first. The note states this.
+
+### S8 — Sector strength **never filters**; every sector always renders; computed per market
+
+- **Never filters.** It contributes its one point to the star score (S6) and it is a board you read. It
+  does not gate, reorder, or remove candidates. Direct parallel to ticket 10's advisory-only regime
+  filter and ticket 06's report-rather-than-judge stance.
+- **All 11 sectors always render**, both markets, even at 0% on every lookback. A dead sector is
+  information, and hiding it would violate ticket 05's "absence of data means nothing."
+- **Computed per market, displayed on a shared axis.** Ticket 03 measured Technology at 27% of its US
+  sample and 1% of its IDX sample, so a pooled cross-market ranking would make "Technology is leading on
+  IDX" a statement about one or two stocks. Ticket 06 already fixed ranking as per-market. Two rankings,
+  one 11-sector axis, side by side.
+- **Layout belongs to ticket 11.** This ticket fixes the numbers and the eligibility rules only.
+
+### S9 — Sector/industry cache: new names block, 1/30th rolls nightly, a failed fetch never nulls
+
+Ticket 03 established that sector costs **one request per symbol**. This session measured the full
+universe at **1.2s spacing with zero throttling across ~1,900 consecutive calls** — so ticket 03's 2s
+recommendation was conservative, and a full pass is ~45 minutes rather than 75. Still far too long for
+the nightly job.
+
+- **New names block.** A symbol entering the universe has sector/industry fetched *before* it can appear
+  anywhere — a name with no industry cannot be placed on the axis, so this is correctness, not cost. At
+  ticket 05's measured churn (~30 US / ~8 IDX a night) that is under 90 requests, ~2 minutes.
+- **Existing names refresh on a rolling 1/30th slice nightly** — ~73 names, ~2 minutes — so the whole
+  universe turns over every 30 days with no wholesale pass and bounded staleness. Nightly cost stays flat
+  as the universe grows.
+- **A failed fetch never nulls a cached value.** Straight from ticket 03's "Yahoo throttling fails as
+  silence" and ticket 05's "removal requires stronger evidence than admission": on throttle or error the
+  name keeps yesterday's industry and is retried, never blanked.
+
+Net: ~4 minutes added to the nightly run, worst-case 30-day staleness on reclassification, **zero**
+staleness on new names — which is what the ticket's "themes are born fast, and that is exactly when they
+matter" actually demanded.
+
+### Hand-offs
+
+- **→ Ticket 11 (dashboard IA):** three boards to lay out per market — 11 sector rows with five shares
+  plus two rotation columns; the ranked-industry board; and the per-candidate industry tag. Plus the
+  regime-conditional pullback note (S7) and the `k/n` fragility device (S4).
+- **→ Ticket 08 (setup detection):** S6 is the computable boolean for the §3.5 "sector/theme
+  confirmation" line — leave-one-out sector share ≥ 10% on 1m.
+- **→ Ticket 12 (architecture):** sector/industry is a cached table with the S9 refresh policy, and
+  nightly sector-share history is a **fifth** persisted stream (see the map's validation fog).

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -108,6 +108,32 @@ is written during wayfinding.
   twice. Rank history persists nightly on a **rolling 2-year window**. The session also **reproduced
   ticket 05's universe exactly (1,966 / 288) from its written decisions alone**.
 
+- [Sector/theme leadership and rotation model](issues/07-sector-theme-and-rotation-model.md) — **industry
+  *is* the theme layer**, which dissolves ticket 03's four-way parity dilemma rather than deciding it:
+  Yahoo returns `industry` in the *same* request as `sector`, so 145 industries arrive free on both
+  markets — no scraper, no LLM line item, no curation, no staleness — and v1 stays entirely free-data. A
+  narrative layer spanning industries ("nickel downstream", "GLP-1") is ruled **out of scope**. Sector
+  strength is **share of members in that lookback's top decile, five numbers per sector** (1w/1m/3m/6m/12m),
+  aggregated over ticket 06's rank table per R6 — per-lookback deciles, *not* the §3.1 union gate, which
+  would park every sector near 29%. **Rotation is two sortable columns**: the **shape differential**
+  `share(1w) − share(6m)` (zero tunables, no history, default sort) and a **20-session temporal delta**
+  whose window is inherited from §2/§3.5's 10/20-day horizon, not invented — the trader overruled the
+  session's sparkline-and-eyeball proposal and required it computed. **Quantization is an IDX problem**:
+  one name moves IDX Technology's share **11.1pp** (vs 0.5–3.2pp on US), and Technology topped the measured
+  IDX rotation board at +22.2pp on *two stocks* — so a sector needs **`k ≥ 2` in the decile to top the
+  board**, with `k/n` on every row; nothing is ever hidden, and shrinkage was rejected as smoothing.
+  **IDX cannot carry an industry leaderboard** (median industry size 2, 32 singletons), US can (~135
+  industries, Biotechnology 58) — resolved as **one rule, `n ≥ 10` to be ranked**, yielding ~55 US rows and
+  4 IDX rows: parity of rule, not of result. §3.5's confirmation boolean is **leave-one-out sector share
+  ≥ 10% on 1m** — the leave-one-out is load-bearing, because a candidate inflates its own sector and the
+  naive rule fires 77–90%, making the point nearly free; the industry-peer alternative was rejected for
+  swinging 24–55% (IDX) vs 79–86% (US) and being unavailable to a third of IDX names. §10's pullback-RS is
+  **emergent** — a decile is cross-sectional, so on a falling tape the 1m decile *is* what held up — surfaced
+  as regime-conditional copy, with the washout inversion stated as a limit. Sector strength **never filters**.
+  Cache: **new names block, 1/30th rolls nightly, a failed fetch never nulls**. The session also
+  **reproduced the universe a third time (290/1,896)** and measured **1.2s Yahoo spacing as throttle-free**,
+  halving ticket 03's assumed full-pass cost.
+
 ## Not yet specified
 
 - **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
@@ -123,7 +149,10 @@ is written during wayfinding.
   launch. **Ticket 06 adds a fourth** — nightly percentile rank and raw return per (name, lookback), so
   a future validation can ask not just what was rankable but *where it ranked*. Together — what was
   listed, what was rankable, where it ranked, what was signalled — they are the seed of whatever
-  validation eventually becomes possible.
+  validation eventually becomes possible. **Ticket 07 adds a fifth** — nightly sector and ranked-industry
+  shares, so a future study can ask whether sector leadership actually preceded the moves, and can replay
+  the rotation columns rather than only the per-name ranks. It is a few hundred KB a year and, like the
+  other four, irrecoverable if not started at launch.
   **Two constraints ticket 06 puts on that seed, which sharpen this patch rather than clear it:** the
   rank stream is the first that **discards** — a rolling 2-year window was chosen deliberately, so a
   multi-year study is foreclosed unless a coarser permanent archive is added later (a few MB/year); and
@@ -148,6 +177,13 @@ is written during wayfinding.
 
 ## Out of scope
 
+- **Narrative theme layer spanning industries** — "nickel downstream", "GLP-1", "AI" as named, curated
+  themes. Ruled out by [Sector/theme leadership and rotation model](issues/07-sector-theme-and-rotation-model.md):
+  Yahoo's 145-industry level arrives free with sector and covers the theme question wherever the theme
+  *is* an industry (most of the time on IDX). The remainder — genuinely cross-industry narratives — would
+  cost either a paid LLM tagging pass, a US-only ETF-holdings scraper that breaks market parity, or
+  ongoing hand-curation. Not on the route to a v1 spec. The option survey is preserved in
+  [ticket 03's findings](research/03-sector-taxonomy.md) if it ever becomes its own effort.
 - **Episodic Pivot (§4)** — deferred by the method reference itself; needs intraday/pre-market data.
 - **Parabolic short (§5)** — not practically available on IDX, largest blow-up risk.
 - **Position sizing calculator (§8)** — considered and ruled out of v1.

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -119,15 +119,15 @@ is written during wayfinding.
   `share(1w) − share(6m)` (zero tunables, no history, default sort) and a **20-session temporal delta**
   whose window is inherited from §2/§3.5's 10/20-day horizon, not invented — the trader overruled the
   session's sparkline-and-eyeball proposal and required it computed. **Quantization is an IDX problem**:
-  one name moves IDX Technology's share **11.1pp** (vs 0.5–3.2pp on US), and Technology topped the measured
-  IDX rotation board at +22.2pp on *two stocks* — so a sector needs **`k ≥ 2` in the decile to top the
-  board**, with `k/n` on every row; nothing is ever hidden, and shrinkage was rejected as smoothing.
-  **IDX cannot carry an industry leaderboard** (median industry size 2, 32 singletons), US can (~135
-  industries, Biotechnology 58) — resolved as **one rule, `n ≥ 10` to be ranked**, yielding ~55 US rows and
-  4 IDX rows: parity of rule, not of result. §3.5's confirmation boolean is **leave-one-out sector share
-  ≥ 10% on 1m** — the leave-one-out is load-bearing, because a candidate inflates its own sector and the
-  naive rule fires 77–90%, making the point nearly free; the industry-peer alternative was rejected for
-  swinging 24–55% (IDX) vs 79–86% (US) and being unavailable to a third of IDX names. §10's pullback-RS is
+  one name moves IDX Utilities' share **10.0pp** (vs 0.3–1.7pp anywhere on US), and Technology topped the
+  measured IDX rotation board at +21.4pp on *three stocks* — so a sector needs **`k ≥ 2` in the decile to
+  top the board**, with `k/n` on every row; nothing is ever hidden, and shrinkage was rejected as smoothing.
+  **IDX cannot carry an industry leaderboard** (87 industries, median size 2, 38 singletons), US can (139
+  industries, median size 9, Biotechnology 107) — resolved as **one rule, `n ≥ 10` to be ranked**, yielding
+  63 US rows and 7 IDX rows: parity of rule, not of result. §3.5's confirmation boolean is **leave-one-out
+  sector share ≥ 10% on 1m** — the leave-one-out is load-bearing, because a candidate inflates its own
+  sector and the naive rule fires 77–90%, making the point nearly free; the industry-peer alternative was
+  rejected for swinging 24–55% (IDX) vs a flat 88–89% (US) and being unavailable to 38 IDX singletons. §10's pullback-RS is
   **emergent** — a decile is cross-sectional, so on a falling tape the 1m decile *is* what held up — surfaced
   as regime-conditional copy, with the washout inversion stated as a limit. Sector strength **never filters**.
   Cache: **new names block, 1/30th rolls nightly, a failed fetch never nulls**. The session also

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -91,6 +91,23 @@ is written during wayfinding.
   follow-through is **captured nightly from day one but never shown or gated in v1** — it is the only
   unbiased regime signal available and is irrecoverable if not started at launch.
 
+- [Ranking and decile model](issues/06-ranking-and-decile-model.md) — **the gate and the leaderboard are
+  two different cuts**, which dissolves ticket 05's "a decile of 1,966 is unreviewable" hand-off. The
+  §3.1 gate is a **union of top deciles across 1w/1m/3m/6m/12m** — measured at **566 US / 82 IDX**, so
+  **"top decile" passes ~29% of the universe, not 10%**, and the 28.8%/28.5% agreement across two
+  markets differing 7× in size shows a percentile gate is self-normalising. The leaderboard is **five
+  separate boards per market, 30 rows each** — N=30 is simultaneously §1's "top 1–2% of gainers" on US
+  and IDX's natural decile. Returns are **calendar-anchored on adjusted closes, which narrows D6**
+  (traded-bar windows stay for ADR and dollar volume only). The model **reports rather than judges**:
+  **pure return, no volatility adjustment** (normalising would replace up to 20 of 30 US rows), **no
+  smoothing** (the 1w board turns over 16 of 30 nightly and that is honest), **ADR does nothing by
+  default** — a column plus one toggle, off everywhere. Rows carry a **`k/5` breadth badge** (only 3 of
+  1,964 US names lead all five windows) and a **`NEW` marker**; §1's "up ≥30% in 5 days" is a **flag on
+  the 1w board**, with the accepted failure mode that a hot tape hides the names below rank 30. Ranking
+  is a **shared service** — ticket 07 aggregates over its rank table rather than defining strength
+  twice. Rank history persists nightly on a **rolling 2-year window**. The session also **reproduced
+  ticket 05's universe exactly (1,966 / 288) from its written decisions alone**.
+
 ## Not yet specified
 
 - **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
@@ -103,8 +120,16 @@ is written during wayfinding.
   can ask what was actually rankable on a given night, not merely what was listed. **Ticket 10 adds a
   third** — every detected setup and its trigger level, written nightly from launch. All three exist for
   the same reason: they are unbiased *and* irrecoverable after the fact, so the clock has to start at
-  launch. Together — what was listed, what was rankable, what was signalled — they are the seed of
-  whatever validation eventually becomes possible.
+  launch. **Ticket 06 adds a fourth** — nightly percentile rank and raw return per (name, lookback), so
+  a future validation can ask not just what was rankable but *where it ranked*. Together — what was
+  listed, what was rankable, where it ranked, what was signalled — they are the seed of whatever
+  validation eventually becomes possible.
+  **Two constraints ticket 06 puts on that seed, which sharpen this patch rather than clear it:** the
+  rank stream is the first that **discards** — a rolling 2-year window was chosen deliberately, so a
+  multi-year study is foreclosed unless a coarser permanent archive is added later (a few MB/year); and
+  the stored ranks carry a **~1.5% noise floor** from denominator churn (30 US / 8 IDX names entering or
+  leaving the universe overnight even with D11's hysteresis), so small percentile moves are not
+  necessarily price moves. Whatever validation becomes possible has to be robust to both.
 - **Alerting.** He hangs price alerts on the trendline. Whether v1 notifies at all, and through what
   channel, waits on detection being defined. Running locally narrows the options — a desktop
   notification or a nightly digest, not a push service.

--- a/references/qullamaggie-method.md
+++ b/references/qullamaggie-method.md
@@ -1,0 +1,407 @@
+# Qullamaggie Method — Core Reference
+
+Distilled from ~360 Kristjan Kullamägi (Qullamaggie) stream/video transcripts (~2.2M words).
+Everything below is what he actually says in the transcripts. Parameters that he never states numerically
+have been **resolved by Aji** and are marked `[SET BY AJI]` — those are house rules, not his words.
+
+---
+
+## 0. Operating philosophy
+
+- Three setups only: **Breakout/Continuation**, **Episodic Pivot (EP)**, **Parabolic Short**. Nothing else.
+- He is a **home-run trader**: most trades scratch or lose small; roughly 10–15% of trades produce
+nearly all of the P&L. The method is engineered so the winners are allowed to run.
+- Edge comes from **stock selection + tight stops**, not prediction. Price action dictates; no macro calls.
+- He invented none of it — ADR, the EP, the breakout, the parabolic short are all borrowed (Minervini,
+Dan Zanger, Stockbee lineage). Pattern recognition on the *strongest* stocks is the skill.
+- Repeated hard filter: **do not trade slow or choppy stocks.** No momentum, no ADR, no trade.
+
+---
+
+
+
+## 1. Universe & scanning
+
+
+
+### Liquidity floor `[SET BY AJI]`
+
+
+| Market  | Minimum average daily dollar volume           |
+| ------- | --------------------------------------------- |
+| **US**  | **$20,000,000 / day** (his own stated cutoff) |
+| **IDX** | **Rp 1,000,000,000 / day**                    |
+
+
+> **Sizing caveat (not his rule — worth adding):** Rp 1B/day is thin in absolute terms. His US floor exists so
+> that a 10–20% position can be entered and exited without slippage. On IDX, add a second constraint:
+> **intended position value ≤ ~5–10% of the stock's average daily value traded**, or the exit at the stop
+> won't be reachable at the stop. This binds *before* the Rp 1B floor does once your account grows.
+
+
+
+### Volatility floor (ADR)
+
+- Focus on stocks with **ADR ≥ 4–5%**. He rejects names on the spot for being slow:
+1.9 ADR, 2.4 ADR, 2.8 ADR → "you shouldn't even be trading this thing."
+- ADR is the *primary* stock-quality filter, above market cap. For a small account: high-ADR names, market cap irrelevant.
+- Comparative logic he uses out loud: if two vehicles express the same theme, take the higher-ADR one
+(e.g. a 7.6-ADR name over a 2.4-ADR ETF on the same sector; AGQ at 4.9 ADR over SLV at 2.6).
+
+
+
+### ADR definition (settled — TradingView)
+
+```pine
+//@version=5
+indicator("ADR %")
+length = input.int(20)
+adr    = 100 * (ta.sma(high / low, length) - 1)
+plot(adr)
+```
+
+Equivalently `ADR% = SMA20( (High / Low − 1) × 100 )` — identical, since SMA is linear.
+
+Caveat to be aware of, not to fix: on stream he sometimes describes ADR as gap-inclusive (today's high vs
+*yesterday's* low, "like ATR but it includes gaps"). The formula above is **intraday-range only and excludes
+gaps**, so a habitual gapper screens *lower* than it really moves. Immaterial for flags; **matters for EPs** —
+the `3 × ADR` gap test in §4 is therefore slightly generous. All ADR thresholds in this document assume the
+TradingView definition.
+
+### The scans (nightly / weekly)
+
+1. **Up ≥ 30% in the past 5 days**
+2. **Biggest gainers over 1 / 3 / 6 / 12 / 18 / 24 months**
+3. **Intraday gainers + pre-market gappers** (for EPs)
+4. **His watchlist**, built from 1–3
+
+A "momentum leader" = a stock in the **top 1–2% of gainers** over some lookback (1m / 3m / 6m).
+His tradeable US universe at size: roughly **150 stocks**. Nightly review: ~10 minutes.
+
+---
+
+
+
+## 2. Chart setup
+
+
+| Timeframe     | Moving averages                                                                                               |
+| ------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Daily**     | 10, 20, 50 (and 100/150/200 for context) — **simple**. The *only* exponential on the daily is the **65 EMA**. |
+| **60-minute** | 10, 20, 65 — **exponential only**.                                                                            |
+
+
+Plus ADR(20) and dollar volume as displayed columns.
+
+Why they matter: the strongest stocks **"surf" the rising 10 and 20** and rarely violate them. Price riding the
+rising 10/20/65 EMA on the 60-min = *frontside*. Those same EMAs flipping to resistance = *backside*.
+
+---
+
+
+
+## 3. Setup 1 — Breakout / Continuation (the bread and butter)
+
+
+
+### 3.1 Preconditions
+
+1. **A big prior move.** `[SET BY AJI]` The stock must sit in the **top decile of 1–6 month returns** within its
+  universe (IDX or US). This is the gate that separates a real flag from a random consolidation.
+2. **Consolidation after the move**: sideways, **higher lows**, **range contraction** — it gets *tight*.
+3. **Minimum consolidation length** `[SET BY AJI]`: **3–5 days sideways, minimum, for every variant**
+  (flag, HTF, triangle, base). Shorter than that and there is no range to break.
+4. **The 10-day and 20-day catch up** to price during the consolidation. He repeatedly refuses setups with
+  "it needs a few more days sideways for the 20-day to catch up," and states a preference for
+   **20-day-based setups over 10-day ones** ("I never trust the 10-day ones").
+5. Ideally the pullback found support on a **rising 10 / 20 / 50-day**.
+6. **Break of the range on volume.**
+
+
+
+### 3.2 Geometry — how he actually draws the trendline
+
+*Sources: the video transcripts, plus a community explainer (ZM / AR / APPS worked examples) that quotes Kris
+directly. Quotes below marked **[K]** are his words; the rest is the explainer's reconstruction of his method.*
+
+**The gate first:**
+
+> **Draw the triangle. Connect the lower highs with a descending line; connect the higher lows with a rising line.
+> If you cannot draw a triangle — if there is no range and no higher lows — there is no setup. Full stop.**
+
+He says this almost verbatim, repeatedly: *"if you can't draw a triangle, there's no setup."*
+
+**But drawing it correctly is the part everyone gets wrong.** Three rules:
+
+**(1) The trendline visualizes the trend and sets the alert. That's all it is.**
+Two functions only: see the tightening, and hang a price alert on the line. It is not a magic level.
+
+**(2) Do not connect random points — connect the *overall trend*.**
+
+- **[K]** *"Trendlines, connecting some random points, I don't believe in that."*
+- **[K]** *"It's the overall trend — these undercuts and overshoots, they're normal. You want to see the overall trend."*
+- **[K]** *"You'll see a lot of these trendlines and triangles I draw, the price moves both above and below them.
+You **want** these undercuts and overshoots, you want those false breakdowns and false breakouts — that's where
+you build setup strength. You need to look at the overall trend... you can clearly see it's getting tighter and
+tighter. You want to visualise the tightness."*
+
+So: candles poking through the line in both directions is **correct and desirable**. A line that every candle
+respects perfectly is a line drawn on too few points. The false breaks *are* the base-building.
+
+**(3) The drawing procedure — find the tight cluster first, then extrapolate backwards.**
+
+> **Find a tight range  sitting on a rising moving average → anchor the line there →
+> extrapolate it backwards over the prior highs.**
+
+This is the inversion most people miss. The naive method — connect the recent swing highs and wait for a break
+above them — produces a **late entry**, far from the moving average, with a wide stop. (The APPS example in the
+explainer: connect-the-highs gives you an entry that "would not have been great.") Drawing from the tight cluster
+gives you a line that price crosses **while it is still hugging the 10/20/50-day**.
+
+**Why this matters more than it looks — it's the load-bearing link to your stop rule:**
+
+> *"Kris always buys very close to his moving averages. That's another thing you can't do if you wait for the
+> 'true' range break above recent highs."*
+
+Buying at/near the rising MA is what makes a **≤ 1 × ADR stop (§7)** physically possible. Wait for the textbook
+break of the recent high and the MA is now 8–10% below you, the stop is unaffordable, and the trade is dead on
+arrival. **The geometry rule and the stop rule are the same rule.**
+
+Corollary, from Kris on $AR: by the time price cleared the obvious highs he said **[K]** *"there is no setup —
+the setup was a few days ago off the 50d."* The setup is at the MA, not at the high.
+
+**(4) A breakout by itself is not an edge.**
+
+- **[K]** *"A breakout is not an edge. You need to buy breakouts in the right stocks — just a breakout is not an edge."*
+This is why §3.1's top-decile prior-move gate exists. The line is worthless on a stock that shouldn't be on the
+watchlist in the first place.
+
+**Other notes:**
+
+- **Names don't matter.** Triangle, wedge, pennant, flag, channel — he shrugs at the vocabulary ("I call it a
+triangle, the fancy word is wedge I guess"). What matters is **converging boundaries + higher lows + tightening**.
+He mocks rigid HTF definitions: most are too strict and will make you miss the best setups. Whether the pullback
+was 10% or 35% is not the test.
+- **Channel** = same thing with parallel rather than converging boundaries. Same treatment.
+- **Bear flag** = exact mirror (big move down, lower highs + higher lows tightening, break *below*). Useful as an
+exit/avoid signal even if you never short.
+- **He places and trails stops off the pivots themselves** — the 60-min and daily higher lows — manually. He won't
+use an automatic trailing stop because it wouldn't sit on the pivot he wants.
+
+
+
+### 3.3 Vocabulary → verdict
+
+His live language maps almost 1:1 onto a grading scale. Learn it, because it *is* the rubric:
+
+
+| He says                                                                                   | Means                      | Action           |
+| ----------------------------------------------------------------------------------------- | -------------------------- | ---------------- |
+| "linear and orderly", "clean", "tight", "smooth", "very explosive"                        | Textbook                   | Trade, full size |
+| "obeying the 10 and 20", "surfing the rising 10-day"                                      | Institutional accumulation | Strong positive  |
+| "needs to tighten up", "needs a few more days sideways", "let the 20-day catch up"        | Not yet                    | Alert, wait      |
+| "wide and loose", "sloppy", "all over the place", "random", **"it looks like a barcode"** | No structure               | Skip permanently |
+| "too choppy", "it's a slow stock", "low ADR"                                              | No edge                    | Skip permanently |
+
+
+
+
+### 3.4 Anti-patterns (auto-reject)
+
+- Loose, wide-range consolidation. Can't draw the triangle → skip.
+- Consolidation < 3–5 days, or MAs haven't caught up → skip (alert, revisit).
+- No prior big move / not top-decile → not a setup at any price.
+- Low ADR / slow stock → skip regardless of how pretty the pattern is.
+- Months of sideways with no momentum leg in front of it → skip.
+
+
+
+### 3.5 Setup quality score (1–5 stars) `[SET BY AJI]`
+
+He grades every setup 1–5 stars on stream but never publishes the rubric. From how he actually talks, the
+score is driven overwhelmingly by **tightness and orderliness of the range and pullback** — not by
+pattern taxonomy. Formalized:
+
+
+| Dimension                                                        | Weight | 1 point if…                                                      |
+| ---------------------------------------------------------------- | ------ | ---------------------------------------------------------------- |
+| **Tightness** of the range (contraction into the breakout)       | **×2** | Range is narrow and *narrowing*; recent candles are small-bodied |
+| **Orderliness** of the pullback (linear, clean, no wild candles) | **×2** | Pullback is a smooth drift, not a barcode; obeys 10/20-day       |
+| Prior move strength (top decile 1–6m)                            | ×1     | Yes                                                              |
+| Higher lows intact into the breakout level                       | ×1     | Yes                                                              |
+| MA support: 10/20 caught up and rising; 50 respected             | ×1     | Yes                                                              |
+| Volume: dry-up in the base, expansion on the break               | ×1     | Yes                                                              |
+| Sector / theme confirmation                                      | ×1     | Yes                                                              |
+| ADR ≥ 5%                                                         | ×1     | Yes                                                              |
+
+
+Max 10 → **stars = score ÷ 2**. Tightness and orderliness are double-weighted because they are the two
+things he actually names when he calls something five-star, and the two things he names when he rejects.
+**Trade 4–5 stars at full size; 3 stars at half size or not at all; below 3, don't.**
+
+---
+
+
+
+## 4. Setup 2 — Episodic Pivot (EP) — **DEFERRED, NOT IN v1**
+
+A catalyst-driven gap that starts a whole new trend.
+
+**Trigger** `[SET BY AJI]`**:**
+
+```
+gap%  ≥  max( 10% , 3 × ADR )
+```
+
+Plus, from his own words:
+
+- **Catalyst**: earnings (his favourite — "earnings breakouts are the most powerful breakouts") or major news.
+- **The gap must be big relative to the stock's own ADR** — this is the point of the formula above. He dismissed
+a +17% gap as "barely 2× ADR" for a high-ADR name, and praised a +20% gap that was **~5× that stock's ADR**.
+Sweet spot he quotes for larger caps: **+10% to +30%**.
+- **Volume explosion out of the gate** `[SET BY AJI]`**: first-5-minute volume ≥ 50% of 20-day average daily volume.**
+(His own benchmark example was extreme: a stock averaging ~1.6M shares/day traded **1.5M shares in the first
+5 minutes**, ~90% of ADV. 50% is the permissive floor; ≥90% is a five-star EP.)
+- Strongest version: the EP gaps up **out of a base / from strength** — i.e. it is *also* a breakout.
+- "Deep EPs" (gap out of a long downtrend, reclaiming the 150/200-day) work, but he says they are **not his
+comfort zone** and he underperforms on them. Treat as lower conviction.
+- Extreme gaps (>100%) can work in small caps but are the exception, not the plan.
+
+**Entry**: opening range high (§6). **Stops, sizing and sell rules are identical to the breakout.**
+
+---
+
+
+
+## 5. Setup 3 — Parabolic Short — **DEFERRED, NOT IN v1**
+
+Cut from the decision skill for now: shorting is not practically available to you on IDX, and it is the part of
+his method with the largest blow-up risk (he lost a quarter of his capital in a single day shorting frontside,
+and six figures on other attempts).
+
+**Retained only as a long-side defence signal:**
+
+- *Frontside* = 10 / 20 / 65 EMA (60-min) act as **support**; higher lows; still going up. **You may hold longs.**
+- *Backside* = those same EMAs flip to **resistance**; **lower highs**; intraday ranges breaking down.
+**A name that has gone backside is a SELL / DO-NOT-BUY. Never buy a breakout in a backside stock.**
+
+If you later trade this on IBKR, the missing rule is his definition of a "true parabolic" (he says "that's not
+even close to a parabolic" constantly but never gives numbers) — plus: only short the backside, enter on
+opening-range-low breaks / VWAP failures / 60-min bear flags, take a **starter first and add** (unlike longs),
+and cover into weakness at the 10 / 20 / 50-day.
+
+---
+
+
+
+## 6. Entries — the breakout and/or opening range break
+
+He buys as soon as the range break, or on ORB if the price gapped up over the range.
+
+**Which day is "the day the range breaks"?** The day price crosses **the trendline drawn per §3.2** — anchored on the tight consolidation days cluster and extrapolated backwards — **not** the day it takes out the prior swing high. Those are
+usually different days, and the difference is the entire trade: the trendline break happens while price is still
+hugging the rising 10/20/50-day (affordable stop); the swing-high break happens after price has left the MA behind
+(stop too wide → §7 kills the trade). If you find yourself entering far from a moving average, you drew the line wrong.
+
+
+| Trigger        | Character                                                                                                  |
+| -------------- | ---------------------------------------------------------------------------------------------------------- |
+| **1-min ORH**  | Earliest, tightest stop, **highest failure rate**. His most-used on high-conviction names.                 |
+| **5-min ORH**  | Middle ground. The "second chance" if the 1-min fails or you missed it.                                    |
+| **60-min ORH** | Lowest failure rate, but often **way too wide** — the stock has already run and the stop becomes unusable. |
+
+
+**Selection logic: use the shortest timeframe whose stop you can actually afford** (§7). If the 60-min opening
+range puts your stop beyond 1× ADR, the trade is dead — pass, and wait for it to set up again.
+
+Other mechanics:
+
+- **Longs: buy full size immediately.** No starters, no scaling in, no waiting for confirmation.
+- Missed both the 1-min and 5-min ORH and it's already ~14%+ past the trigger: **it's gone. Be faster next time.**
+- Re-entry is legitimate: stopped out, then it reclaims the range → he re-buys, sometimes higher.
+---
+
+
+
+## 7. Stops
+
+- **Default stop = low of the day (LOD)** on the entry day. Alternatives: low of the opening range, or low of the
+breakout day. On a gap-*down* open below the prior day's low, he uses the **red-to-green / green-to-red** level.
+- **Max stop width** `[SET BY AJI]`**: 1 × ADR.** If the required stop is wider than one ADR, **no trade** — pass and
+wait for a re-set. (Consistent with him rejecting ~8% stops and approving one that was "less than half the ATR,
+well within the criteria.")
+- **Tight stops are the entire game.** They are also what makes the sizing in §8 arithmetic work.
+- Stops only move **up**, never wider. After the first partial → **stop to breakeven**.
+- Intraday defence: if the breakout **falls back into its range** or takes out the LOD, cut or halve.
+*"The best breakouts go straight up and never make you second-guess."*
+
+---
+
+
+
+## 8. Risk & position sizing
+
+
+| Parameter                   | Value                                                                                           |
+| --------------------------- | ----------------------------------------------------------------------------------------------- |
+| **Risk per trade**          | **0.3–0.5%** of account, typical. **Hard cap 1%.** He says 1% risk is *a lot* of risk.          |
+| **Position size**           | **10–20%** of account typical; up to **~25%** on high conviction + liquidity.                   |
+| **Sizing math**             | `shares = max_dollar_risk ÷ (entry − stop)`. He does it mentally in ~10 seconds; no calculator. |
+| **Positions held**          | He runs 20–26; recommends **< 20**.                                                             |
+| **Small accounts (< $50k)** | Be **concentrated**: 5–6 positions max, 20–25% each.                                            |
+| **Exposure**                | Can exceed 100% (margin) in a strong tape; goes near-flat when there's no edge.                 |
+
+
+**Position size (10–20% of equity) ≠ risk (0.3–0.5% of equity).** The stop distance reconciles them — which is
+exactly why the 1× ADR cap in §7 is load-bearing: a wider stop forces a smaller position, and past 1× ADR the
+position gets too small to be worth the slot.
+
+---
+
+
+
+## 9. Sell rules (longs) — the part most people get wrong
+
+The canonical rule, repeated across years:
+
+1. **Ignore the first 1–2 days.** Do nothing, no matter how much it runs.
+2. **Sell 1/3 to 1/2 into strength on day 3–5.** (He sometimes splits: 1/3 on day 3, 1/3 on day 5.)
+3. **Move the stop to breakeven** on the remainder.
+4. **Trail the rest with a moving average. Exit on the first CLOSE below it.**
+
+**Which MA to trail with** `[SET BY AJI]`**:**
+
+
+| Stock's ADR | Trail with    |
+| ----------- | ------------- |
+| **< 5%**    | **10-day MA** |
+| **≥ 5%**    | **20-day MA** |
+
+
+(Rationale: the faster the stock, the more room it needs — a 7-ADR name will slice the 10-day on noise alone.
+Exception: declared long-horizon position trades may trail the 50-day, sized ≤ 10%.)
+
+Overnight rule of thumb: closes **near the lows of the day** and below your level → out. Closes strong → hold,
+and today's low becomes the new stop.
+
+---
+
+
+
+## 10. Market regime filter
+
+He does not predict, but he does **size to the environment**:
+
+- **Long-friendly**: index and leaders above a **rising 10 and 20-day**; breakouts follow through
+("they just go up, no headaches"); fresh leadership; sectors moving in packs.
+- **Do not swing long**: **10-day sloping down, 20-day sloping down, 10 below 20** → "high fail rate,
+you probably shouldn't swing trade on the long side."
+- **Choppy markets** produce false signals both ways — fewer trades, smaller size, and he says openly
+"I don't see an edge right now" and sits.
+- **Pullbacks are information**: whatever holds up (finds support on the 20-day while the index tests the 50)
+is showing **relative strength** → those lead the next leg. In a *deep* washout, the first bounce is led by
+the most beaten-down junk; in a *mild* (5–10%) pullback, it's the RS names that lead.
+- **Sector matters**: strength clusters. Check the theme of every candidate.
+
+---
+


### PR DESCRIPTION
Resolves [ticket 07 — Sector/theme leadership and rotation model](.scratch/screening-dashboard/issues/07-sector-theme-and-rotation-model.md) on the [Qullamaggie Screening Dashboard v1 map](.scratch/screening-dashboard/map.md).

> **Note:** this branch also carries two commits that were sitting unpushed on local `main` — the ticket 06 resolution and the tracked method reference. They appear in this diff because `origin/main` never received them.

## What was decided

- **Industry *is* the theme layer.** Yahoo returns `industry` in the *same* `.info` request as `sector`, so 145 industries arrive free on both markets. This dissolves ticket 03's escalated four-way parity dilemma (US-only ETF scraper / paid LLM tagging / correlation clusters / hand-curation) rather than choosing among them, and v1 stays entirely free-data. Narrative themes spanning industries are **ruled out of scope**.
- **Sector strength** = share of members in that lookback's top decile, five numbers per sector, aggregated over ticket 06's rank table per R6 — per-lookback deciles, not the §3.1 union gate, which would park every sector near 29%.
- **Rotation is two sortable columns** — the parameter-free shape differential `share(1w) − share(6m)` as default sort, plus a 20-session temporal delta whose window is inherited from §2/§3.5's 10/20-day horizon. The session initially proposed leaving this to the eye; the trader required it computed and sortable.
- **`k ≥ 2` to top the rotation board**, `k/n` on every row. Nothing is ever hidden; shrinkage rejected as smoothing.
- **One industry board, `n ≥ 10` to be ranked** — same rule both markets, 63 US rows and 7 IDX rows. Parity of rule, not of result.
- **§3.5 confirmation boolean** = leave-one-out sector share ≥ 10% on 1m.
- **§10 pullback-RS is emergent**, surfaced as regime-conditional copy; sector strength never filters.
- **Cache policy** — new names block, 1/30th rolls nightly, a failed fetch never nulls.

## Measured, not estimated

The session rebuilt the universe from ticket 05's written decisions alone and got **290 IDX / 1,896 US** against its 288 / 1,966 — the third independent reproduction — then pulled sector and industry for **every** name (289/290 IDX and 1,893/1,896 US carry one) and computed ticket 06's deciles on top.

- **IDX quantization is the real constraint**: one name moves IDX Utilities' share **10.0pp**, against 0.3–1.7pp anywhere on US. Technology topped the measured IDX rotation board at +21.4pp on *three stocks*. Hence `k ≥ 2`.
- **IDX cannot carry an industry board**: 87 industries, median size **2**, 38 singletons. US can: 139 industries, median size 9, 63 at `n ≥ 10`. Hence one rule with a density floor.
- **The naive §3.5 rule self-inflates to 77–90%** because the candidate sits in its own sector's numerator; leave-one-out drops it to a stable 52% on IDX. The rejected industry-peer alternative is a flat 88–89% on US against 24–55% on IDX.
- **Yahoo tolerates 1.2s spacing with zero throttling** across ~1,850 consecutive `.info` calls, cutting ticket 03's assumed full-pass cost from 75 to ~48 minutes.

An earlier commit on this branch recorded US industry figures from a 58% interim sample; the second commit corrects them against the completed fetch. All corrections moved in the direction of strengthening the rulings.

## Map state

Frontier is now **ticket 08 (setup detection — the highest-risk ticket on the map)** and **ticket 12 (architecture and local runtime shape)**. Ticket 11 remains blocked on 08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)