### PR TITLE
Resolve wayfinder ticket 12: architecture and local runtime shape

### DIFF
--- a/.scratch/screening-dashboard/issues/12-architecture-and-deployment.md
+++ b/.scratch/screening-dashboard/issues/12-architecture-and-deployment.md
@@ -1,7 +1,7 @@
 # Architecture and local runtime shape
 
 Type: grilling
-Status: open
+Status: resolved
 Blocked by: 05
 
 ## Question
@@ -83,3 +83,229 @@ by them.
 level) written every run from launch — a third forward-accumulating capture alongside the listing files
 and universe membership already on this ticket. Ticket 10 also needs index bars for `^IXIC` and
 `^JKSE` ingested on the same path as equities.
+
+## Answer
+
+**One DuckDB file, one command per market, and every derived table is dated rows.** Everything below is
+that plus nine decisions, three of which went against the session's recommendation and are recorded with
+their costs rather than smoothed over.
+
+The ingest set is the **enumerated** universe, not the tradeable one — liquidity is measured *from* bars,
+so **~6,550 symbols** are pulled (840 IDX + 5,711 US per tickets 01/02) of which 288/1,966 survive ticket
+05's gate. That number, not 2,250, sizes every cost below.
+
+### A1. The store is a single DuckDB file
+
+`data/screener.duckdb` holds bars and every derived table. Columnar, so the whole-universe scans that
+ranking (5 lookbacks × 2,254 names) and detection do are fast; full SQL, so the map's standing "a live
+backend is assumed — the UI may query the store freely" holds without precomputed views.
+
+The decisive property is **the reproducibility freeze tickets 08/09/15 need is `cp`**. One file, no
+partition layout, no manifest — a pinned snapshot is a filename. SQLite was rejected on the iteration loop
+(row-store scans, and this project keeps returning to that loop); Parquet-on-disk was rejected because the
+six accumulating streams want row-level appends and Parquet is bad at exactly that.
+
+**Footprint is a non-issue and is measured, not estimated.** A separate implementation of this same
+universe (`~/Projects/q-scanner-v2`, see A10) holds 6,838 tickers × ~900 days as parquet in **146 MB**;
+scaled to A7's ten years that is **~580 MB**, and DuckDB compresses at least as well.
+
+### A2. Ingest is incremental append with a weekly full refresh
+
+Nightly asks each symbol for bars since its last stored one. A **full-universe 10y refetch runs weekly**.
+
+This went against the session's recommendation, which was to refetch everything nightly on the grounds
+that **the ingest cost is per-request, not per-bar** — 6,550 requests at ticket 02's measured 12 req/s is
+~9 minutes whether you ask for one day or ten years, so a full rebuild is free in wall clock and immune to
+ticket 01's invisible rights adjustments. The trade taken instead is bandwidth (~600 MB/night saved) and
+compute against a bounded correctness window. Recorded because A3 is where the bill arrives.
+
+### A3. No drift detector — the weekly refresh is the only repair, and the append seam is a knowing omission
+
+Ticket 01 established that Yahoo applies **rights adjustments invisibly** (BBRI rescaled 10/11 with no
+split or dividend entry), so an incrementally-appended adjusted series can go wrong undetectably.
+
+Two repairs were put and both declined, in favour of one mechanism rather than two:
+
+1. A **20-bar overlap check** — request the last 20 bars instead of the new one (identical request count,
+   so still ~9 minutes), compare the 19 overlapping adjusted closes and volumes against the store, and
+   full-refetch any symbol that disagrees. Declined.
+2. An **off-cycle refetch of symbols with a Yahoo-reported split or dividend** — a handful nightly,
+   covering every *visible* action and leaving only the invisible IDX rights cases to leak. Declined.
+
+**The accepted cost, stated plainly:** an appended bar arrives on the new basis while stored history sits
+on the old one, so for up to six days the seam reads as a **real overnight gap** — and ticket 08's detector
+reads gaps as price action. The failure is not "slightly stale numbers"; it is a spurious detection or a
+wrong ADR on any name that had a corporate action that week. It is bounded, self-healing on the weekly
+refresh, and confined to the affected names, which are a small fraction nightly.
+
+This is the fourth knowing omission on this map, alongside ticket 08's three. Like those, it is a
+hypothesis — that a six-day seam on a handful of names does not change what reaches the top of the list —
+and like those it is untestable until there is forward history. **It is also the cheapest of the four to
+reverse:** repair 1 costs no extra requests, so if a seam artefact is ever seen on a chart, turning it on
+is a one-line change rather than a redesign.
+
+### A4. Every derived table is dated rows, appended and never rewritten
+
+Universe membership, ranks, sector shares, detections, scores, signal vectors — all keyed by
+`(market, session, …)`. "Tonight" is `WHERE session = (SELECT max(session) …)`.
+
+This **collapses the map's six owed capture streams into the normal write path** rather than bolting six
+captures alongside a current-state store. There is one set of facts, and the thing the app reads *is* the
+thing the archive holds, so they cannot disagree. It also makes ticket 14's digest backfillable over
+history exactly as 14 assumed, and lets ticket 15 replay a corrected rubric backwards over accumulated
+signal vectors.
+
+**Derived rows are written once and never rewritten.** They are a point-in-time record of what was
+knowable that night; rewriting them after a rescale would inject look-ahead into the very streams the map
+is accumulating *because* they are unbiased. Backfill (A6) therefore only ever fills **absent** sessions.
+
+### A5. Runs are per market — two `launchd` jobs, with run-on-open as the fallback
+
+Ticket 11's I1 made market the top-level axis, so there is no global nightly job. Two jobs:
+**≥19:00 WIB** for IDX (ticket 01 measured the 2026-08-04 bar final at 19:49 WIB; earlier is unproven) and
+**≥17:00 ET** for US. `launchd`'s `StartCalendarInterval` fires a missed job once on wake, so a sleeping
+laptop delays a run rather than losing it.
+
+On top of that, **opening a market tab whose last final session is missing from the store kicks a run**
+with a progress state. Two mechanisms, and the second is deliberate: it is the honest answer to "the
+machine was shut", and it means the app is never silently a day stale. Run-on-open alone was rejected
+because a ~9-minute US pull does not fit inside §1's 10-minute nightly budget; manual-only was rejected
+because a forgotten night is invisible until you notice the as-of date.
+
+### A6. Missed sessions are backfilled for everything derivable; as-of captures are stamped, never faked
+
+Bar history heals itself for free — you ask for everything since the last stored bar. The derived rows
+split on one line:
+
+- **Derivable from bar history** — universe membership, ranks, detections, scores, signal vectors. These
+  are deterministic functions of bars, so recomputing session T−3 today gives what it would have given on
+  the night. The run computes every session between the last computed one and the latest final session, so
+  a week away costs seconds of compute and leaves **no hole** in the accumulating streams.
+- **As-of only** — listing-file snapshots and sector/industry labels. These cannot be reconstructed
+  (that is ticket 02's survivorship point). They are stamped with the run date and **never backfilled**, so
+  a gap there is visible and honest rather than fabricated.
+
+One wrinkle is accepted: backfilling from today's bars uses today's adjusted basis for a past session.
+Ticket 05 established that almost every quantity in the method is a **ratio**, and a uniform rescale
+cancels in a ratio, so this is immaterial — the same property that made ticket 01's unrecoverable raw IDX
+prices cost nothing.
+
+### A7. Ten years of bar history
+
+Ranking lookbacks run to 24 months (§1), so 3 years is the functional floor. Ten was chosen over the
+recommended five for headroom on whatever validation eventually becomes possible — the map's largest fog
+patch — at roughly **~580 MB** (A1) and a longer weekly refresh. Local running removes any ceiling and
+the weekly refresh re-pulls this depth anyway, so it is a fixed cost, not a growing one. IDX history
+reaches back to ~2000–2004 and US is ample, so ten years is available on both.
+
+### A8. Resource endpoints; the frontend composes the workbench
+
+`/api/regime/{market}`, `/api/candidates/{market}`, `/api/sectors/{market}`, `/api/boards/{market}`,
+`/api/chart/{market}/{symbol}`, `/api/runs/{market}`.
+
+Chosen over screen-shaped endpoints (one call returning the whole workbench). The workbench costs 3–4
+round trips against a local backend, which is free, and the surfaces stay independently addressable. The
+cost is that assembly moves to the frontend and there are now five payloads to keep in sync — which is
+what A9 pays for. A general query layer was rejected: no schema contract to generate types from, and the
+domain logic would migrate to the frontend.
+
+### A9. One repo; TS types generated from the OpenAPI schema
+
+```
+backend/     Python package — pipeline stages, DuckDB access, FastAPI app
+frontend/    Vite + React + TS
+data/        screener.duckdb, digests/
+CONTEXT.md   domain vocabulary (glossary only)
+docs/adr/    decisions that outlive this map
+```
+
+Pydantic response models give FastAPI an OpenAPI schema for free; `openapi-typescript` turns it into
+committed `.d.ts`, regenerated by a script. A renamed field becomes a **typecheck failure rather than a
+runtime `undefined`** — which matters more under A8, where five payloads compose one screen. FastAPI
+serves the built frontend, so it is **one process on one URL**.
+
+### A10. lightweight-charts, porting `renderChart.ts` from `q-scanner-v2`
+
+TradingView's renderer (Apache 2.0, ~45 KB, canvas). Candles, line series and histogram volume are
+first-class; ticket 11's I5 trigger and base-low stop are `createPriceLine`; **the two fitted trendlines
+are line series over the base window**, which draws them *as fits* with candles piercing them in both
+directions — exactly what §3.2 requires and what a purpose-built trendline widget would have "fixed".
+
+`~/Projects/q-scanner-v2/web/src/renderChart.ts` (lightweight-charts v5, React 18, Vite) already draws
+candles, SMA 10/20/50, volume histogram, and dashed trigger/stop price lines against a FastAPI payload.
+**It is ported as the starting point.** I5 then needs four additions it does not have: the **65 EMA**
+(§2's one daily exponential), the **two fitted lines** over the base window, the **shaded base window**,
+and **volume with base bars distinguished** for ticket 08's dry-up dimension. Expansion is not drawn — per
+08's D11 it exists only at the break.
+
+**The rest of `q-scanner-v2` is deliberately not adopted.** It is a working implementation of
+substantially this app and its architecture answers several questions above differently (parquet+SQLite,
+~2.5y depth, manual runs, hand-written frontend types, and — notably — a working `adjusted_close` overlap
+drift detector of exactly the kind A3 declined). It also diverges from the *map*: its pattern engine is
+built on tunable `PatternParams` with an eval sweep where ticket 08 arrived at a zero-tunable detector by a
+different method, and its IDX sectors come from the exchange's IDX-IC xlsx where ticket 03 ruled IDX-IC out
+in favour of Yahoo GECS on both markets. Adopting it as the baseline was put as an explicit fork and
+declined; this map's decisions stand as taken. Recorded because it is prior art a future session would
+otherwise rediscover — and because its `eval/labels` + `--sweep` machinery is the shape of what ticket 15
+is specified to build.
+
+### Forced by earlier tickets, not decided here
+
+Listed so the build session does not have to re-derive them:
+
+- **Pacing.** 12 req/s (ticket 02: unthrottled returns 52.9% of the universe while reporting the losses as
+  "possibly delisted"; 12 req/s gives 99.93% in 8.5 min, measured from a residential IP, which is what a
+  local v1 is). Exponential backoff on 429. **An empty result is `unresolved`, never absent** — the map's
+  standing "Yahoo fails as silence" property.
+- **Quarantine is per market.** A run resolving < ~99% of symbols is quarantined and does not publish; the
+  last good run keeps serving with a banner (ticket 05 D3/D7/D11). Membership is sticky — removal needs
+  positive evidence, never a failed fetch.
+- **Partial-bar guard.** The exchange-clock finality rule drops provisional bars at ingest (ticket 05), and
+  the exchange calendar is derived from observed bar dates rather than a hardcoded holiday table. A5's
+  schedule means a run only ever sees its own market's closed session.
+- **Both series stored.** Adjusted and unadjusted (ticket 05 D9); dollar volume is the one unadjusted
+  quantity.
+- **Index bars.** `^IXIC` and `^JKSE` ingest on the same path as equities (ticket 10).
+- **How you find out a run failed.** Ticket 14 already answered this: **empty nights still write the
+  digest file**, so a missing `digests/<market>/<session>.md` means a failed run. No alerting layer is
+  needed and none is built.
+- **First-run backfill** is resumable by construction — a symbol with bars at the target depth is done, so
+  an interrupted backfill resumes by re-running. ~9 minutes per market pass; ten years of payload makes
+  the first run bandwidth-bound rather than request-bound.
+- **Reproducibility freeze** for tickets 08/09/15 is `cp data/screener.duckdb snapshots/<date>.duckdb`
+  (A1). Nothing else is needed because nothing lives outside the file.
+
+### Pipeline stages, in order, per market run
+
+1. Snapshot the listing files (as-of, never backfilled) → 2. ingest bars (incremental, or full on the
+weekly pass) → 3. hygiene: drop phantom zero-volume bars, apply the finality rule → 4. resolve the
+universe (liquidity, instrument type, listing age, 80%/3-session density) → 5. indicators (ADR, MAs,
+returns) → 6. ranks, 5 lookbacks → 7. sector and ranked-industry shares → 8. detection → 9. score →
+10. write the digest → 11. write the run record.
+
+Stages 4–9 are recomputed in full from bars every run and rerun per backfilled session (A6). The
+sector/industry label cache is the one incremental piece and its policy is already fixed by ticket 07:
+**new names block, 1/30th rolls nightly, a failed fetch never nulls.**
+
+### Portability — what would be expensive to reverse if hosting ever happens
+
+Hosting is out of scope, but two choices are worth naming. **A1 travels well**: ticket 04's research
+independently landed on file-based columnar storage for this footprint, so a DuckDB file on object storage
+is the same shape. **A2 does not travel**: a weekly full refetch of 6,550 symbols × 10y assumes a
+residential IP and unmetered bandwidth, and ticket 04 found serverless execution timeouts rule out
+everything except GitHub Actions and Cloud Run Jobs. A5's `launchd` is macOS-specific and trivially
+replaced. Nothing here is designed for hosting, and nothing here forecloses it.
+
+### Hand-offs
+
+- **Ticket 13 (assemble the v1 spec)** — A1–A10 plus the stage list and table shape are the architecture
+  section. Note that A3 is a stated defect with a bounded cost, not a clean decision; the spec should carry
+  it as such.
+- **Ticket 15 (star-score thresholds)** — A1's `cp` freeze is the pinned snapshot 15 needs, and A4's
+  dated signal vectors are what let a corrected rubric be replayed backwards. Separately, `q-scanner-v2`'s
+  `eval/labels` + `qs eval --sweep` (A10) is a working instance of the grading-and-sweep loop 15 is
+  specified to build; it currently holds 10 labels, and 15's own question is how many charts are enough.
+- **The validation fog patch** — A4 is what makes the patch tractable: all six streams now land through
+  one write path, dated, from launch. A3 adds a small caveat to it — a name with a corporate action may
+  carry up to six days of seam artefacts in its stored history, so a future study should treat the week
+  before a split as suspect.

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -252,6 +252,29 @@ is written during wayfinding.
   nights still write the file**, so a missing file means a failed run — the map's "Yahoo fails as silence"
   property, bought for free.
 
+- [Architecture and local runtime shape](issues/12-architecture-and-deployment.md) — **one DuckDB file,
+  one command per market, and every derived table is dated rows.** A4 is the load-bearing one: universe
+  membership, ranks, sector shares, detections, scores and signal vectors are all keyed by
+  `(market, session, …)` and appended, which **collapses the map's six owed capture streams into the normal
+  write path** — the thing the app reads *is* the archive, so they cannot disagree, ticket 14's digest is
+  backfillable as it assumed, and ticket 15 can replay a corrected rubric backwards. Derived rows are
+  **written once and never rewritten** (rewriting after a rescale would inject look-ahead into the streams
+  that exist *because* they are unbiased), so backfill fills only absent sessions. The store is one file
+  because **the freeze tickets 08/09/15 need is then `cp`** — footprint measured at ~580 MB for 10y × 6,550
+  symbols, not estimated. The ingest set is the **enumerated** universe (~6,550, not 2,254) since liquidity
+  is measured *from* bars. Runs are **per market** per ticket 11's I1 — two `launchd` jobs (≥19:00 WIB,
+  ≥17:00 ET, firing on wake if missed) plus run-on-open, because a ~9-minute US pull does not fit §1's
+  10-minute budget. Missed sessions are **backfilled for everything derivable**; listing files and sector
+  labels are stamped as-of and never faked. **A3 is a stated defect, not a clean decision**: ingest is
+  incremental with a weekly full refresh and **no drift detector** — two repairs were put and declined
+  (a 20-bar overlap check costing *zero* extra requests, and an off-cycle refetch on reported actions) — so
+  for up to six days a corporate action leaves a **seam that reads as a real overnight gap**, which ticket
+  08's detector reads as price action. Bounded, self-healing, and the **cheapest of the map's four knowing
+  omissions to reverse**. Also: resource endpoints with the frontend composing, one repo with TS types
+  generated from OpenAPI, 10 years of history, and **lightweight-charts** — ticket 11's handed-down "how" —
+  porting `renderChart.ts` from `~/Projects/q-scanner-v2`, whose remaining architecture was put as an
+  explicit fork and **declined**.
+
 ## Not yet specified
 
 - **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
@@ -299,10 +322,25 @@ is written during wayfinding.
   against outcomes, because they were recorded rather than discarded. Validation therefore inherits a
   concrete first question — do type-2 crossings behave differently from type-1 ones? — which is cheaper
   than the star-band question the noise floor above makes nearly unaffordable.
+  **Ticket 12 made this patch tractable and then put one stain on it.** Tractable, because A4 lands all six
+  streams through a single dated, append-only write path from launch — the archive is no longer six
+  bolt-on captures but the thing the app itself reads, so it cannot quietly diverge from what was shown on
+  the night, and derived rows are never rewritten, so no rescale injects look-ahead. The stain is A3: with
+  no adjustment-drift detector, a name with a corporate action can carry up to **six days of seam
+  artefacts** in its stored bars, where the old and new adjustment bases meet and read as a real overnight
+  gap. Any future study has to treat the week around a split or dividend as suspect — and because detection
+  runs on those bars, some detections in that window are artefacts of the ingest path rather than of the
+  tape.
   <!-- "Alerting" graduated into ticket 14 and is now resolved: v1 does not alert; a per-market digest of
        real breaks only. See Decisions so far. -->
-- **Watchlist persistence and user state.** Whether the app remembers names you've marked, and what
-  storage that implies, waits on the architecture ticket.
+- **Watchlist persistence and user state.** **Narrowed by ticket 12, not cleared.** The storage half is
+  now trivial and needs no decision — it would be one more dated table in the same DuckDB file, and A4's
+  append-only shape already fits a mark-and-unmark log. What remains is a product question, and ticket 11
+  answered it *by omission*: its two-screen inventory contains no watchlist, no marking, and no user state
+  of any kind, and no endpoint was defined for one in ticket 12's A8. So v1 as currently specified does not
+  remember anything you do. Nobody has explicitly ruled it in or out, which is why this stays fog rather
+  than graduating — but it is now a one-session question, and it is the last patch on this map that is
+  cheap.
   <!-- "Chart rendering approach" cleared by ticket 11: I5 fixed what the chart draws (§2's MA set
        including the 65 EMA, the primary window only, both fitted lines as fits, trigger and base-low
        stop, volume with base bars distinguished). The remaining library choice is a pure architecture


### PR DESCRIPTION
Resolves [Architecture and local runtime shape](.scratch/screening-dashboard/issues/12-architecture-and-deployment.md) — the last frontier ticket except the second grading round.

**One DuckDB file, one command per market, and every derived table is dated rows.** Ten decisions, three of which went against the session's recommendation and are recorded with their costs.

- **A4 is load-bearing.** Universe membership, ranks, sector shares, detections, scores and signal vectors are all keyed by `(market, session, …)` and appended — which collapses the map's six owed capture streams into the normal write path. The archive *is* what the app reads, so they cannot diverge. Derived rows are written once and never rewritten, so no rescale injects look-ahead into streams that exist precisely because they are unbiased.
- **A1** is one file because the freeze tickets 08/09/15 need is then `cp`. Footprint measured at ~580 MB for 10y × 6,550 symbols, not estimated.
- **A5** runs per market per ticket 11's I1 — two `launchd` jobs (≥19:00 WIB, ≥17:00 ET, firing on wake if missed) plus run-on-open, since a ~9-minute US pull does not fit §1's 10-minute budget.
- **A10** settles the chart library ticket 11 handed down: lightweight-charts, porting `renderChart.ts` from `q-scanner-v2`, plus the four things I5 needs that it lacks (65 EMA, both fitted lines, shaded base window, base-bar volume).

**A3 is a stated defect, not a clean decision.** Ingest is incremental with a weekly full refresh and no adjustment-drift detector. Two repairs were put and declined — a 20-bar overlap check costing *zero* extra requests, and an off-cycle refetch on Yahoo-reported actions — so for up to six days a corporate action leaves a seam that reads as a real overnight gap, which ticket 08's detector reads as price action. Bounded and self-healing, and the cheapest of the map's four knowing omissions to reverse. It is carried into the validation fog patch as a caveat on the stored history.

`q-scanner-v2` turned out to be a working implementation of substantially this app, with a different store, a working drift detector, a tunable pattern engine and IDX-IC sectors. Adopting it as the baseline was put as an explicit fork and declined; it is recorded as prior art so a future session does not rediscover it.

Frontier after this: **Second grading round** alone. **Assemble the v1 spec** is blocked only by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)