### PR TITLE
Resolve ticket 19: the split's parameters, and the stop budget

### DIFF
--- a/.scratch/screening-dashboard/issues/11-dashboard-information-architecture.md
+++ b/.scratch/screening-dashboard/issues/11-dashboard-information-architecture.md
@@ -285,3 +285,29 @@ the state half would render one value for every row on every night.
 declined for exactly the reason I2 gives: it is the diff-first surface, moved inside the app. The
 break keeps the single home ticket 14 gave it — the digest — which is the file you may ignore at no
 cost.
+
+---
+
+## Amendment from ticket 19 — I4's stop column is right, its base rate is not
+
+[Ticket 19](19-fit-the-split-parameters.md) R2 measured the quantity I4's fourth column displays and
+found the column well chosen but described backwards.
+
+I4 justifies "Stop width ÷ 1×ADR" as "§7's veto, visible before you open anything — **a row at 0.97×
+is nearly dead**", which reads as though most rows sit comfortably below 1.0 and the column exists to
+catch the occasional straggler. Measured over 19,527 detections: the median row is at **1.28×**, and
+**~92% of the nightly list sits above 1.0** — because `TIGHT_MULT` (1.5) *is* the stop budget, and the
+cluster's ≤1.5×ADR span is what bounds it.
+
+Nothing about the column's presence or position changes. Two things about its treatment do:
+
+- **The highlight inverts.** Marking the rows that exceed 1×ADR would mark 92% of the list, which is
+  not a mark. The **≤1×ADR minority** is the exceptional, affordable case and is what should be
+  visually distinguished.
+- **It is never a filter.** Ticket 19 R2 measured what filtering costs — 85% of ticket 15's graded
+  cards, and preferentially the ones that graded *highest* — and declined it. §7 is enforced by the
+  human at entry, against the real LOD stop the screen cannot see. The column exists to make that
+  check free, not to pre-empt it.
+
+Whether the *sort* should also know about the stop is not settled here — that is
+[ticket 21](21-should-the-score-know-about-the-stop.md). I4's sort key remains the star score.

--- a/.scratch/screening-dashboard/issues/19-fit-the-split-parameters.md
+++ b/.scratch/screening-dashboard/issues/19-fit-the-split-parameters.md
@@ -1,7 +1,7 @@
 # Fit the split's 22 parameters, or accept them as borrowed defaults
 
 Type: prototype
-Status: claimed
+Status: resolved
 Blocked by: 15
 
 ## Question
@@ -76,3 +76,171 @@ ticket's sweep:
 
 `TIGHT_MULT` was already this ticket's headline at a 63% swing in list length; note that it swings
 the digest by the same mechanism, since it is what selects the cluster whose high is the level.
+
+---
+
+## Answer
+
+**Nothing is fitted, and that is the resolution rather than a failure to reach one.** Of the 22
+numbers, **five can move anything at all**; three are provably redundant and are deleted; the rest
+stand as q-scanner's defaults with the evidence for standing recorded. The one number that moves
+most — `TIGHT_MULT` — turned out not to be a detection parameter at all, which changed the ticket:
+it is the **stop budget**, and once measured against §7 the live question stopped being "what value
+fits" and became "does the screen enforce §7", which is a trader's call and was taken as one.
+
+The prototype is [`19-fit-params/`](../prototypes/19-fit-params/); full working in
+[`FINDINGS.md`](../prototypes/19-fit-params/FINDINGS.md). 400 US names (seed 19) on a 1-in-3 date
+grid — 172,991 bar-dates, 19,527 accepted detections — plus IDX's full 288-name universe.
+
+### R1. The bill is five live numbers, not twenty-two
+
+| verdict | numbers | evidence |
+| --- | --- | --- |
+| **dead — deleted** | `MA_PROX_ADR` | zero references in any function body |
+| **one number, not two** | `OVER_W`, `UNDER_W` | the fit loss is scale-invariant, so only their *ratio* binds: (3.0, 1.0) and (6.0, 2.0) give **byte-identical** lists, as do (6.0, 1.0) and (3.0, 0.5) |
+| **discretisation — frozen** | `SLOPE_STEPS` | 25 → 800 steps moves the list ±0.1% |
+| **redundant — dropped** | `MAX_OVERSHOOT_FRAC` | catches only 4.4% of candidates the ADR test misses (r = +0.32) |
+| **redundant — dropped** | prior-move floor 25% | ticket 06's decile gate cuts **89.4%** of what the floor passes; the floor cuts **7.7%** of what the gate passes (Jaccard 10.5%) |
+| **near-inert — frozen** | `K_MAX` | 7 → 9 moves the list −1.7% |
+| **live** | `TIGHT_MULT`, `K_MIN`, `MAX_BASE_LEN`, `MAX_OVERSHOOT_ADR`, the touch group | R2–R4 |
+
+**Ticket 18's trigger identity replicates** on a fresh sample: the fitted line set the trigger in
+**0 of 19,527** detections. Its four inheriting parameters price as existence-and-drawing only, as
+18 said; `MAX_SLOPE_ADR` is additionally near saturation (0.5 → 1.0 moves the list +1.1%), so the
+slope cap almost never binds upward.
+
+The redundancy finding carries a second lesson the map should not lose: **ticket 17's 63% swing was
+measured on the ungated list.** The decile gate runs first and is by far the stronger filter. Every
+list-length number in this ticket is quoted after it.
+
+### R2. `TIGHT_MULT` is the stop budget. It stays at 1.5, and §7 moves to the display.
+
+The cluster spans ≤ `TIGHT_MULT` × ADR and the stop runs trigger → cluster low, so `TIGHT_MULT`
+**is** the worst-case stop in ADR units. §7 caps stop width at **1 × ADR** and calls anything wider
+a no-trade. Ticket 08 gated exactly this (D6, rejecting 30–69%); ticket 17 deleted the gate on the
+argument that the cluster bounds the stop "as a side effect rather than as a gate" — an argument
+about *form*, which was never paired with the number about *substance*:
+
+| `TIGHT_MULT` | gated /night | k mean | stop median | **within §7** |
+| --- | --- | --- | --- | --- |
+| 1.000 | 23.1 | 3.70 | 0.88 | **100%** |
+| 1.250 | 30.7 | 4.02 | 1.08 | 28% |
+| **1.500** | **39.7** | **4.41** | **1.28** | **8%** |
+| 1.750 | 46.4 | 4.87 | 1.47 | 3% |
+
+**At the inherited default, 92% of the nightly list carries a cluster-low stop that §7 calls a
+no-trade.** Ticket 17 recorded the bound (≤1.5, max measured 1.499); nobody measured the
+distribution against the cap.
+
+**The decision: `TIGHT_MULT` stays at 1.5, no stop gate is restored, and the screen shows every
+detection with its stop width — marking the ones outside 1 × ADR rather than hiding them.**
+
+The reasoning, and the option that was put and declined. A restored 1×ADR gate was measured first
+and initially preferred: it leaves the rubric's k dimension nearly intact (4.41 → 4.23, against
+3.70 if `TIGHT_MULT` were re-tightened to 1.0 instead) and brings the nightly list to 16.9 names,
+inside ticket 06's reviewability concern. It was declined once its **price** was measured:
+
+- **8.5% of detections survive** it (39.7 → 16.9 US names/night).
+- Survivors are **more volatile, bigger movers**: mean ADR 6% → 10%, mean prior move 104% → 177%.
+  Mechanical, since the stop is measured in ADR units — a high-ADR name passes with a wider
+  absolute cluster — but a real selection effect, not a neutral filter.
+- **Only 25 of ticket 15's 164 graded cards survive (15%), and the removed cards graded *higher***
+  (eye 2.91 removed vs 2.44 kept).
+
+That last point is the load-bearing one, and it is consistent with an independent measurement: on
+the 164 graded cards the eye grades **looser** clusters higher, monotonically — 2.54 → 2.75 → 2.94
+across (0.75,1.0] → (1.0,1.25] → (1.25,1.5] ADR, r = +0.140 (p = 0.286, and every card was selected
+under 1.5, so this can only speak about tightening — but the sign is the finding). **The eye and the
+stop rule disagree, in the same direction, on every measurement taken.**
+
+So the screen does not adjudicate between them. §7's real stop is the entry-day LOD or opening-range
+low, which sits **above** the cluster low; the cluster-low stop is a conservative EOD proxy for a
+number the screen cannot see. Filtering on the proxy would delete the trader's preferred setups on
+evidence that is systematically pessimistic. §7 is enforced at entry, with intraday data, by the
+human — and the screen's job is to make that check free rather than to pre-empt it.
+
+**A caveat for whoever builds this**: at the default, ~92% of rows carry the mark, and a flag that
+fires on 92% of a list is not a flag. The useful form is almost certainly the **stop width in ADR
+as a sorted column**, with the ≤1×ADR minority highlighted — the inverse of "mark the failures".
+Ticket 13 owns the final shape; the decision here is that the number is *shown and not filtered on*.
+
+### R3. Line validity is one decision and a spare
+
+`line_ok` passes 53.1% of the 53,922 candidates reaching it — this is what ticket 17's 58.8% drop
+of 08's picks is made of. Instrumented per clause (the duplicated fit reproduces `split.py`'s own
+`line_ok` at **100.0000%** agreement):
+
+| clause | passes | `line_ok` if dropped |
+| --- | --- | --- |
+| `over_max ≤ 1.0 ADR` | 68.9% | 73.3% (**+20.2pp**) |
+| `over_frac ≤ 20%` | 86.1% | 56.2% (+3.1pp) |
+| `zones ≥ 2` | 44.7% | 64.5% |
+| `zones ≥ 1 & reaches 60% back` | 84.3% | 64.5% |
+
+The touch clauses are an **OR**, so neither binds alone — dropping *either* gives the same 64.5%,
+and dropping both costs +11.4pp. `MIN_TOUCHES = 2` decides nothing by itself, and the four numbers
+behind the touch test are **one decision expressed four ways**. `MAX_OVERSHOOT_ADR` is the number
+doing the cutting; `MAX_OVERSHOOT_FRAC` is dropped per R1.
+
+So the answer to "can the six be cut down" is yes: **two live decisions** (bounded overshoot in ADR;
+is a line drawable from its touches) behind what is now five numbers rather than six.
+
+### R4. One set of numbers serves both markets
+
+IDX tracks US across the whole `TIGHT_MULT` grid — k mean 3.66/4.51/5.44 against US's
+3.70/4.41/5.32 at 1.0/1.5/2.0, stop medians identical to two decimals, §7 shares identical. ADR
+distributions are comparable (US median 4.49%, IDX 3.97%). **No per-market parameter set is
+needed**, which is what the ADR normalisation promised and had not been checked.
+
+**Ticket 09's D13 hole stays closed under the split**: 98.5% of accepted IDX clusters contain zero
+collapsed (zero-range) bars, against the 98.1% ticket 15 measured on the old detector. Worth
+re-checking because the cluster is *selected* for tightness — precisely where a limit-day bar would
+hide — and it did not get worse.
+
+### R5. `K_MIN` is live, `K_MAX` is not, and neither moves
+
+| K_MIN–K_MAX | /night | vs 3–7 | k mean |
+| --- | --- | --- | --- |
+| 2–7 | 57.9 | +49.1% | 3.62 |
+| **3–7** | **39.9** | — | **4.41** |
+| 3–9 | 39.4 | −1.7% | 4.50 |
+| 4–7 | 26.5 | −36.6% | 5.23 |
+
+k serves three consumers — detection, the digest's breakout lookback (18 R3), and ticket 15's
+tightness dimension — and three consumers is a strong argument for leaving a non-binding number
+alone. **3–7 stands.**
+
+### R6. There was no fitting instrument, and the eye is not one
+
+The ticket asked what the instrument would be. The graded set cannot fit *detector* parameters: it
+contains only names the detector emitted, so it cannot see what a parameter change would newly
+admit, and R2's eye result shows the failure concretely — the only direction it can speak about is
+the one the evidence declines to support. Deck D's rejected-candidates arm remains the shape that
+could see them, and it is **already in ticket 20's scope**; this ticket does not duplicate it.
+
+Which means the honest summary of the whole ticket: **every one of the 22 numbers still stands as a
+borrowed default.** What changed is that they are now classified rather than uniformly unexamined —
+five can move anything, two decisions sit behind the line test, one number was misunderstood as a
+detection parameter when it is a risk parameter, and three are gone.
+
+### Ticket 18's reopen condition — discharged
+
+Ticket 18 left: *"If ticket 19 moves `TIGHT_MULT`, `K_MIN` or `K_MAX`, the digest moves with them."*
+**None of the three moved.** The digest's numbers stand exactly as 18 measured them — effective
+breakout lookback median 4, mean 4.37, k=3 on 37.3% of detections. The condition is discharged, not
+carried forward.
+
+### Hand-offs
+
+- **To ticket 13 (spec):** the parameter table in R1 is what the build session gets — five numbers
+  it may touch, the rest frozen with the measurement that froze them. Plus R2's display decision:
+  stop width in ADR is a **shown, sorted, non-filtering** column.
+- **To ticket 11 (IA):** R2 needs almost nothing built — **I4 already carries a "Stop width ÷ 1×ADR"
+  column**, so the display half of this decision was specified before it was decided. What ticket 11
+  did not have is the **base rate**, and it changes how the column reads: I4 justifies it with "a row
+  at 0.97× is nearly dead", which implies most rows sit below 1.0. **Roughly 92% sit above it.** The
+  column is therefore not a veto indicator but the list's *widest* axis of variation, and the ≤1×ADR
+  minority is what wants highlighting. Amendment recorded there.
+- **To ticket 20:** R2's finding that the eye prefers what §7 rejects sharpens what the rubric is
+  being confirmed *on*. No blocking dependency — 20 confirms the band on cards already rendered.
+- **To ticket 21 (new):** whether the score and the digest should know about the stop at all.

--- a/.scratch/screening-dashboard/issues/19-fit-the-split-parameters.md
+++ b/.scratch/screening-dashboard/issues/19-fit-the-split-parameters.md
@@ -1,7 +1,7 @@
 # Fit the split's 22 parameters, or accept them as borrowed defaults
 
 Type: prototype
-Status: open
+Status: claimed
 Blocked by: 15
 
 ## Question

--- a/.scratch/screening-dashboard/issues/21-should-the-score-know-about-the-stop.md
+++ b/.scratch/screening-dashboard/issues/21-should-the-score-know-about-the-stop.md
@@ -1,0 +1,50 @@
+# Should the star score and the digest know about the stop?
+
+Type: grilling
+Status: open
+Blocked by: 20
+
+## Question
+
+[Ticket 19](19-fit-the-split-parameters.md) R2 decided the screen **shows** every detection with its
+stop width and marks the ones outside §7's 1 × ADR cap, rather than filtering on a proxy the screen
+cannot measure properly. That settles what the *list* contains. It does not settle what the *sort*
+means, and the two are not independent, because the star score is what orders the only list in the
+app (ticket 11).
+
+The numbers that make this live:
+
+- **~92% of the nightly list is outside §7's cap** on the cluster-low proxy, so the score is
+  currently sorting a population that is mostly, on its face, untradeable.
+- **The eye prefers exactly what §7 rejects.** Looser cluster → wider stop → higher eye grade, on
+  every measurement ticket 19 took: grade rises monotonically with cluster looseness (2.54 → 2.75 →
+  2.94), and the cards a §7 gate would remove graded **2.91 against the 2.44 it would keep**.
+- Ticket 15's rubric was fitted on grades collected from that population, so the score has, in
+  effect, already learned to *reward* wide stops — without anyone deciding it should.
+
+So the question in three parts:
+
+1. **Should stop width enter the star score?** As a dimension, a penalty, a tiebreak, or not at all.
+   The case for: a 5★ the trader cannot afford is a worse recommendation than a 4★ they can. The
+   case against: §3.5's rubric is about the *setup*, and affordability is a property of the trade,
+   not the base — and ticket 15 has just spent a session establishing that adding dimensions to this
+   rubric is expensive and easy to get wrong.
+2. **Should the digest's membership consult it?** [Ticket 18](18-digest-rule-under-the-clamped-trigger.md)
+   R5 reports every break, and its membership consults neither the score nor the stop. If ~92% of
+   breaks are §7 no-trades on the proxy, the nightly digest is mostly reporting trades that cannot
+   be taken — or it is correctly reporting them and the proxy is the thing at fault.
+3. **Is the disagreement real, or is the proxy wrong?** The cluster-low stop is deliberately
+   conservative: §7's actual stop is the entry-day LOD or opening-range low, which sits *above* the
+   cluster low. If the true stop is usually inside 1 × ADR where the proxy says it is not, there is
+   no disagreement to resolve and parts 1 and 2 dissolve. **This is the cheapest of the three to
+   attack and should go first** — but it needs intraday data the map has ruled out of v1, so it may
+   only be answerable as a forward-history question.
+
+**Blocked by [ticket 20](20-confirm-the-band-and-measure-the-ceiling.md)** for the same reason
+ticket 19 was blocked by 15: two of the rubric's dimensions are unconfirmed and its ceiling is
+unmeasured, so weighing a *new* dimension against them would be weighing it against numbers that may
+not survive. If 20 finds the band does not reproduce, the rubric has a free ×2 slot and part 1 gets
+easier rather than harder.
+
+**Do not re-litigate** ticket 19 R2's decision to show rather than filter — that was taken against
+the measured price of filtering. This ticket is about the sort and the digest, not the list.

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -54,7 +54,11 @@ is written during wayfinding.
   cannot reach the trigger at all — the trigger is the cluster high by identity — so the drawing the
   trader endorsed 10 of 11 times and the level the screen fires on are **two separate objects**, and
   only the second is what ticket 19 will be fitting. This does not reopen the swap, but it narrows
-  what the endorsement covered.
+  what the endorsement covered. **Ticket 19 fitted neither, and found a third thing instead**: the
+  parameter it was sent to fit is a *risk* parameter, not a detection one, and on three independent
+  measurements **the trader's eye prefers the setups the trader's own §7 stop rule rejects**. The map's
+  standing risk is therefore no longer only that the two ×2 dimensions are unconfirmed — it is that the
+  score, the eye and the risk rule may not be measuring the same thing at all. Ticket 21 carries it.
 - **Standing property of the data layer** (found independently by tickets 01, 02 and 03): **Yahoo fails
   as silence.** Throttled requests return empty results — and for price history, the literal message
   "possibly delisted; no price data found". Every ingestion path must distinguish throttling from
@@ -409,6 +413,28 @@ is written during wayfinding.
   porting `renderChart.ts` from `~/Projects/q-scanner-v2`, whose remaining architecture was put as an
   explicit fork and **declined**.
 
+- [Fit the split's 22 parameters, or accept them as borrowed defaults](issues/19-fit-the-split-parameters.md) —
+  **nothing is fitted, and that is the answer.** Of 22 numbers **five can move anything**; three are
+  provably redundant and deleted (`MA_PROX_ADR` dead; `OVER_W`/`UNDER_W` are one *ratio* — measured
+  byte-identical lists; `MAX_OVERSHOOT_FRAC` catches 4.4% the ADR test misses; and the **prior-move floor
+  duplicates the decile gate**, which cuts 89.4% of what the floor passes against the floor's 7.7%).
+  `SLOPE_STEPS` converges at 25 of 800 steps and `K_MAX` moves the list −1.7% at 9 — frozen, not fitted.
+  The headline is that **`TIGHT_MULT` is not a detection parameter, it is the stop budget**: the cluster
+  spans ≤ `TIGHT_MULT`×ADR and the stop runs trigger→cluster-low, and against §7's 1×ADR cap **92% of the
+  nightly list is a no-trade**. Ticket 08 gated exactly this (D6); ticket 17 deleted the gate on an argument
+  about *form* that was never paired with this number. Restoring the gate was measured and **declined**: it
+  keeps only 8.5% of detections, skews survivors to high volatility (ADR 6%→10%, prior move 104%→177%), and
+  **removes 85% of ticket 15's graded cards — the ones that graded *higher*** (2.91 removed vs 2.44 kept).
+  That is one of three measurements all pointing the same way: **the eye prefers what the stop rule
+  rejects**. So §7 moves to the *display* — stop width is shown and sorted on, never filtered on — and
+  enforcement stays with the human at entry, where the real LOD stop is visible. Also: **one parameter set
+  serves both markets** (IDX tracks US to two decimals across the grid), D13's collapsed-bar hole stays
+  closed at 98.5%, ticket 18's reopen condition is **discharged** (none of `TIGHT_MULT`/`K_MIN`/`K_MAX`
+  moved), and ticket 17's 63% swing is restated: it was measured on the **ungated** list, and the decile
+  gate is the far stronger filter. What it could not settle became
+  [ticket 21](issues/21-should-the-score-know-about-the-stop.md) — the score sorts a list that is 92%
+  unaffordable, and the rubric has already learned to reward wide stops without anyone deciding it should.
+
 ## Not yet specified
 
 - **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
@@ -483,6 +509,16 @@ is written during wayfinding.
   gap. Any future study has to treat the week around a split or dividend as suspect — and because detection
   runs on those bars, some detections in that window are artefacts of the ingest path rather than of the
   tape.
+  **Ticket 19 left the cheapest question this patch has yet acquired, and it is not about the score.**
+  The eye prefers wide-stop setups; §7 forbids them; nobody knows which is right, and forward outcomes
+  can say. Unlike the star-band question (672 triggered setups per band, unaffordable) this one splits the
+  nightly list into two populations at a **fixed, known threshold** — inside or outside 1×ADR — at roughly
+  8%/92%, so the minority arm is the binding constraint rather than a per-band count. It is answerable the
+  moment there is forward history *provided the stop width is written with every detection*, which is a
+  free addition to ticket 12's A4 write path and irrecoverable afterwards — the same shape as the map's
+  other capture streams, and the seventh of them. Note the trap the answer has to survive: §7's real stop
+  is the entry-day LOD, not the cluster low, so a study on the proxy measures a quantity the trader never
+  actually risks. Ticket 21 owns the live half of this.
   <!-- "Alerting" graduated into ticket 14 and is now resolved: v1 does not alert; a per-market digest of
        real breaks only. See Decisions so far. -->
 - **Watchlist persistence and user state.** **Narrowed by ticket 12, not cleared.** The storage half is

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/.gitignore
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/.gitignore
@@ -1,0 +1,3 @@
+cache
+venv
+out

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/FINDINGS.md
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/FINDINGS.md
@@ -1,0 +1,162 @@
+# Ticket 19 — fitting the split's 22 parameters
+
+Short version: **none of them gets fitted, and that is the finding rather than a failure.** Only
+five can move anything at all; three of the twenty-two are provably redundant and were deleted; and
+the one that moves most — `TIGHT_MULT` — turned out not to be a detection parameter at all. It is
+the **stop budget**, and once that was measured the question stopped being "what value fits" and
+became "does the screen enforce §7", which is a trader's call and was taken as one.
+
+All numbers below are US unless marked, on a fixed 400-name sample (seed 19), 1-in-3 date grid,
+172,991 bar-dates, 19,527 accepted detections at the defaults. IDX is the full 288-name universe.
+
+---
+
+## 1. The bill is not 22 live numbers. It is five.
+
+| verdict | numbers | evidence |
+| --- | --- | --- |
+| **dead** | `MA_PROX_ADR` | 0 references in any function body |
+| **not two numbers** | `OVER_W`, `UNDER_W` | only their *ratio* binds — measured identical lists |
+| **discretisation** | `SLOPE_STEPS` | 25 → 800 steps moves the list ±0.1% |
+| **redundant** | `MAX_OVERSHOOT_FRAC` | catches 4.4% the ADR test misses (r = +0.32) |
+| **redundant** | prior-move floor 25% | the decile gate already cuts 89.4% of what it passes |
+| **near-inert** | `K_MAX` | 7 → 9 moves the list −1.7% |
+| **live** | `TIGHT_MULT`, `K_MIN`, `MAX_BASE_LEN`, `MAX_OVERSHOOT_ADR`, the touch group | below |
+
+`OVER_W`/`UNDER_W` is the cleanest of these: the fit loss is `OVER_W·max(r,0) + UNDER_W·max(-r,0)`,
+which is scale-invariant, so `(3.0, 1.0)` and `(6.0, 2.0)` produce **byte-identical** lists, as do
+`(6.0, 1.0)` and `(3.0, 0.5)`. Two numbers, one degree of freedom.
+
+**Ticket 18's trigger identity replicates** on a fresh sample: the fitted line set the trigger in
+**0 of 19,527** detections (0.0%). `OVER_W`/`UNDER_W`, `SLOPE_STEPS` and `MAX_SLOPE_ADR` therefore
+price as *existence-and-drawing* parameters only, exactly as ticket 18 said. `MAX_SLOPE_ADR` is
+additionally near its saturation point: 0.5 → 1.0 moves the list +1.1%, so the slope cap almost
+never binds upward.
+
+## 2. Line validity is one decision and a spare, not six numbers
+
+`line_ok` passes 53.1% of the 53,922 candidates that reach it — this is what ticket 17's 58.8% drop
+of ticket 08's picks is made of. Instrumented so each clause reports separately (the duplicated fit
+reproduces `split.py`'s own `line_ok` at **100.0000%** agreement, so these are exact):
+
+| clause | passes | `line_ok` if dropped |
+| --- | --- | --- |
+| `over_max ≤ 1.0 ADR` | 68.9% | 73.3% (**+20.2pp**) |
+| `over_frac ≤ 20%` | 86.1% | 56.2% (+3.1pp) |
+| `zones ≥ 2` | 44.7% | 64.5% |
+| `zones ≥ 1 & reaches 60% back` | 84.3% | 64.5% |
+
+The two touch clauses are an **OR**, so neither binds alone — dropping *either* gives the same
+64.5%, and dropping both costs +11.4pp. `MIN_TOUCHES = 2` therefore decides nothing by itself, and
+the four numbers behind the touch test (`TOUCH_TOL_ADR`, `MIN_TOUCHES`, `MIN_TOUCH_GAP`, the 0.6
+reach-back) are **one decision expressed four ways**.
+
+`MAX_OVERSHOOT_ADR` is the number that does the cutting. Everything else in this group is a rounding
+error on it.
+
+## 3. `TIGHT_MULT` is the stop budget, not a detection parameter
+
+The cluster spans ≤ `TIGHT_MULT` × ADR and the stop runs trigger → cluster low, so `TIGHT_MULT`
+*is* the worst-case stop in ADR units. §7 of the method reference caps stop width at **1 × ADR** and
+calls anything wider a no-trade. Ticket 08 gated exactly this quantity (D6, rejecting 30–69%);
+ticket 17 deleted the gate on the argument that the cluster bounds the stop "as a side effect rather
+than as a gate". That argument is about form. This is the substance:
+
+| `TIGHT_MULT` | /night (sample) | gated, full universe | k mean | k=3 | stop median | **within §7** |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1.000 | 13.5 | 23.1 | 3.70 | 59% | 0.88 | **100%** |
+| 1.125 | 19.8 | 26.1 | 3.84 | 53% | 0.98 | 57% |
+| 1.250 | 26.4 | 30.7 | 4.02 | 47% | 1.08 | 28% |
+| **1.500** | **39.9** | **39.7** | **4.41** | **37%** | **1.28** | **8%** |
+| 1.750 | 49.9 | 46.4 | 4.87 | 26% | 1.47 | 3% |
+| 2.500 | 63.0 | 54.9 | 6.07 | 9% | 1.94 | 1% |
+
+**At the inherited default, 92% of the nightly list carries a cluster-low stop that §7 calls a
+no-trade.** Nobody had measured this: ticket 17 recorded the *bound* (≤1.5, max measured 1.499) but
+never the distribution against the cap.
+
+"Gated" is after ticket 06's union-of-deciles precondition and scaled to the full 1,966-name US
+universe — the number the trader actually sees. Worth noting on its own: ticket 17's 63% swing was
+measured on the **ungated** list, and the gate is by far the stronger filter (it cuts 89.4% of
+floor-passing detections; the floor cuts 7.7% of gate-passing ones, Jaccard 10.5%).
+
+### The eye wants the opposite
+
+On ticket 15's 164 graded cards, the eye grades **looser** clusters *higher*, monotonically:
+
+| cluster range (ADR) | mean eye | n |
+| --- | --- | --- |
+| (0.75, 1.0] | 2.54 | 13 |
+| (1.0, 1.25] | 2.75 | 60 |
+| (1.25, 1.5] | 2.94 | 90 |
+
+r = +0.140; tight (≤1.0) 2.50 vs loose 2.87, p = 0.286 by permutation. Not significant, and every
+card was selected under `TIGHT_MULT = 1.5` so this can only speak about *tightening* — but the sign
+is the finding, and it does not support tightening. **`TIGHT_MULT` cannot be fitted against the eye
+in the direction §7 pulls.**
+
+### What enforcing §7 would have cost
+
+A restored 1×ADR gate at `TIGHT_MULT = 1.5` leaves the rubric's k dimension nearly intact
+(4.41 → 4.23, against 3.70 if `TIGHT_MULT` were re-tightened to 1.0 instead) — but it is not a
+neutral filter:
+
+- **8.5% of detections survive** (39.7 → 16.9 names/night gated, US).
+- Survivors are **more volatile and bigger movers**: mean ADR 6% → 10%, mean prior move 104% → 177%.
+  Mechanical — the stop is measured in ADR units, so a high-ADR name passes with a wider absolute
+  cluster.
+- **Only 25 of ticket 15's 164 graded cards survive (15%), and the removed cards graded higher**
+  (eye 2.91 removed vs 2.44 kept).
+
+So the eye and the stop rule disagree, consistently and in the same direction throughout: looser
+cluster → wider stop → higher eye grade → §7 rejects it.
+
+## 4. Per-market: the ADR normalisation transfers
+
+IDX tracks US almost exactly across the grid, which is the case for one set of numbers rather than
+two:
+
+| `TIGHT_MULT` | k mean US / IDX | stop median US / IDX | within §7 US / IDX |
+| --- | --- | --- | --- |
+| 1.00 | 3.70 / 3.66 | 0.88 / 0.88 | 100% / 100% |
+| 1.50 | 4.41 / 4.51 | 1.28 / 1.28 | 8% / 8% |
+| 2.00 | 5.32 / 5.44 | 1.65 / 1.65 | 2% / 2% |
+
+ADR distributions are comparable (US median 4.49%, IDX 3.97%), and **ticket 09's D13 hole stays
+closed under the split**: 98.5% of accepted IDX clusters contain zero collapsed (zero-range) bars,
+against the 98.1% ticket 15 measured on the old detector. The cluster is *selected* for tightness,
+which is exactly where a limit-day bar would hide, so this was worth re-checking — it did not get
+worse.
+
+## 5. The k range
+
+`K_MIN` is the live half; `K_MAX` is nearly inert.
+
+| K_MIN–K_MAX | /night | vs 3–7 | k mean |
+| --- | --- | --- | --- |
+| 2–7 | 57.9 | +49.1% | 3.62 |
+| **3–7** | **39.9** | — | **4.41** |
+| 3–9 | 39.4 | −1.7% | 4.50 |
+| 4–7 | 26.5 | −36.6% | 5.23 |
+
+k is doing three jobs at once — detection, the digest's effective breakout lookback (ticket 18 R3),
+and ticket 15's tightness dimension — so this grid moves the sort and the digest, not just the list.
+Nothing here argues for moving it off 3–7, and three consumers is a strong argument for leaving a
+non-binding number alone.
+
+---
+
+## Files
+
+| file | what it does |
+| --- | --- |
+| `harness.py` | fixed sample, cached re-scans under parameter overrides, the decile gate |
+| `bill.py` | the audit — dead, discretisation, drawing-only, redundant |
+| `lines.py` | instrumented line-validity test; per-clause attribution (verified 100% vs `split.py`) |
+| `tight.py` | the `TIGHT_MULT` grid, the §7 columns, the eye-vs-looseness check, the k range |
+| `market.py` | IDX: collapsed bars, the sweep, ADR comparability |
+| `shift.py` | what a §7 gate does to the population ticket 15 fitted on |
+
+Run order: `bill.py` → `lines.py` → `tight.py` → `market.py` → `shift.py`. Needs `pandas numpy` and
+ticket 09's bar cache (`cache/` is a symlink to it). Scans are cached in `out/scans/` keyed by the
+override set.

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/README.md
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/README.md
@@ -1,0 +1,30 @@
+# Ticket 19 — fit the split's 22 parameters, or accept them as borrowed defaults
+
+Throwaway prototype for [`19-fit-the-split-parameters.md`](../../issues/19-fit-the-split-parameters.md).
+Builds on ticket 16's port (`split.py`, imported not modified) and ticket 09's bar cache
+(`cache/` symlinks to it).
+
+**Read [`FINDINGS.md`](FINDINGS.md) first.** Short version: only five of the twenty-two numbers can
+move anything, three are provably redundant, and `TIGHT_MULT` is not a detection parameter — it is
+the stop budget, which put §7 rather than list length at the centre of the ticket.
+
+## Code
+
+| file | what it does |
+| --- | --- |
+| `harness.py` | fixed sample, cached re-scans under parameter overrides, ticket 06's decile gate |
+| `bill.py` | the audit — dead, discretisation, drawing-only, redundant |
+| `lines.py` | instrumented line-validity test, per-clause attribution |
+| `tight.py` | the `TIGHT_MULT` grid with §7 columns, eye-vs-looseness, the k range |
+| `market.py` | IDX: collapsed bars, the sweep, ADR comparability |
+| `shift.py` | what a §7 stop gate does to the population ticket 15 fitted on |
+
+Run order: `bill.py` → `lines.py` → `tight.py` → `market.py` → `shift.py`. Needs `pandas numpy`
+(the `venv/` symlink points at ticket 15's) and ticket 09's cache.
+
+Scans are cached under `out/scans/`, keyed by a hash of the override set — the sweeps ask for the
+same configuration from several angles, and a full pass is ~9s. Delete `out/` to force a re-scan.
+
+`lines.py` duplicates `split.py`'s `fit_line` rather than monkeypatching it, so ticket 16's file
+stays untouched; `verify()` checks the duplicate against the original and prints the agreement
+(100.0000% on 53,922 candidates). If that number is not 100%, nothing in `FINDINGS.md` §2 counts.

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/bill.py
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/bill.py
@@ -1,0 +1,161 @@
+"""Audit the 22 numbers before fitting any of them.
+
+Fitting is expensive and a parameter only earns a fit if it is *live*. Four ways a number can fail
+to be:
+
+  dead            defined and never read
+  discretisation  a resolution knob, not a preference — converges and then stops mattering
+  drawing-only    changes what the chart shows and whether a detection exists, but ticket 18's
+                  identity means it cannot move the trigger
+  redundant       something upstream already does its job
+
+Everything left is live and goes to the sweeps. Nothing here needs the trader — these are facts
+about the code and the tape.
+"""
+
+import os
+import re
+import sys
+
+import numpy as np
+import pandas as pd
+
+import harness as H
+
+P16 = H.P16
+
+
+def dead_numbers():
+    """A parameter never read by the module is dead however plausible it looks."""
+    src = open(os.path.join(P16, "split.py")).read()
+    # the constants sit in one block above the first function, so everything from `def prior_move`
+    # onwards is use rather than definition
+    body = src.split("def prior_move", 1)[1]
+    print("=== dead: defined and never read\n")
+    for name in list(H.BILL) + list(H.DEAD):
+        uses = len(re.findall(rf"\b{name}\b", body))
+        if uses == 0:
+            print(f"  {name:20s} 0 uses in any function body — DEAD")
+    print("\n  (every other name in the bill is read at least once)")
+
+
+def trigger_identity():
+    """Ticket 18's identity, re-checked on this sample: does the fitted line ever set the level?"""
+    df = H.scan("US")
+    a = H.accepted(df)
+    print("\n=== the trigger identity (ticket 18 R1), re-measured on this sample\n")
+    # trigger = max(line_end, cluster_high); cluster_high is recoverable from the stop width.
+    line_bound = 0
+    n = len(a)
+    # split.py does not persist cluster_high, but trigger == cluster_high whenever the line loses.
+    # Recompute line_end for a subsample and compare directly.
+    import split as S
+    frames = H.frames("US")
+    checked = wins = 0
+    for sym, g in a.groupby("symbol"):
+        d = frames[sym]
+        high = d["High"].to_numpy(float)
+        low = d["Low"].to_numpy(float)
+        close = d["Close"].to_numpy(float)
+        adr = pd.Series(high / low - 1.0).rolling(20).mean().to_numpy()
+        for _, r in g.iterrows():
+            as_of, k = int(r["end"]), int(r["cluster_k"])
+            adr_abs = adr[as_of] * close[as_of]
+            ch = float(high[as_of - k + 1:as_of + 1].max())
+            anchor = (as_of - k + 1) + int(np.argmax(high[as_of - k + 1:as_of + 1]))
+            # the line can only lose height going forward: it is anchored at ch and slopes <= 0
+            checked += 1
+            if float(r["trigger"]) > ch + 1e-9:
+                wins += 1
+        if checked > 20000:
+            break
+    print(f"  detections checked           {checked:,}")
+    print(f"  fitted line set the trigger  {wins:,} ({wins / max(checked, 1):.1%})")
+    print("  the line is anchored AT the cluster high and searched over non-positive slopes,")
+    print("  so line_end <= cluster_high by construction. Four numbers below inherit this.")
+    return line_bound, n
+
+
+def discretisation():
+    """SLOPE_STEPS is a grid resolution. If the list stops moving, it is not a preference."""
+    print("\n=== discretisation: does SLOPE_STEPS converge?\n")
+    base = None
+    print(f"  {'SLOPE_STEPS':>12s} {'accepted':>10s} {'/night':>8s} {'vs 200':>9s}")
+    for v in (25, 50, 100, 200, 400, 800):
+        a = H.accepted(H.scan("US", {"SLOPE_STEPS": v}))
+        if v == 200:
+            base = len(a)
+        print(f"  {v:>12d} {len(a):>10,} {H.per_night(a):>8.1f}", end="")
+        print(f" {'—' if base is None else f'{len(a) / base - 1:+8.2%}'}")
+    print("\n  a resolution knob, not a preference: fix it and stop counting it.")
+
+
+def drawing_only():
+    """The four line-shape numbers cannot move the trigger. What DO they move?"""
+    print("\n=== drawing-only: the line-shape four (ticket 18's added scope)\n")
+    base = H.accepted(H.scan("US"))
+    print(f"  baseline {len(base):,} accepted, {H.per_night(base):.1f}/night\n")
+    print(f"  {'parameter':16s} {'value':>7s} {'accepted':>10s} {'vs base':>9s}")
+    for name, values in (("OVER_W", (1.5, 3.0, 6.0)),
+                         ("UNDER_W", (0.5, 1.0, 2.0)),
+                         ("MAX_SLOPE_ADR", (0.25, 0.5, 1.0))):
+        for v in values:
+            a = H.accepted(H.scan("US", {name: v}))
+            print(f"  {name:16s} {v:>7} {len(a):>10,} {len(a) / len(base) - 1:>+8.1%}")
+        print()
+    print("  these move only whether a line is drawable (line_ok) and what the chart draws.")
+
+
+def redundant_floor():
+    """Does the 25% prior-move floor do anything the ticket-06 decile gate has not already done?
+
+    Ticket 06 R2 gates on the union of top deciles across 1w/1m/3m/6m/12m per market — ~29% of the
+    universe. The floor is a second momentum filter on the same quantity.
+    """
+    print("\n=== redundancy: the 25% prior-move floor against ticket 06's decile gate\n")
+    ranks, _, _ = pd.read_pickle(os.path.join(H.CACHE, "ranks_us.pkl"))
+    gate = None
+    for lb, frame in ranks.items():
+        top = frame >= 0.90
+        gate = top if gate is None else (gate | top)
+    gate.index = pd.to_datetime(gate.index)
+
+    df = H.scan("US")
+    a = H.accepted(df, floor=False).copy()
+    a["date"] = pd.to_datetime(a["date"])
+    cols = set(gate.columns)
+    a = a[a.symbol.isin(cols)]
+    a = a[a.date.isin(set(gate.index))]
+    if not len(a):
+        print("  no overlap between the sample and the rank table — skipped")
+        return
+    in_gate = np.array([bool(gate.at[d, s]) for s, d in zip(a.symbol, a.date)])
+    passes = (a.move_gain >= H.MOVE_FLOOR).to_numpy()
+
+    n = len(a)
+    print(f"  detections with rank coverage      {n:,}")
+    print(f"  pass the 25% floor                 {passes.mean():.1%}")
+    print(f"  in the union-of-deciles gate       {in_gate.mean():.1%}")
+    print(f"  both                               {(passes & in_gate).mean():.1%}")
+    print()
+    print(f"  P(floor | in gate)                 {passes[in_gate].mean():.1%}")
+    print(f"  P(in gate | floor)                 {in_gate[passes].mean():.1%}")
+    print(f"  floor's marginal cut, given gate   "
+          f"{1 - passes[in_gate].mean():.1%} of gated detections")
+    print(f"  gate's marginal cut, given floor   "
+          f"{1 - in_gate[passes].mean():.1%} of floored detections")
+    both = float((passes & in_gate).sum())
+    print(f"\n  agreement (Jaccard)                "
+          f"{both / float((passes | in_gate).sum()):.1%}")
+
+
+def main():
+    dead_numbers()
+    trigger_identity()
+    discretisation()
+    drawing_only()
+    redundant_floor()
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/harness.py
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/harness.py
@@ -1,0 +1,185 @@
+"""Shared scan harness for ticket 19's parameter work.
+
+Every script here asks the same question in a different direction: if this number moved, what
+would move with it? So they all need the same three things — a fixed sample of names, a way to
+re-scan under overridden parameters, and a consistent definition of "a detection".
+
+The sample is fixed by seed so two scripts' numbers are comparable; the scan is cached to disk
+keyed by the override set, because the sweeps re-scan the same configurations repeatedly.
+"""
+
+import hashlib
+import json
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+P16 = os.path.abspath(os.path.join(HERE, "..", "16-trendline-fit"))
+sys.path.insert(0, P16)
+CACHE = os.path.join(HERE, "cache")
+OUT = os.path.join(HERE, "out")
+SCAN_CACHE = os.path.join(OUT, "scans")
+
+import split as S  # noqa: E402
+
+SEED = 19
+N_US = 400
+N_IDX = 288          # IDX's whole universe is smaller than the US sample
+STEP = 3             # 1-in-3 dates, as tickets 16/17 sampled
+MIN_LEN = 400
+SCALE = float(STEP)  # nightly counts are scaled back up for the 1-in-3 grid
+
+# Every free number in split.py. `dead` ones are defined and never read by scan().
+BILL = {
+    "MOVE_WINDOWS": (21, 42, 63, 126),
+    "MAX_BASE_LEN": 45, "MIN_BASE_LEN": 3,
+    "K_MIN": 3, "K_MAX": 7, "TIGHT_MULT": 1.5,
+    "CATCHUP_10": 1.0, "CATCHUP_20": 2.0,
+    "OVER_W": 3.0, "UNDER_W": 1.0, "SLOPE_STEPS": 200, "MAX_SLOPE_ADR": 0.5,
+    "TOUCH_TOL_ADR": 0.35, "MIN_TOUCHES": 2, "MIN_TOUCH_GAP": 3,
+    "MAX_OVERSHOOT_ADR": 1.0, "MAX_OVERSHOOT_FRAC": 0.20,
+}
+DEAD = {"MA_PROX_ADR": 0.5}
+MOVE_FLOOR = 25.0    # the prior-move floor, applied after the scan rather than inside it
+
+
+def _frames(market):
+    """The fixed sample of cleaned frames for a market."""
+    path = os.path.join(CACHE, f"universe_{market.lower()}.pkl")
+    raw = pd.read_pickle(path)
+    syms = sorted(s for s, d in raw.items() if len(d) >= MIN_LEN)
+    n = N_US if market == "US" else N_IDX
+    if len(syms) > n:
+        rng = np.random.default_rng(SEED)
+        take = sorted(int(i) for i in rng.choice(len(syms), size=n, replace=False))
+        syms = [syms[i] for i in take]
+    return {s: S.clean(raw[s]) for s in syms}
+
+
+_FRAME_CACHE = {}
+
+
+def frames(market):
+    if market not in _FRAME_CACHE:
+        _FRAME_CACHE[market] = _frames(market)
+    return _FRAME_CACHE[market]
+
+
+def _key(market, overrides):
+    blob = json.dumps({"m": market, "o": sorted(overrides.items()), "seed": SEED,
+                       "step": STEP, "n": N_US if market == "US" else N_IDX},
+                      default=str, sort_keys=True)
+    return hashlib.sha1(blob.encode()).hexdigest()[:16]
+
+
+def scan(market="US", overrides=None, verbose=False):
+    """Re-scan the fixed sample with split.py's module-level parameters overridden.
+
+    Cached on disk: the sweeps below re-request the same configuration from several angles, and a
+    full pass is ~40s.
+    """
+    overrides = dict(overrides or {})
+    os.makedirs(SCAN_CACHE, exist_ok=True)
+    path = os.path.join(SCAN_CACHE, f"{market}_{_key(market, overrides)}.pkl")
+    if os.path.exists(path):
+        return pd.read_pickle(path)
+
+    saved = {k: getattr(S, k) for k in overrides}
+    try:
+        for k, v in overrides.items():
+            setattr(S, k, v)
+        rows = []
+        for i, (sym, d) in enumerate(sorted(frames(market).items())):
+            for r in S.scan(d, range(90, len(d), STEP)):
+                r["symbol"] = sym
+                rows.append(r)
+            if verbose and i % 100 == 0:
+                print(f"    {market} {i} names, {len(rows)} rows", flush=True)
+    finally:
+        for k, v in saved.items():
+            setattr(S, k, v)
+
+    df = pd.DataFrame(rows)
+    df.to_pickle(path)
+    return df
+
+
+def accepted(df, floor=True):
+    """A detection as the nightly list would see it: all three gates, then the prior-move floor."""
+    if not len(df):
+        return df
+    ok = (df.tight.fillna(False).astype(bool)
+          & df.line_ok.fillna(False).astype(bool)
+          & df.caught_up.fillna(False).astype(bool))
+    if floor:
+        ok &= df.move_gain >= MOVE_FLOOR
+    return df[ok]
+
+
+_GATE = None
+US_UNIVERSE = 1966   # ticket 05's measured US universe, for scaling the sample back up
+
+
+def gate():
+    """Ticket 06 R2's precondition gate: the union of top deciles across 1w/1m/3m/6m/12m.
+
+    A boolean frame (date x symbol). It covers fewer names and dates than the bar cache, so
+    anything measured through it is measured on the covered subset and said so.
+    """
+    global _GATE
+    if _GATE is None:
+        ranks, _, _ = pd.read_pickle(os.path.join(CACHE, "ranks_us.pkl"))
+        g = None
+        for frame in ranks.values():
+            top = frame >= 0.90
+            g = top if g is None else (g | top)
+        g.index = pd.to_datetime(g.index)
+        _GATE = g
+    return _GATE
+
+
+def covered_names(market="US"):
+    """Sample names the rank table covers at all.
+
+    This is the scaling denominator, and it must not depend on the parameter setting: counting
+    only names that happened to produce a detection would shrink the denominator whenever the
+    detector got stricter, which flatters every tightening.
+    """
+    return len(set(frames(market)) & set(gate().columns))
+
+
+def gated(df):
+    """Restrict to detections whose name was in the decile gate that night.
+
+    Returns (gated_rows, covered_rows) — coverage is partial, so the caller reports the
+    denominator alongside.
+    """
+    g = gate()
+    if not len(df):
+        return df, df
+    d = df.copy()
+    d["date"] = pd.to_datetime(d["date"])
+    d = d[d.symbol.isin(set(g.columns)) & d.date.isin(set(g.index))]
+    if not len(d):
+        return d, d
+    keep = np.array([bool(g.at[dt, s]) for s, dt in zip(d.symbol, d.date)])
+    return d[keep], d
+
+
+def per_night(df):
+    """Mean nightly list length, scaled back up from the 1-in-3 date grid."""
+    if not len(df):
+        return 0.0
+    return float(df.groupby("date").size().mean()) * SCALE
+
+
+if __name__ == "__main__":
+    import time
+    t = time.time()
+    d = scan("US", verbose=True)
+    a = accepted(d)
+    print(f"\nUS baseline: {len(d):,} bar-dates, {len(a):,} accepted, "
+          f"{per_night(a):.1f}/night, {time.time() - t:.0f}s")

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/lines.py
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/lines.py
@@ -1,0 +1,170 @@
+"""The six line-validity numbers: which of them is actually doing the cutting?
+
+`line_ok` is the single largest behaviour change ticket 17 introduced — it drops 58.8% of ticket
+08's picks — and it is decided by six numbers nobody has looked at individually. A sweep answers
+"what happens if I move this", which is the wrong question when the real one is "does this
+constraint ever bind independently of the others".
+
+So this instruments the test instead of sweeping it: one pass records each constraint's verdict
+separately for every candidate that got as far as having a cluster. That gives the marginal cost of
+each, and — more usefully — how much of the cut survives dropping any one of them, which is what
+tells you whether six numbers are carrying six decisions or one.
+
+The fit itself is duplicated from split.py rather than monkeypatched: it belongs to ticket 16 and
+should stay untouched, and the duplication is checked against it (`verify()`).
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+
+import harness as H
+import split as S
+
+CONSTRAINTS = ["touches", "reaches_back", "overshoot_adr", "overshoot_frac"]
+
+
+def fit_flags(high, adr_abs, anchor, base_start, as_of, cluster_k):
+    """split.fit_line, with each clause of `ok` reported separately."""
+    t = np.arange(base_start, as_of + 1)
+    h = high[base_start:as_of + 1].astype(float)
+    y_a = float(high[anchor])
+    slopes = np.linspace(-S.MAX_SLOPE_ADR * adr_abs, 0.0, S.SLOPE_STEPS)
+    resid_all = h[None, :] - (y_a + slopes[:, None] * (t - anchor)[None, :])
+    loss = S.OVER_W * np.clip(resid_all, 0, None) + S.UNDER_W * np.clip(-resid_all, 0, None)
+    m = float(slopes[int(np.argmin(loss.sum(axis=1)))])
+
+    resid = h - (y_a + m * (t - anchor))
+    tol = S.TOUCH_TOL_ADR * adr_abs
+    cluster_start = as_of - cluster_k + 1
+    touch_idx = t[(np.abs(resid) <= tol) & (t < cluster_start)]
+    zones = 1 + sum(1 for a, b in zip(touch_idx[:-1], touch_idx[1:]) if b - a >= S.MIN_TOUCH_GAP) \
+        if len(touch_idx) else 0
+    over = resid > tol
+    over_max = float(resid[over].max() / adr_abs) if over.any() else 0.0
+    base_len = as_of - base_start + 1
+    reaches = bool(len(touch_idx) > 0 and touch_idx[0] <= base_start + 0.6 * base_len)
+
+    return {
+        "zones": int(zones),
+        "touches": bool(zones >= S.MIN_TOUCHES),
+        "reaches_back": bool(zones >= 1 and reaches),
+        "overshoot_adr": bool(over_max <= S.MAX_OVERSHOOT_ADR),
+        "overshoot_frac": bool(float(over.mean()) <= S.MAX_OVERSHOOT_FRAC),
+        "over_max": over_max,
+        "over_frac": float(over.mean()),
+    }
+
+
+def collect(market="US"):
+    """Every candidate that reached the line test, with each constraint's verdict."""
+    path = os.path.join(H.OUT, f"lineflags_{market}.pkl")
+    if os.path.exists(path):
+        return pd.read_pickle(path)
+    rows = []
+    for sym, d in sorted(H.frames(market).items()):
+        d = d.reset_index(drop=True)
+        high, low, close = (d[c].to_numpy(float) for c in ("High", "Low", "Close"))
+        adr = pd.Series(high / low - 1.0).rolling(20).mean().to_numpy()
+        c = pd.Series(close)
+        sma = {n: c.rolling(n).mean().to_numpy() for n in (10, 20, 50)}
+        for as_of in range(90, len(d), H.STEP):
+            a = adr[as_of]
+            if np.isnan(a) or a <= 0:
+                continue
+            adr_abs = a * close[as_of]
+            mv = S.prior_move(high, low, as_of)
+            if mv is None:
+                continue
+            gain, peak = mv
+            base_start = peak
+            if as_of - base_start + 1 > S.MAX_BASE_LEN:
+                recent = as_of - S.MAX_BASE_LEN + 1
+                base_start = recent + int(np.argmax(high[recent:as_of + 1]))
+            if as_of - base_start + 1 < S.MIN_BASE_LEN:
+                continue
+            g10 = close[as_of] - sma[10][as_of] if not np.isnan(sma[10][as_of]) else np.inf
+            g20 = close[as_of] - sma[20][as_of] if not np.isnan(sma[20][as_of]) else np.inf
+            if not (g10 <= S.CATCHUP_10 * adr_abs and g20 <= S.CATCHUP_20 * adr_abs):
+                continue
+            cl = S.find_cluster(high, low, as_of, adr_abs)
+            if cl is None:
+                continue
+            k = cl[0]
+            anchor = (as_of - k + 1) + int(np.argmax(high[as_of - k + 1:as_of + 1]))
+            f = fit_flags(high, adr_abs, anchor, base_start, as_of, k)
+            f.update({"symbol": sym, "end": as_of, "move_gain": gain,
+                      "base_len": as_of - base_start + 1, "cluster_k": k})
+            rows.append(f)
+    df = pd.DataFrame(rows)
+    df.to_pickle(path)
+    return df
+
+
+def verify(df):
+    """The duplicated fit must reproduce split.py's own line_ok, or none of this counts."""
+    ref = H.scan("US")
+    ref = ref[ref.tight.fillna(False) & ref.caught_up.fillna(False)]
+    ref = ref[ref.move_gain.notna()]
+    mine = df.copy()
+    mine["line_ok"] = (mine.touches | mine.reaches_back) & mine.overshoot_adr & mine.overshoot_frac
+    j = ref.merge(mine[["symbol", "end", "line_ok"]], on=["symbol", "end"],
+                  suffixes=("_ref", "_mine"))
+    agree = (j.line_ok_ref.astype(bool) == j.line_ok_mine).mean()
+    print(f"=== verification: duplicated fit vs split.py, n={len(j):,}  agreement {agree:.4%}")
+    if agree < 0.999:
+        print("  MISMATCH — the numbers below are not trustworthy")
+    return agree
+
+
+def main():
+    df = collect("US")
+    verify(df)
+    df = df.copy()
+    df["line_ok"] = (df.touches | df.reaches_back) & df.overshoot_adr & df.overshoot_frac
+    n = len(df)
+    print(f"\n=== line validity on {n:,} candidates that reached the test "
+          f"(cluster found, caught up)\n")
+    print(f"  line_ok passes   {df.line_ok.mean():.1%}  — the rest is what ticket 17's "
+          f"58.8% drop is made of\n")
+
+    print("  each constraint on its own:")
+    print(f"  {'constraint':18s} {'passes':>8s} {'fails':>8s}")
+    named = {"touches": f"zones >= {S.MIN_TOUCHES}",
+             "reaches_back": "zones>=1 & reaches 60% back",
+             "overshoot_adr": f"over_max <= {S.MAX_OVERSHOOT_ADR} ADR",
+             "overshoot_frac": f"over_frac <= {S.MAX_OVERSHOOT_FRAC:.0%}"}
+    for c in CONSTRAINTS:
+        print(f"  {named[c]:30s} {df[c].mean():>7.1%} {1 - df[c].mean():>7.1%}")
+
+    print("\n  what each is worth: pass rate if that constraint alone is dropped")
+    print(f"  {'dropped':30s} {'line_ok':>9s} {'recovered':>10s}")
+    base = df.line_ok.mean()
+    for c in CONSTRAINTS:
+        parts = {x: df[x] for x in CONSTRAINTS}
+        parts[c] = pd.Series(True, index=df.index)
+        ok = (parts["touches"] | parts["reaches_back"]) & parts["overshoot_adr"] \
+            & parts["overshoot_frac"]
+        print(f"  {named[c]:30s} {ok.mean():>8.1%} {ok.mean() - base:>+9.1f}pp"
+              .replace("pp", " pp"))
+
+    print("\n  the touch pair is an OR, so neither binds alone — dropping both:")
+    ok = df.overshoot_adr & df.overshoot_frac
+    print(f"  {'both touch tests':30s} {ok.mean():>8.1%} {ok.mean() - base:>+9.1%}")
+    ok2 = (df.touches | df.reaches_back)
+    print(f"  {'both overshoot tests':30s} {ok2.mean():>8.1%} {ok2.mean() - base:>+9.1%}")
+
+    print("\n  overlap between the two overshoot tests (are they one decision or two?)")
+    a, b = df.overshoot_adr, df.overshoot_frac
+    print(f"    fails ADR only     {((~a) & b).mean():>6.1%}")
+    print(f"    fails frac only    {(a & (~b)).mean():>6.1%}")
+    print(f"    fails both         {((~a) & (~b)).mean():>6.1%}")
+    print(f"    corr               {np.corrcoef(a.astype(float), b.astype(float))[0, 1]:>+6.3f}")
+
+    print("\n  TOUCH_TOL_ADR / MIN_TOUCH_GAP feed `zones`; the zone distribution:")
+    print(df.zones.value_counts().sort_index().head(8).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/market.py
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/market.py
@@ -1,0 +1,89 @@
+"""Per-market: do these numbers transfer to IDX, or does the tape break the assumption?
+
+Every parameter in the bill is expressed in ADR units and is therefore scale-free — which is the
+argument for one set of numbers across both markets. The argument has a known hole: IDX's limit
+days (ARA/ARB) and price quantization produce bars whose range is zero or a fixed tick, and a
+zero-range bar makes the cluster look tight for a reason that has nothing to do with a tightening
+base. Ticket 09 hit this at D13; ticket 15 then de-scoped it, having measured 98.1% of accepted IDX
+detections carrying zero collapsed bars.
+
+That measurement was made under the *old* detector. The cluster is selected to be tight, so it is
+exactly the window a collapsed bar would sneak into — this re-measures it on the split.
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+
+import harness as H
+import split as S
+
+GRID = [1.0, 1.25, 1.5, 1.75, 2.0]
+
+
+def collapsed_bars():
+    """How often is a cluster tight because the tape stopped moving rather than because it based?"""
+    print("=== IDX: collapsed bars inside the cluster (the D13 hole, re-measured on the split)\n")
+    a = H.accepted(H.scan("IDX"))
+    frames = H.frames("IDX")
+    zero = []
+    for sym, g in a.groupby("symbol"):
+        d = frames[sym]
+        high = d["High"].to_numpy(float)
+        low = d["Low"].to_numpy(float)
+        for _, r in g.iterrows():
+            as_of, k = int(r["end"]), int(r["cluster_k"])
+            rng = high[as_of - k + 1:as_of + 1] - low[as_of - k + 1:as_of + 1]
+            zero.append(int((rng <= 0).sum()))
+    z = np.array(zero)
+    print(f"  accepted IDX detections        {len(z):,}")
+    if not len(z):
+        return
+    print(f"  clusters with 0 collapsed bars {(z == 0).mean():.1%}")
+    print(f"  with 1                         {(z == 1).mean():.1%}")
+    print(f"  with 2+                        {(z >= 2).mean():.1%}")
+    print(f"  mean collapsed bars per cluster {z.mean():.3f} of k")
+    print("\n  ticket 15 measured 98.1% clean under the old detector; the comparison above is")
+    print("  what the split does to that, since the cluster is *selected* for tightness.")
+
+
+def idx_sweep():
+    print("\n=== TIGHT_MULT on IDX vs US: does the ADR normalisation transfer?\n")
+    print(f"  {'TIGHT':>6s} {'IDX/night':>10s} {'vs 1.5':>8s} {'k mean':>7s} "
+          f"{'stop med':>9s} {'§7 ok':>7s}")
+    base = None
+    rows = []
+    for v in GRID:
+        a = H.accepted(H.scan("IDX", {"TIGHT_MULT": v}))
+        if v == 1.5:
+            base = len(a)
+        sw = a.stopw_adr.replace([np.inf, -np.inf], np.nan).dropna()
+        d = f"{len(a) / base - 1:+7.1%}" if base else "      —"
+        print(f"  {v:>6.2f} {H.per_night(a):>10.1f} {d:>8s} {a.cluster_k.mean():>7.2f} "
+              f"{sw.median():>9.2f} {(sw <= 1.0).mean():>6.0%}")
+        rows.append({"TIGHT_MULT": v, "n": len(a), "per_night": H.per_night(a),
+                     "k_mean": float(a.cluster_k.mean()), "stop_med": float(sw.median()),
+                     "s7": float((sw <= 1.0).mean())})
+    pd.DataFrame(rows).to_pickle(os.path.join(H.OUT, "tight_IDX.pkl"))
+    print("\n  compare the US grid: if the shapes match, one number serves both markets.")
+
+
+def adr_levels():
+    """A sanity check on the normalisation itself — is IDX's ADR distribution comparable?"""
+    print("\n=== ADR distribution, both markets (the quantity every parameter divides by)\n")
+    for m in ("US", "IDX"):
+        a = H.accepted(H.scan(m))
+        q = a.adr.quantile([0.1, 0.5, 0.9])
+        print(f"  {m:4s} n={len(a):>7,}  ADR p10 {q.loc[0.1]:.3%}  median {q.loc[0.5]:.3%}  "
+              f"p90 {q.loc[0.9]:.3%}")
+
+
+def main():
+    adr_levels()
+    collapsed_bars()
+    idx_sweep()
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/shift.py
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/shift.py
@@ -1,0 +1,82 @@
+"""What the restored §7 stop gate does to the population ticket 15 fitted the rubric on.
+
+The gate was chosen partly on the argument that it disturbs ticket 15 *less* than re-tightening
+TIGHT_MULT would, because it filters the population rather than redefining the geometry. That is
+an argument, and it is cheap to check: if the surviving population's k distribution is badly
+skewed, the rubric's tightness dimension is being fed something other than what it was fitted on,
+and the difference between "filter" and "redefine" stops mattering.
+
+Also prices the gate on IDX, since the decision applies to both markets.
+"""
+
+import numpy as np
+import pandas as pd
+
+import harness as H
+
+CAP = 1.0
+
+
+def shift(market="US"):
+    a = H.accepted(H.scan(market, {"TIGHT_MULT": 1.5}))
+    sw = a.stopw_adr.replace([np.inf, -np.inf], np.nan)
+    keep = a[(sw <= CAP).fillna(False)]
+    print(f"\n=== {market}: population before and after the 1 x ADR stop gate\n")
+    print(f"  detections            {len(a):>8,}  ->  {len(keep):>8,}  "
+          f"({len(keep) / len(a):.1%} survive)")
+    print(f"  nightly (raw sample)  {H.per_night(a):>8.1f}  ->  {H.per_night(keep):>8.1f}")
+    print()
+    print(f"  {'quantity':22s} {'before':>9s} {'after':>9s} {'shift':>9s}")
+    for col, label in (("cluster_k", "cluster k (rubric)"),
+                       ("base_len", "base length"),
+                       ("cluster_range_adr", "cluster range ADR"),
+                       ("adr", "ADR"),
+                       ("move_gain", "prior move %")):
+        b, f = a[col].astype(float), keep[col].astype(float)
+        print(f"  {label:22s} {b.mean():>9.2f} {f.mean():>9.2f} {f.mean() - b.mean():>+9.2f}")
+
+    print(f"\n  k distribution (ticket 15's tightness dimension)")
+    print(f"  {'k':>3s} {'before':>9s} {'after':>9s}")
+    for k in range(3, 8):
+        b = float((a.cluster_k == k).mean())
+        f = float((keep.cluster_k == k).mean())
+        print(f"  {k:>3d} {b:>8.1%} {f:>8.1%}")
+
+    # the honest comparison: option B re-tightened k to a mean of 3.70 on US
+    if market == "US":
+        alt = H.accepted(H.scan("US", {"TIGHT_MULT": 1.0}))
+        print(f"\n  for comparison, TIGHT_MULT = 1.0 (the option not taken): "
+              f"k mean {alt.cluster_k.mean():.2f}")
+        print(f"  the gate leaves k at {keep.cluster_k.mean():.2f} against "
+              f"{a.cluster_k.mean():.2f} unfiltered")
+
+
+def graded_check():
+    """How many of ticket 15's 164 graded cards would the gate have removed?
+
+    If the gate deletes most of the graded set, the rubric's fitted thresholds are calibrated on a
+    population the screen no longer shows, and ticket 20 inherits a bigger job than it thinks.
+    """
+    import os
+    path = os.path.join(H.CACHE, "split_graded.pkl")
+    if not os.path.exists(path):
+        return
+    g = pd.read_pickle(path)
+    g = g[g.stopw_adr.notna()].copy()
+    keep = g[g.stopw_adr <= CAP]
+    print(f"\n=== ticket 15's graded cards under the gate\n")
+    print(f"  graded cards with a stop measured   {len(g)}")
+    print(f"  within the 1 x ADR cap              {len(keep)} ({len(keep) / len(g):.0%})")
+    if "eye" in g and len(keep) > 3:
+        print(f"  mean eye grade, kept                {keep.eye.astype(float).mean():.2f}")
+        print(f"  mean eye grade, removed             "
+              f"{g[g.stopw_adr > CAP].eye.astype(float).mean():.2f}")
+    print("\n  a low survival rate here does not invalidate ticket 15's fit, but it means the")
+    print("  thresholds were fitted mostly on cards the gate now removes — which is a question")
+    print("  for ticket 20, not this one.")
+
+
+if __name__ == "__main__":
+    shift("US")
+    shift("IDX")
+    graded_check()

--- a/.scratch/screening-dashboard/prototypes/19-fit-params/tight.py
+++ b/.scratch/screening-dashboard/prototypes/19-fit-params/tight.py
@@ -1,0 +1,188 @@
+"""TIGHT_MULT and the k range — the numbers that have to be chosen rather than derived.
+
+TIGHT_MULT is four things at once, which is why it cannot be fitted against a single objective:
+
+  1. §3.4's looseness auto-reject — the trader's own criterion, an eye judgement
+  2. the bound on the stop: the cluster must span <= TIGHT_MULT x ADR, and the stop runs from the
+     trigger to the cluster low
+  3. the largest single lever on nightly list length (ticket 17 measured a 63% swing)
+  4. since ticket 15, an input to the *score* — cluster length k is the rubric's tightness
+     dimension, and k is chosen as the largest window that fits under TIGHT_MULT x ADR
+
+(4) is new and is the reason this ticket could not run before 15. Moving TIGHT_MULT redistributes
+k, and k is what the rubric reads, so the parameter moves the sort as well as the list.
+
+The k range inherits its own double duty from ticket 18: the cluster high *is* the trigger, so
+K_MIN/K_MAX also set the digest's effective breakout lookback.
+
+This script measures all four consequences on one grid and hands the choice over. It does not pick
+a value — that is the trader's, against an explicit budget.
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+
+import harness as H
+
+GRID = [1.0, 1.125, 1.25, 1.375, 1.5, 1.625, 1.75, 2.0, 2.5]
+K_GRIDS = [(3, 5), (3, 7), (3, 9), (2, 7), (4, 7), (5, 9)]
+
+
+def tight_sweep(market="US"):
+    print(f"=== TIGHT_MULT, {market}: the four consequences on one grid\n")
+    rows = []
+    for v in GRID:
+        a = H.accepted(H.scan(market, {"TIGHT_MULT": v}))
+        sw = a.stopw_adr.replace([np.inf, -np.inf], np.nan).dropna()
+        # what the trader actually sees: the decile gate runs first, and the sample is 400 of the
+        # 1,966 US names, so the gated count is scaled back up to the real universe
+        if market == "US":
+            gt, cov = H.gated(a)
+            n_cov = H.covered_names(market)
+            real = H.per_night(gt) * (H.US_UNIVERSE / n_cov)
+        else:
+            gt = cov = a
+            real = np.nan
+        rows.append({
+            "TIGHT_MULT": v,
+            "accepted": len(a),
+            "per_night": H.per_night(a),
+            "gate_pass": (len(gt) / len(cov)) if len(cov) else np.nan,
+            "real_night": real,
+            "k_mean": float(a.cluster_k.mean()) if len(a) else np.nan,
+            "k3_share": float((a.cluster_k == 3).mean()) if len(a) else np.nan,
+            "stop_med": float(sw.median()) if len(sw) else np.nan,
+            "stop_p90": float(sw.quantile(0.90)) if len(sw) else np.nan,
+            # §7 caps the stop at 1 x ADR and calls anything wider a no-trade. Ticket 17 removed
+            # ticket 08's D6 gate on exactly this quantity, so this column is what that cost.
+            "stop_le_1.0": float((sw <= 1.0).mean()) if len(sw) else np.nan,
+            "stop_le_1.5": float((sw <= 1.5).mean()) if len(sw) else np.nan,
+            "rng_med": float(a.cluster_range_adr.median()) if len(a) else np.nan,
+        })
+    r = pd.DataFrame(rows)
+    base = float(r.loc[r.TIGHT_MULT == 1.5, "accepted"].iloc[0])
+    r["vs_default"] = r.accepted / base - 1.0
+
+    print(f"  {'TIGHT':>6s} {'/night':>7s} {'gated':>7s} {'vs 1.5':>8s} {'k mean':>7s} {'k=3':>6s} "
+          f"{'stop med':>9s} {'stop p90':>9s} {'§7 ok':>7s}")
+    for _, x in r.iterrows():
+        print(f"  {x.TIGHT_MULT:>6.3f} {x.per_night:>7.1f} {x.real_night:>7.1f} "
+              f"{x.vs_default:>+7.1%} "
+              f"{x.k_mean:>7.2f} {x['k3_share']:>5.0%} {x.stop_med:>9.2f} "
+              f"{x.stop_p90:>9.2f} {x['stop_le_1.0']:>6.0%}")
+    print("\n  '/night' is the raw detector on the 400-name sample; 'gated' is after ticket 06's")
+    print("  decile gate and scaled to the full 1,966-name US universe — what the trader sees.")
+    print("  '§7 ok' is the share whose trigger-to-cluster-low stop is within the method's 1 x ADR")
+    print("  cap. TIGHT_MULT *is* the stop budget: the cluster spans <= TIGHT_MULT x ADR and the")
+    print("  stop runs from the trigger to the cluster low, so the column is near-mechanical —")
+    print("  which is the point. Ticket 08 gated this at 1.0 (D6); ticket 17 deleted that gate.")
+    print(f"\n  swing across the grid: {r.vs_default.max() - r.vs_default.min():.0%} in list length")
+    r.to_pickle(os.path.join(H.OUT, f"tight_{market}.pkl"))
+    return r
+
+
+def stop_gate_option():
+    """What ticket 08's D6 would cost if restored on top of the split, rather than replaced by it.
+
+    Ticket 17's argument for deleting D6 was that the cluster bounds the stop 'as a side effect
+    rather than as a gate' — the separation the trader asked for. That argument is about *form*.
+    This is the number about *substance*: at the default, how much of the list is outside §7?
+    """
+    print("\n=== restoring a §7 stop gate on top of TIGHT_MULT = 1.5\n")
+    a = H.accepted(H.scan("US", {"TIGHT_MULT": 1.5}))
+    sw = a.stopw_adr.replace([np.inf, -np.inf], np.nan)
+    ok = sw <= 1.0
+    print(f"  detections                     {len(a):,}")
+    print(f"  within §7's 1 x ADR cap        {ok.mean():.1%}")
+    print(f"  a D6-style gate would cut      {1 - ok.mean():.1%} of the nightly list")
+    n_cov = H.covered_names("US")
+    gt, cov = H.gated(a)
+    gt2, _ = H.gated(a[ok.fillna(False)])
+    scale = H.US_UNIVERSE / n_cov
+    print(f"  gated list, full universe      {H.per_night(gt) * scale:.1f}/night  ->  "
+          f"{H.per_night(gt2) * scale:.1f}/night")
+    print(f"  (rank coverage: {n_cov} of {len(H.frames('US'))} sampled names)")
+    print("\n  compare TIGHT_MULT = 1.0 above, which reaches the same cap by construction")
+    print("  instead of by a second gate — one number rather than two, but it also re-tightens")
+    print("  the cluster the rubric reads (k) and the digest's breakout lookback.")
+
+
+def eye_on_looseness():
+    """Does the trader's eye actually dislike a loose cluster?
+
+    The 172 graded cards carry `cluster_range_adr`, so the question is answerable without new
+    grading — and it is the only evidence that could make TIGHT_MULT a *fitted* number rather than
+    a budget. Cards were selected under 1.5, so this sees the eye's response only within
+    [0, 1.5]: it can say whether tightening is supported, never whether loosening is.
+    """
+    path = os.path.join(H.CACHE, "split_graded.pkl")
+    if not os.path.exists(path):
+        print("\n  (no graded set — skipped)")
+        return
+    g = pd.read_pickle(path)
+    g = g[g.cluster_range_adr.notna() & g.eye.notna()].copy()
+    g["eye"] = g.eye.astype(float)
+    print(f"\n=== the eye against cluster looseness, n={len(g)} graded cards\n")
+    r = float(np.corrcoef(g.cluster_range_adr, g.eye)[0, 1])
+    print(f"  corr(cluster range in ADR, eye grade)  r = {r:+.3f}")
+    print(f"  (negative would mean the eye punishes a loose cluster)\n")
+    bins = [0, 0.75, 1.0, 1.25, 1.5]
+    g["band"] = pd.cut(g.cluster_range_adr, bins)
+    t = g.groupby("band", observed=True).eye.agg(["mean", "count"])
+    print(f"  {'cluster range (ADR)':22s} {'mean eye':>9s} {'n':>5s}")
+    for b, x in t.iterrows():
+        print(f"  {str(b):22s} {x['mean']:>9.2f} {int(x['count']):>5d}")
+    lo = g[g.cluster_range_adr <= 1.0].eye
+    hi = g[g.cluster_range_adr > 1.0].eye
+    if len(lo) > 5 and len(hi) > 5:
+        p = welch_p(lo.to_numpy(float), hi.to_numpy(float))
+        print(f"\n  tight (<=1.0 ADR, n={len(lo)}) {lo.mean():.2f}  vs  "
+              f"loose (>1.0, n={len(hi)}) {hi.mean():.2f}   p = {p:.3f}")
+        print("\n  the sign is the finding: every card here was selected under TIGHT_MULT = 1.5,")
+        print("  so this can only speak about tightening, and it does not support it.")
+
+
+def welch_p(a, b, iters=20000, seed=19):
+    """Two-sided permutation p-value for a difference in means (no scipy in this venv)."""
+    rng = np.random.default_rng(seed)
+    obs = abs(a.mean() - b.mean())
+    pool = np.concatenate([a, b])
+    n = len(a)
+    hits = 0
+    for _ in range(iters):
+        rng.shuffle(pool)
+        if abs(pool[:n].mean() - pool[n:].mean()) >= obs - 1e-12:
+            hits += 1
+    return (hits + 1) / (iters + 1)
+
+
+def k_sweep(market="US"):
+    """The k range sets detection AND the digest's breakout lookback AND the rubric's tightness."""
+    print(f"\n=== the k range, {market}: detection, digest lookback, rubric input\n")
+    print(f"  {'K_MIN':>6s} {'K_MAX':>6s} {'/night':>7s} {'vs 3-7':>8s} {'k mean':>7s} "
+          f"{'k med':>6s} {'stop med':>9s}")
+    base = None
+    for kmin, kmax in K_GRIDS:
+        a = H.accepted(H.scan(market, {"K_MIN": kmin, "K_MAX": kmax}))
+        if (kmin, kmax) == (3, 7):
+            base = len(a)
+        sw = a.stopw_adr.replace([np.inf, -np.inf], np.nan).dropna()
+        d = f"{len(a) / base - 1:+7.1%}" if base else "      —"
+        print(f"  {kmin:>6d} {kmax:>6d} {H.per_night(a):>7.1f} {d:>8s} "
+              f"{a.cluster_k.mean():>7.2f} {a.cluster_k.median():>6.0f} "
+              f"{sw.median():>9.2f}")
+    print("\n  k is the effective breakout lookback (ticket 18 R3) and the rubric's tightness")
+    print("  dimension (ticket 15 R1), so this grid moves the digest and the sort, not just the list.")
+
+
+def main():
+    r = tight_sweep("US")
+    stop_gate_option()
+    eye_on_looseness()
+    k_sweep("US")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Resolves [ticket 19](.scratch/screening-dashboard/issues/19-fit-the-split-parameters.md).

**Nothing is fitted, and that is the answer.** Of the 22 numbers, five can move anything; three are provably redundant and deleted; the rest stand as borrowed defaults with the measurement that froze them.

- `MA_PROX_ADR` is dead. `OVER_W`/`UNDER_W` are one *ratio* — measured byte-identical lists. `SLOPE_STEPS` converges at 25 of 800 steps. `MAX_OVERSHOOT_FRAC` catches 4.4% the ADR test misses. The prior-move floor duplicates the decile gate, which cuts 89.4% of what the floor passes against the floor's 7.7%.
- Line validity is **two decisions behind five numbers**, not six: `MAX_OVERSHOOT_ADR` does the cutting (+20.2pp), and the four touch numbers are an OR in which neither branch binds alone.
- **`TIGHT_MULT` is the stop budget, not a detection parameter.** Against §7's 1×ADR cap, **92% of the nightly list is a no-trade**. Restoring ticket 08's D6 gate was measured and declined — it keeps 8.5% of detections and removes 85% of ticket 15's graded cards, preferentially the ones that graded *highest*. The eye prefers what the stop rule rejects, on all three measurements taken. §7 therefore moves to the display, never the filter.
- One parameter set serves both markets (IDX tracks US to two decimals). D13's collapsed-bar hole stays closed at 98.5%. Ticket 18's reopen condition is **discharged** — none of `TIGHT_MULT`/`K_MIN`/`K_MAX` moved.

Also amends ticket 11 (I4's stop column is right, its base rate is backwards) and opens ticket 21 for what the collision means for the sort.

Prototype in `.scratch/screening-dashboard/prototypes/19-fit-params/`; the instrumented line-fit reproduces `split.py`'s own `line_ok` at 100.0000% on 53,922 candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)