### PR TITLE
Resolve ticket 26: the line penalty is a silent tiebreak

### DIFF
--- a/.scratch/screening-dashboard/issues/26-the-line-penalty-and-the-longer-list.md
+++ b/.scratch/screening-dashboard/issues/26-the-line-penalty-and-the-longer-list.md
@@ -1,7 +1,7 @@
 # What does the line penalty look like, and does the list survive at 9.5 a night?
 
 Type: grilling
-Status: open
+Status: resolved
 Blocked by: —
 
 ## Question
@@ -53,3 +53,119 @@ specified still works at the new size.
 
 If the answer is "refit the rubric with a new dimension", that is a second grading round and should
 be split out rather than absorbed here.
+
+## Answer
+
+**The penalty is a silent tiebreak, and the list this ticket was framed around is three times the
+size the map recorded.** Full working: [`FINDINGS.md`](../prototypes/26-line-penalty/FINDINGS.md).
+
+Grilling only — no new grades. Every number below comes from deck F's existing 105 grades, ticket
+15's published rubric, ticket 25's `split.pkl` scan and ticket 18's cached consecutive-bar scan.
+
+### R1. The rubric does not demote them already, so any demotion is deliberate
+
+Deck F's cards had only ever been read by the eye. Scored with ticket 15 R4's thresholds, the
+machine returns **the same null**: `line_not_drawable` grades **−0.03★** against detections (95% CI
+−0.46 to +0.40) where the eye read −0.12★. Agreement with the eye is if anything slightly better on
+the marginal arm (r = +0.223 vs +0.180; pooled +0.198). **Two independent rulers, one null** — so
+the remedy is not "restore a demotion the score is already applying", it is "add one, knowing the
+evidence says it should be small".
+
+### R2. A tiebreak, keyed on any line failure, and nothing more
+
+`line_ok` sorts **below** an accepted name **at equal star score**, and has no other effect.
+Trader's call. It touches no fitted number, adds no dimension, invents no tunable, and forces no
+second grading round — while still honouring ticket 25's pre-registered "scored penalty" rather
+than quietly reverting to a flat admission. It is insurance against the gap deck F could not
+exclude: anything worse than −0.72★ is ruled out, −0.5★ is not.
+
+**Keyed on the whole path, not the overshoot sub-test.** The overshoot lead survives contact with
+the second ruler — machine −0.42★ against the eye's −0.84★, the only sub-test either ruler thinks
+is working — but the cards failing **both** sub-tests grade **+0.25★ by eye, above detections**,
+56% at ≥4★, and an overshoot key demotes that group hardest. A shape that gets its best-graded
+group backwards is not a shape at n=8. Collecting more cards on the split was put as an option in
+its own right and **declined**: a tiebreak is already the smallest effect available, so refining
+its shape is precision the map cannot spend twice.
+
+### R3. Nothing marks it — not in the row, not on the chart
+
+Trader's call, against the live argument that a sort key you cannot audit is one you will not trust
+(ticket 15 R4's own reasoning, and the reason the rubric is boolean). No glyph, no column, and
+ticket 11's I4 inventory is unchanged. **The chart draws the fitted line exactly as for any other
+name** — checked in the detector: the envelope is always computable, `line_ok` is a verdict on the
+fit's quality and not on whether one exists, so there is always a line to draw. Ticket 18's identity
+makes it decoration either way, since the line never reaches the trigger.
+
+The consequence, stated plainly: at equal score two rows swap for a reason the screen never shows.
+The defence is that the reason is visible in the drawing the chart already renders — the candles
+either touch that line twice or they do not.
+
+### R4. The digest takes them: ~7.0 → ~9.6 US rows a night
+
+Measured, not assumed, by re-running ticket 18's own classifier with the line test as a switch.
+Membership ignores `line_ok`, consistent with 18 R5, which already fixed that digest membership
+ignores quality cuts (it ignores the stop entirely). Keeping the line test as a digest gate would
+reinstate as a filter, in one place, the test just removed everywhere else for not separating.
+
+The growth is **+37%, not +59%**, because **marginal names break through their trigger at 0.62× the
+accepted rate** (US 3.04% vs 4.90% of detection-nights; IDX 2.28% vs 3.66%). IDX goes 0.9 → ~1.2.
+
+### R5. The break-rate gap is real, and is not priced into the score
+
+It is not the level sitting further away (distance to trigger 0.69 vs 0.65 ADR) and it is not base
+length — it holds inside every length bucket, most extremely at L ≤ 10 (**0.74% vs 4.88%**). This is
+the **first non-eye evidence about this population on the map**, and it points the same way a
+penalty would.
+
+It is still **not** a score input, trader's call. A lower break rate is not a worse setup: no return
+is attached to it, and these bases may simply take longer or resolve down. Pricing it in would be
+ticket 24's error for the fourth time — judging with the wrong ruler — with the rulers reversed.
+Recorded as a validation question instead.
+
+### R6. Ticket 11's screen is unchanged
+
+I2's scan-not-a-queue argument was never about length; it was a refusal to read a machine-chosen
+subset. A cap, a star floor and a default filter were all available and all cost a tunable. Raising
+the trade line above 4★ was put and declined — ticket 15 R5 already tested ≥4.5★ and rejected it on
+a pre-registered bar, and the only evidence for re-opening is 12 called cards.
+
+**The one adverse measurement is recorded rather than acted on**: precision at the 4★ line reads
+0.71 on detections alone and **0.58 once the marginal names are merged in** (deck F, 12 cards
+called). It is a hint, it cannot move a threshold, and it points at the exact row ticket 11 says
+gets read. Ticket 15 R5's headline 0.53 was measured on a different deck and is not directly
+comparable.
+
+### R7. The correction: every list-size level on this map is a sample count
+
+This ticket's second half was framed as "does the list survive at 9.5 a night?" — and **9.5 is not
+the app's list length.** `split.pkl` scans **628 US symbols** (a random Nasdaq draw plus a 39-name
+momentum core, `universe.py`) against ticket 05's measured **1,966**. Ticket 25's `lnd_cost.py`
+scales ×3 for the 1-in-3 date grid and **not** for the universe. Ticket 18's `crossings.py` scales
+for the universe explicitly. **The two figures this ticket set side by side were on different
+bases.**
+
+| | as specified | with the demotion |
+| --- | --- | --- |
+| list, sample-scale (as ticket 25 wrote it) | 5.98 | 9.52 |
+| **list, universe-scale (×3.13)** | **18.7** | **29.8** |
+| digest (already universe-scale) | 7.0 | ~9.6 |
+
+`nightly_mix.py` reproduces 5.98 → 9.52 exactly before rescaling, so this is a scaling error, not a
+disagreement about the population. **The +59% ratio is unaffected** — it is a ratio inside one pool,
+and deck F priced it correctly. R6 was decided against the corrected ~19 → ~30, not against 9.5.
+
+Two caveats keep this a correction rather than a measurement: the scan pool is not ticket 05's
+liquidity-gated universe, so the rescale transfers a per-name rate across populations of different
+composition; and ticket 19's 39.7 gated names/night uses ticket 06's five-window union gate rather
+than ticket 08's D15 three-window decile. **No list level on this map has been measured on the real
+universe** — parked as fog, because no spec decision depends on it and ticket 12's ingest makes it
+free to measure the day it exists.
+
+### R8. The write path needs a version bump, not a schema change
+
+`line_ok`, `touch_zones` and `overshoot_adr` are already in ticket 08 D16's persisted signal vector,
+so storing the demoted signal is free, as this ticket guessed. What is **not** free: 59% more rows
+start being written as detections under a changed definition, and nothing in the stream marks the
+boundary. The map's validation patch already requires the **detector version** to be written
+alongside each detection (from ticket 17's swap); this remedy is a second detector-definition
+change and needs the same bump. Free today, irrecoverable afterwards.

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -83,6 +83,15 @@ is written during wayfinding.
   at full power (+0.03★, n=33), which is tickets 19 and 24's pattern a third time: a rule about
   *entry* measured with a ruler about *quality*. Parked as fog, because it needs a different
   question rather than more cards.
+  **Ticket 26 closed the operational half and left the map with a smaller worry and a new one.**
+  The remedy is a **silent tiebreak** — no refit, no dimension, no tunable — chosen after the
+  *machine* was pointed at deck F's cards for the first time and returned the same null as the eye
+  (−0.03★ against −0.12★), so **two independent rulers agree there is nothing much to demote**. The
+  new worry is not about the line test at all: **every list-size level on this map is a sample
+  count**. Ticket 25's 5.98 → 9.5 names a night is measured over 628 scanned symbols against ticket
+  05's 1,966-name universe and scaled only for the date grid, while ticket 18's 7.0 digest rows is
+  scaled for the universe — so the app's nightly list is nearer **19 → 30**, and the two figures the
+  map has been quoting side by side were never on the same basis. Ratios survive; levels do not.
 - **Standing property of the data layer** (found independently by tickets 01, 02 and 03): **Yahoo fails
   as silence.** Throttled requests return empty results — and for price history, the literal message
   "possibly delisted; no price data found". Every ingestion path must distinguish throttling from
@@ -492,7 +501,39 @@ is written during wayfinding.
   length k replicates a fourth time** (+0.329, p = 0.001); and the **ceiling reaches 30 pairs at
   +0.846**, the pooled 24-pair figure the map had owed having been computed free (+0.855) before the
   deck was rendered. The penalty's shape and the longer list graduated to
-  [ticket 26](issues/26-the-line-penalty-and-the-longer-list.md).
+  [ticket 26](issues/26-the-line-penalty-and-the-longer-list.md), **which has since resolved and
+  corrected this ticket's cost figure — the list is ~19 → ~30 a night, not 5.98 → 9.5.**
+
+- [What does the line penalty look like, and does the list survive?](issues/26-the-line-penalty-and-the-longer-list.md)
+  — **a silent tiebreak, and the list was never 9.5 a night.** The penalty is the smallest shape
+  available: `line_ok` sorts **below an accepted name at equal star score** and does nothing else —
+  no dimension, no refit, no second grading round, no tunable, and **nothing marks it** (no glyph,
+  no column, and the chart draws the fitted line exactly as for any other name, since the envelope
+  is always computable and `line_ok` only ever judged its quality). The decision rests on a
+  measurement nobody had taken: deck F's cards had only been read by the eye, and **scored with
+  ticket 15's rubric the machine returns the same null** — `line_not_drawable` at **−0.03★**
+  (CI −0.46 to +0.40) against the eye's −0.12★, with agreement no worse on the marginal arm
+  (r = +0.223 vs +0.180). Two rulers, one null: the score was not quietly demoting these names
+  already, so any demotion had to be added deliberately, and the evidence caps how much.
+  **The overshoot lead does not become a shape**: it survives the second ruler (machine −0.42★ vs
+  eye −0.84★, the only sub-test either thinks is working), but the cards failing **both** sub-tests
+  grade **+0.25★ above detections**, 56% at ≥4★, and an overshoot key demotes them hardest. Ticket
+  11's screen is **unchanged**, and its precision cost is recorded rather than acted on: at the 4★
+  line, 0.71 on detections alone → **0.58 merged** (12 cards called, a hint that cannot move a
+  threshold ticket 15 R5 has now upheld three times). The digest **takes them, ~7.0 → ~9.6 US rows a
+  night** — growth of +37% rather than +59%, because of the finding that outlives the ticket:
+  **marginal names break through their trigger at 0.62× the accepted rate** (3.04% vs 4.90% of
+  detection-nights), not explained by distance to the level (0.69 vs 0.65 ADR) and holding inside
+  **every** base-length bucket, most extremely at L ≤ 10 (0.74% vs 4.88%). That is the **first
+  non-eye evidence about this population on the map**, and it is deliberately **not** priced into
+  the score — a lower break rate is not a worse setup with no return attached, and pricing it would
+  be ticket 24's wrong-ruler error a fourth time with the rulers reversed. **The correction is the
+  bigger output**: `split.pkl` scans **628 US symbols** against ticket 05's **1,966**, and ticket
+  25's cost figure scales for the 1-in-3 date grid but **not** for the universe, while ticket 18's
+  `crossings.py` scales for both — so the nightly screen is **~18.7 → ~29.8 names**, the +59% ratio
+  is untouched, and the two numbers the map quoted side by side were on different bases. The write
+  path needs a **detector-version bump** (`line_ok` is already in D16's persisted vector, but 59%
+  more rows begin being written under a changed definition, and nothing marks the boundary).
 
 - [Does IDX need its own thresholds?](issues/22-idx-per-market-calibration.md) — **no: one threshold
   set covers both markets**, and the reason is more interesting than the ruling. Both pre-registered
@@ -662,7 +703,9 @@ is written during wayfinding.
   is load-bearing here: detections recorded before the swap are under a different definition, and nothing
   marks the boundary unless **the detector version is written alongside them**. That is a small, free
   addition to the write path today and irrecoverable afterwards — the same shape as the map's other five
-  capture streams.
+  capture streams. **Ticket 26 made that requirement recurring rather than one-off**: demoting
+  `line_ok` is a second change to what counts as a detection, and it starts writing 59% more rows
+  under the new definition. The version stamp is not a marker for one swap, it is a column.
   **Ticket 12 made this patch tractable and then put one stain on it.** Tractable, because A4 lands all six
   streams through a single dated, append-only write path from launch — the archive is no longer six
   bolt-on captures but the thing the app itself reads, so it cannot quietly diverge from what was shown on
@@ -699,6 +742,19 @@ is written during wayfinding.
      "do not fight k" argument a statement about §7 rather than about geometry.
   A residual trap survives even measurement 1: §6 usually enters on the opening range, so the breakout-day
   low is itself a proxy — but it errs **narrow-to-wide**, the safe direction, unlike the cluster low.
+  **Ticket 26 added the first non-eye measurement this patch has ever had, and it is already
+  collected.** The names `line_ok` used to reject **break through their trigger at 0.62× the rate of
+  accepted ones** (3.04% vs 4.90% of detection-nights, US; 2.28% vs 3.66% IDX), not explained by
+  distance to the level and holding inside every base-length bucket — 0.74% vs 4.88% at L ≤ 10. The
+  eye says these names are indistinguishable (−0.12★) and the rubric agrees (−0.03★); **the tape
+  does not**. Ticket 26 declined to price it into the score, because a break rate is not a return:
+  a base that breaks less often may resolve later, or lower, and nothing here can tell those apart.
+  That makes it the map's **third** eye-versus-something disagreement, alongside the eye-versus-§7
+  stop and the eye-versus-outcomes result ticket 09 found — and unlike those, its arms are already
+  written to the archive by ticket 12's A4 at 23,605 vs 22,375 detections, so the follow-up question
+  is only *what happens next* to the two populations. It needs forward returns, not more grading,
+  and it inherits the same trap: a rule about which setups *complete* is not a rule about which
+  setups are *good*.
   <!-- "Alerting" graduated into ticket 14 and is now resolved: v1 does not alert; a per-market digest of
        real breaks only. See Decisions so far. -->
 - **Watchlist persistence and user state.** **Narrowed by ticket 12, not cleared.** The storage half is
@@ -732,6 +788,20 @@ is written during wayfinding.
   What would sharpen it into a ticket is naming that question: probably something about realised stop
   distance at entry for names that were extended when detected, which is forward-history work and
   therefore folds into the validation patch above.
+- **No list level on this map has been measured on the real universe.** Found by
+  [ticket 26](issues/26-the-line-penalty-and-the-longer-list.md): the detection scans run over a
+  **628-name US sample** (`universe.py` draws random Nasdaq common stock plus a 39-name momentum
+  core) against ticket 05's measured **1,966**, and the tickets differ in whether they scale for it
+  — ticket 18's `crossings.py` does, ticket 25's `lnd_cost.py` does not, and ticket 19 uses ticket
+  06's five-window union gate where ticket 08's D15 says three. So the map carries "~63 a night"
+  (17), "39.7 a night" (19) and "5.98 a night" (25) for overlapping quantities, and the best current
+  estimate of the app's nightly list is **~19 as specified, ~30 with ticket 26's remedy**, obtained
+  by rescaling rather than by measuring. Every *ratio* on the map survives this; every *level* is
+  provisional. It is fog rather than a ticket because **no spec decision depends on the level** —
+  ticket 26 re-put its list question at the corrected size and the answer did not move — and because
+  ticket 12's ingest makes the real number free to compute the day it exists. What would sharpen it
+  into a ticket is a decision that actually turns on list length: a cap, a star floor, or any
+  reading-cost argument, none of which v1 currently contains.
 - **Survivorship bias.** Yahoo's screener enumerates only live names, so delisted history is not
   discoverable. Harmless for nightly scanning, potentially fatal for any backtest — folds into the
   validation patch above once that takes shape.

--- a/.scratch/screening-dashboard/prototypes/26-line-penalty/FINDINGS.md
+++ b/.scratch/screening-dashboard/prototypes/26-line-penalty/FINDINGS.md
@@ -1,0 +1,128 @@
+# Ticket 26 — the line penalty is a silent tiebreak, and the list is three times what the map said
+
+Working for [ticket 26](../../issues/26-the-line-penalty-and-the-longer-list.md). No new grading:
+every number here comes from deck F's existing 105 grades, ticket 15's published rubric, ticket 25's
+`split.pkl` scan and ticket 18's cached consecutive-bar scan.
+
+| script | what it measures |
+| --- | --- |
+| `deckF_machine.py` | deck F's three arms scored with ticket 15 R4's rubric — the machine's view of cards only the eye had seen |
+| `nightly_mix.py` | the merged nightly list: length, star distribution, and what sits at the top of ticket 11's sort |
+| `digest_volume.py` | ticket 18's classifier re-run with the line test as a switch |
+
+Environment: symlink ticket 09's `cache/` into `../09-star-score/cache` and use a pandas 3.x venv
+(the cached pickles are `datetime64[s]`-backed). `digest_volume.py` reads ticket 18's `out/daily.pkl`
+and finds it in the ticket-18 worktree if it is not local.
+
+---
+
+## 1. The machine does not separate them either
+
+Ticket 25 measured the `line_not_drawable` arm against the eye. Nobody asked what the rubric that
+sorts the list says about the same cards.
+
+| arm | n | machine | eye | machine ≥4★ | eye ≥4★ |
+| --- | --- | --- | --- | --- | --- |
+| accepted detections | 33 | 2.92 | 2.97 | 21% | 39% |
+| `line_not_drawable` | 33 | **2.89** | 2.85 | 15% | 33% |
+| `not_caught_up` | 33 | 2.74 | 3.00 | 15% | 36% |
+
+Machine Δ = **−0.03★** (95% CI −0.46 to +0.40) against the eye's −0.12★. **Both rulers return the
+same null**, which is the fact the remedy has to be built on: the rubric is not quietly demoting
+these names already, so whatever demotion they get has to be added deliberately — and the evidence
+says it should be small.
+
+Agreement with the eye is the same on both populations (r = +0.180 accepted, **+0.223** marginal,
+pooled +0.198, mae 1.06★), so the rubric is not *worse* at reading marginal names. It is equally
+weak on both, consistent with ticket 20's finding that it captures about a third of the achievable.
+
+## 2. Where they land in the sort, and the one place they look worse
+
+On 250 sampled nights, scored and sorted as ticket 11's screen would:
+
+| | accepted | marginal |
+| --- | --- | --- |
+| mean machine star | 3.05 | 2.94 |
+| share ≥ 4★ | 24% | **15%** |
+| share ≥ 3★ | 64% | 60% |
+
+So they interleave, with a mild thinning at the top: the list grows **+59%** but rows at ≥4★ grow
+only **+38%** (1.43 → 1.97 a night, sample-scale). Marginal names take **35% of the top 3** and 37%
+of the top 10, against a 37% share of the list — proportional, not concentrated.
+
+**The one adverse signal is precision at the trade line.** On deck F, of cards the machine calls
+≥4★, the share the eye also calls ≥4★ is **0.71 on detections alone and 0.58 once the marginal names
+are merged in** (0.40 on the marginal arm by itself). Only 12 cards are called at all, so this is a
+hint and cannot move a threshold — but it is the only measurement pointing at a real cost, and it
+points at the exact row ticket 11 says gets read.
+
+## 3. The sub-tests, in both rulers
+
+| failure | n | machine | Δ | eye | Δ |
+| --- | --- | --- | --- | --- | --- |
+| touches only | 16 | 3.19 | +0.26 | 3.00 | +0.03 |
+| overshoot only | 8 | 2.50 | **−0.42** | 2.12 | **−0.84** |
+| both | 9 | 2.72 | −0.20 | **3.22** | **+0.25** |
+
+The overshoot lead survives contact with the second ruler — both agree it is the only sub-test doing
+work — but **the `both` group is what kills it as a shape**: it grades *above* detections by eye
+(56% at ≥4★), and any rule keyed on overshoot demotes it hardest. A shape that gets its best-graded
+group backwards is not a shape, at n=8 and n=9.
+
+## 4. The digest: +37%, not +59%, because these names break less
+
+Ticket 18's classifier, re-run with detection as `tight & caught_up` with and without `& line_ok`:
+
+| | detections | digest rows/night (ungated) | break rate per detection-night |
+| --- | --- | --- | --- |
+| US, line_ok gates | 22,375 | 0.92 | **4.90%** |
+| US, line_ok demoted | 45,980 | 1.92 | marginal names **3.04%** |
+| IDX, line_ok gates | 6,867 | 0.22 | 3.66% |
+| IDX, line_ok demoted | 13,261 | 0.47 | marginal names 2.28% |
+
+**Marginal names break through their trigger at 0.62× the accepted rate**, so the digest grows by
+less than the list: applying the gated +59% growth and the measured relative rate, ticket 18's
+**7.0 → ~9.6 US rows a night**, and 0.9 → ~1.2 on IDX.
+
+The rate gap is not the level sitting further away (distance to trigger 0.69 vs 0.65 ADR) and it is
+not base length — it holds inside every length bucket, most extremely at L ≤ 10, where marginal
+names break **0.74%** of detection-nights against **4.88%** for accepted ones:
+
+| base length | marginal break rate | accepted break rate |
+| --- | --- | --- |
+| ≤ 10 | 0.74% (n=5,979) | 4.88% (n=7,151) |
+| 11–15 | 3.08% | 5.38% |
+| 16–20 | 4.41% | 5.01% |
+| 21–30 | 3.68% | 4.81% |
+| 31–45 | 3.92% | 4.32% |
+
+This is the first non-eye evidence about this population on the map. It is **not** priced into the
+score: a lower break rate is not a worse setup — there is no return attached to it, and these bases
+may simply take longer. Recorded as a validation question, which is ticket 24's rule (do not judge a
+rule with the wrong ruler) applied to a finding rather than to a rule.
+
+## 5. The list is ~3× what the map has been saying
+
+`split.pkl` covers **628 US symbols** — `universe.py` draws a random sample of Nasdaq common stock
+plus a 39-name momentum core — against ticket 05's measured **1,966-name** universe. Ticket 25's
+`lnd_cost.py` scales ×3 for the 1-in-3 date grid and **not** for the universe; ticket 18's
+`crossings.py` scales for the universe explicitly (`scale = 1966 / names`). **The two numbers ticket
+26 puts side by side are on different bases.**
+
+| | as specified | with the demotion |
+| --- | --- | --- |
+| list, sample-scale (ticket 25's figures) | 5.98 | 9.52 |
+| **list, universe-scale (×3.13)** | **18.7** | **29.8** |
+| digest (already universe-scale) | 7.0 | ~9.6 |
+
+`nightly_mix.py` reproduces ticket 25's 5.98 → 9.52 exactly before rescaling, so this is a scaling
+error and not a disagreement about the population.
+
+**The +59% ratio is unaffected** — it is a ratio inside one pool, and deck F priced it correctly.
+What was wrong is the level, which is the number ticket 26's second half was framed around.
+
+Two caveats. The scan pool is not ticket 05's liquidity-gated universe, so the rescale transfers a
+per-name detection rate across populations of different composition — it is the map's own
+convention, not a measurement. And ticket 19 reports 39.7 gated names/night using ticket 06's
+**five-window union** gate; on ticket 08's D15 (top decile in any of 1m/3m/6m), which is what the
+detector specifies, it is the 18.7 above. Neither level has ever been measured on the real universe.

--- a/.scratch/screening-dashboard/prototypes/26-line-penalty/README.md
+++ b/.scratch/screening-dashboard/prototypes/26-line-penalty/README.md
@@ -1,0 +1,40 @@
+# Ticket 26 — the line penalty and the longer list
+
+Throwaway working for [`26-the-line-penalty-and-the-longer-list.md`](../../issues/26-the-line-penalty-and-the-longer-list.md).
+**Read [`FINDINGS.md`](FINDINGS.md) first.**
+
+No new grading. Ticket 26 was a grilling ticket and every number here is recomputed from evidence
+that already existed: deck F's 105 grades, ticket 15's published rubric, ticket 25's `split.pkl`
+scan, and ticket 18's cached consecutive-bar scan.
+
+| file | what it does |
+| --- | --- |
+| `deckF_machine.py` | scores deck F's three arms with ticket 15 R4's thresholds — the machine's view of cards only the eye had seen |
+| `nightly_mix.py` | the merged nightly list: length (both scales), star distribution, and the top of ticket 11's sort |
+| `digest_volume.py` | ticket 18's classifier re-run with the line test as a switch |
+
+Run order is free; nothing depends on anything else here.
+
+```
+./deckF_machine.py F=342443144532212342111434311434253524334334252443334444223325421431224312222223244354422234245233422234221
+./nightly_mix.py nights=250
+./digest_volume.py
+```
+
+## Environment
+
+Needs ticket 09's `cache/` symlinked into `../09-star-score/cache` and **pandas 3.x** (the cached
+pickles carry `datetime64[s]`-backed frames that pandas 2.3 cannot unpickle). `digest_volume.py`
+also needs ticket 18's `out/daily.pkl`; it looks locally first and falls back to the ticket-18
+worktree.
+
+## Caveats
+
+- The scan pool is **628 US names** — a random Nasdaq draw plus a 39-name momentum core — not ticket
+  05's 1,966-name liquidity-gated universe. `nightly_mix.py` prints both the raw sample count and the
+  ×3.13 rescale, and says which convention each earlier ticket used. See FINDINGS §5.
+- `digest_volume.py` inherits ticket 18's caveat: D15's decile gate is not applied to its scan, so
+  its rows-per-night figures are upper bounds. The **ratio** between the two gate sets is the
+  answer; the levels are ticket 18's.
+- Sub-test splits are n=8/n=9 and were pre-registered as descriptive only. Nothing here re-opens
+  that.

--- a/.scratch/screening-dashboard/prototypes/26-line-penalty/deckF_machine.py
+++ b/.scratch/screening-dashboard/prototypes/26-line-penalty/deckF_machine.py
@@ -1,0 +1,170 @@
+"""Ticket 26 — score deck F's cards with ticket 15's published rubric.
+
+Ticket 25 measured the `line_not_drawable` arm against the EYE and found no separation. It never
+asked what the MACHINE says about the same cards. That is the number ticket 26 needs, because the
+remedy is a change to a ranking: if the rubric already sorts the marginal names below the accepted
+ones, part of the penalty is already paid and a further demotion is double-counting; if it sorts
+them level, the whole question is where the penalty goes.
+
+Also recomputes ticket 15 R5's precision at the 4-star line separately per arm — R5's 0.53 was
+measured before the population grew.
+
+Usage: deckF_machine.py F=<grades string>
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+P15 = os.path.abspath(os.path.join(HERE, "..", "15-grading-round-2"))
+P09 = os.path.abspath(os.path.join(HERE, "..", "09-star-score"))
+for p in (P15, P09):
+    sys.path.insert(0, p)
+CACHE = os.path.join(P09, "cache")
+
+from rubric3 import score3                     # noqa: E402
+from split_signals import signals_at, frames   # noqa: E402
+import ranks as R                              # noqa: E402
+
+# ticket 15 R4 / ROUND3_RESULTS.md — the published set, not rubric3.py's defaults
+T_R3 = {"cluster_k": 4, "ord_lo": 0.275, "ord_hi": 0.50, "dryup": 0.90, "len_ok": 26}
+
+ARMS = ["detection", "line_not_drawable", "not_caught_up"]
+
+
+def load(grades):
+    man = pd.read_csv(os.path.join(P15, "deckF_manifest.csv")).sort_values("card")
+    if len(grades) != len(man):
+        raise SystemExit(f"got {len(grades)} grades, deck has {len(man)} cards")
+    man = man.assign(eye=[int(c) for c in grades])
+    rk, _, _ = R.load_or_build()
+    sectors = pd.read_pickle(os.path.join(CACHE, "sectors_us.pkl"))
+    fr = frames("US")
+    out = []
+    for _, r in man.iterrows():
+        d = fr.get(r.symbol)
+        if d is None:
+            continue
+        sig = signals_at(d, int(r.end))
+        if sig is None:
+            continue
+        pm = R.prior_move_pct(rk, r.symbol, r.date)
+        ss = R.sector_share_loo(rk, sectors, r.symbol, r.date)
+        s = score3({**sig, "adr": r.adr}, pm, ss, "boolean", T=T_R3)
+        out.append({**r.to_dict(), "machine": s["stars"], "points": s["points"],
+                    "prior_move": pm, "sector_share": ss})
+    return pd.DataFrame(out)
+
+
+def welch(a, b):
+    a, b = np.asarray(a, float), np.asarray(b, float)
+    d = a.mean() - b.mean()
+    se = np.sqrt(a.var(ddof=1) / len(a) + b.var(ddof=1) / len(b))
+    return d, se, (d - 1.96 * se, d + 1.96 * se)
+
+
+def main(grades):
+    df = load(grades)
+    print(f"scored {len(df)} of 105 cards with ticket 15 R4 thresholds {T_R3}\n")
+
+    print("=== machine star score by arm (the sort key ticket 11's list uses)")
+    print(f"{'arm':20s} {'n':>3s} {'machine':>8s} {'eye':>6s} {'m>=4':>6s} {'eye>=4':>7s}")
+    for tag in ARMS:
+        d = df[df.tag == tag]
+        if not len(d):
+            continue
+        print(f"{tag:20s} {len(d):3d} {d.machine.mean():8.2f} {d.eye.mean():6.2f} "
+              f"{(d.machine >= 4).mean():6.0%} {(d.eye >= 4).mean():7.0%}")
+    rep = df[df.tag.str.startswith("repeat")]
+    if len(rep):
+        print(f"{'repeats':20s} {len(rep):3d} {rep.machine.mean():8.2f} {rep.eye.mean():6.2f}")
+
+    acc = df[df.tag == "detection"]
+    for tag in ARMS[1:]:
+        d = df[df.tag == tag]
+        if not len(d):
+            continue
+        dd, se, ci = welch(d.machine, acc.machine)
+        print(f"\n{tag} vs detections, MACHINE: {dd:+.2f}* (se {se:.2f}, "
+              f"95% CI {ci[0]:+.2f} to {ci[1]:+.2f})")
+        de, see, cie = welch(d.eye, acc.eye)
+        print(f"{tag} vs detections, EYE:     {de:+.2f}* (se {see:.2f}, "
+              f"95% CI {cie[0]:+.2f} to {cie[1]:+.2f})")
+
+    print("\n=== agreement with the eye, per arm")
+    for tag in ARMS:
+        d = df[df.tag == tag]
+        if len(d) < 3:
+            continue
+        r = np.corrcoef(d.machine, d.eye)[0, 1]
+        print(f"{tag:20s} n={len(d):3d}  r = {r:+.3f}  mae = "
+              f"{np.abs(d.machine - d.eye).mean():.2f}*")
+    r_all = np.corrcoef(df.machine, df.eye)[0, 1]
+    print(f"{'pooled':20s} n={len(df):3d}  r = {r_all:+.3f}  mae = "
+          f"{np.abs(df.machine - df.eye).mean():.2f}*")
+
+    print("\n=== ticket 15 R5's precision at the 4-star line, per arm")
+    print("   (of cards the machine calls >=4*, share the eye also calls >=4*)")
+    for tag in ARMS:
+        d = df[df.tag == tag]
+        call = d[d.machine >= 4]
+        if not len(call):
+            print(f"{tag:20s} machine never reaches 4* (n={len(d)})")
+            continue
+        print(f"{tag:20s} n_called={len(call):3d}  precision = "
+              f"{(call.eye >= 4).mean():.2f}  recall = "
+              f"{(call.eye >= 4).sum() / max((d.eye >= 4).sum(), 1):.2f}")
+    mix = df[df.tag.isin(ARMS[:2])]
+    call = mix[mix.machine >= 4]
+    print(f"{'det + lnd merged':20s} n_called={len(call):3d}  precision = "
+          f"{(call.eye >= 4).mean():.2f}")
+
+    print("\n=== where the marginal names would land in a merged nightly sort")
+    mix = mix.sort_values("machine", ascending=False)
+    for top in (5, 10, 20, len(mix)):
+        head = mix.head(top)
+        print(f"top {top:3d} of the merged list: {(head.tag == 'line_not_drawable').mean():5.0%} "
+              f"are line_not_drawable   (base rate "
+              f"{(mix.tag == 'line_not_drawable').mean():.0%})")
+
+    print("\n=== which rubric dimensions the marginal names differ on")
+    dims = ["tightness", "orderliness", "base_length", "ma_support", "volume", "sector",
+            "prior_move", "adr"]
+    print(f"{'dimension':14s} " + "".join(f"{t[:12]:>14s}" for t in ARMS))
+    for dim in dims:
+        row = f"{dim:14s} "
+        for tag in ARMS:
+            d = df[df.tag == tag]
+            vals = [p.get(dim) for p in d.points if p.get(dim) is not None]
+            row += f"{np.mean(vals):14.2f}" if vals else f"{'-':>14s}"
+        print(row)
+
+    print("\n=== the sub-tests, machine view (classification copied from analyse_deckF.py)")
+    d = df[df.tag == "line_not_drawable"].copy()
+    z, o = d.touch_zones.fillna(0), d.overshoot_adr.fillna(0)
+    groups = {"touches only": (z < 2) & (o <= 1.0),
+              "overshoot only": (z >= 2) & (o > 1.0),
+              "both": (z < 2) & (o > 1.0),
+              "overshoot_frac only": (z >= 2) & (o <= 1.0)}
+    det_m, det_e = acc.machine.mean(), acc.eye.mean()
+    for lab, m in groups.items():
+        g = d[m]
+        if not len(g):
+            print(f"  {lab:22s} n= 0")
+            continue
+        print(f"  {lab:22s} n={len(g):2d}  machine {g.machine.mean():.2f}* "
+              f"(d {g.machine.mean()-det_m:+.2f})   eye {g.eye.mean():.2f}* "
+              f"(d {g.eye.mean()-det_e:+.2f})")
+
+
+if __name__ == "__main__":
+    g = None
+    for a in sys.argv[1:]:
+        if a.startswith("F="):
+            g = a[2:]
+    if not g:
+        raise SystemExit(__doc__)
+    main(g)

--- a/.scratch/screening-dashboard/prototypes/26-line-penalty/digest_volume.py
+++ b/.scratch/screening-dashboard/prototypes/26-line-penalty/digest_volume.py
@@ -1,0 +1,111 @@
+"""Ticket 26 — what demoting `line_ok` does to ticket 18's digest volume.
+
+Ticket 26 lists the digest as a knock-on "to check rather than assume". Ticket 18's consecutive-bar
+scan is cached, so this is a re-run of its own classifier with one bit changed: detection is
+`tight & caught_up` with and without `& line_ok`. Everything else — the `close_today >
+trigger_yesterday` rule, the contiguity requirement, the taxonomy — is ticket 18's code path.
+
+Ticket 18's caveat carries: D15's decile gate is NOT applied here, so every rows-per-night figure is
+an upper bound. The RATIO between the two gate sets is the answer; the levels are ticket 18's.
+
+Usage: digest_volume.py
+"""
+
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+P18 = os.path.abspath(os.path.join(HERE, "..", "18-digest-rule"))
+DAILY = None
+for root in (P18, os.path.abspath(os.path.join(
+        HERE, "..", "..", "..", "..", "..", "wf-18-digest-rule", ".scratch",
+        "screening-dashboard", "prototypes", "18-digest-rule"))):
+    p = os.path.join(root, "out", "daily.pkl")
+    if os.path.exists(p):
+        DAILY = p
+        break
+
+MOVE_FLOOR = 25.0
+
+
+def classify(df, require_line_ok):
+    """Ticket 18's crossings.classify, with the line test as a switch."""
+    df = df.copy()
+    det = (df.tight.fillna(False).astype(bool)
+           & df.caught_up.fillna(False).astype(bool)
+           & (df.move_gain >= MOVE_FLOOR))
+    if require_line_ok:
+        det &= df.line_ok.fillna(False).astype(bool)
+    df["detected"] = det
+    df.loc[~df.detected, "trigger"] = np.nan
+    df = df.sort_values(["market", "symbol", "end"]).reset_index(drop=True)
+    g = df.groupby(["market", "symbol"], sort=False)
+
+    df["trig_y"] = g.trigger.shift(1)
+    df["close_y"] = g.close.shift(1)
+    df["det_y"] = g.detected.shift(1).fillna(False).astype(bool)
+    df["contig"] = df.end - g.end.shift(1) == 1
+
+    watching_y = df.det_y & df.contig & (df.close_y <= df.trig_y)
+    df["t1"] = df.detected & watching_y & (df.close > df.trig_y)
+    return df
+
+
+def main():
+    if DAILY is None:
+        raise SystemExit("ticket 18's out/daily.pkl not found — run its crossings.py first")
+    raw = pd.read_pickle(DAILY)
+    print(f"loaded {len(raw):,} scanned bar-nights from {DAILY}\n")
+
+    out = {}
+    for label, req in (("as specified (line_ok gates)", True),
+                       ("line_ok demoted", False)):
+        c = classify(raw, req)
+        out[label] = c
+        print(f"=== {label}")
+        for mkt in ("US", "IDX"):
+            d = c[c.market == mkt]
+            nights = d.date.nunique()
+            names = d.symbol.nunique()
+            det = int(d.detected.sum())
+            t1 = int(d.t1.sum())
+            print(f"  {mkt}: {det:,} detections, {t1:,} digest rows over {nights} nights "
+                  f"/ {names} names  ->  {t1 / nights:.2f} rows per night (ungated)")
+        print()
+
+    print("=== the ratio, which is what transfers to ticket 18's decile-gated 7.0 US rows/night")
+    a, b = out["as specified (line_ok gates)"], out["line_ok demoted"]
+    for mkt in ("US", "IDX"):
+        da, db = a[a.market == mkt], b[b.market == mkt]
+        t1a, t1b = int(da.t1.sum()), int(db.t1.sum())
+        deta, detb = int(da.detected.sum()), int(db.detected.sum())
+        print(f"  {mkt}: detections x{detb / deta:.2f}, digest rows x{t1b / t1a:.2f}")
+    print("\n  NOTE: those ratios are UNGATED. The decile gate cuts the marginal population much"
+          "\n  harder than the accepted one (ticket 25: +98% ungated becomes +59% gated), so the"
+          "\n  transfer has to use the gated growth and the measured relative break rate.")
+    for mkt, rows_now, growth in (("US", 7.0, 0.59), ("IDX", 0.9, 0.59)):
+        db = b[b.market == mkt]
+        det = db[db.detected]
+        acc = det[det.line_ok.fillna(False).astype(bool)]
+        mar = det[~det.line_ok.fillna(False).astype(bool)]
+        rel = mar.t1.mean() / acc.t1.mean()
+        print(f"  {mkt}: marginal names break at {rel:.2f}x the accepted rate, and the gated list"
+              f" grows {growth:+.0%}"
+              f"  ->  {rows_now:.1f} -> {rows_now * (1 + growth * rel):.1f} rows/night")
+
+    print("\n=== do the marginal names break at a different rate than the accepted ones?")
+    for mkt in ("US", "IDX"):
+        db = b[b.market == mkt]
+        det = db[db.detected]
+        for lab, m in (("accepted", det.line_ok.fillna(False).astype(bool)),
+                       ("marginal", ~det.line_ok.fillna(False).astype(bool))):
+            d = det[m]
+            print(f"  {mkt} {lab:9s}: {len(d):,} detections, {int(d.t1.sum()):,} breaks "
+                  f"({d.t1.mean():.2%} of detection-nights)")
+
+
+if __name__ == "__main__":
+    main()

--- a/.scratch/screening-dashboard/prototypes/26-line-penalty/nightly_mix.py
+++ b/.scratch/screening-dashboard/prototypes/26-line-penalty/nightly_mix.py
@@ -1,0 +1,151 @@
+"""Ticket 26 — what the longer list actually looks like on a real night.
+
+`lnd_cost.py` (ticket 25) priced the remedy as a COUNT: 5.98 -> 9.5 US names a night. Ticket 11's
+list is sorted by star score descending, so the count is not the thing the eye pays — the thing it
+pays is where the new rows land. This scores both populations with ticket 15's published rubric and
+reports the merged list the way ticket 11's screen would show it.
+
+Deck F answers the same question at 50/50 arm sizes; the nightly mix is not 50/50.
+
+Usage: nightly_mix.py [nights=N]
+"""
+
+import os
+import sys
+import time
+
+import numpy as np
+import pandas as pd
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+P15 = os.path.abspath(os.path.join(HERE, "..", "15-grading-round-2"))
+P09 = os.path.abspath(os.path.join(HERE, "..", "09-star-score"))
+for p in (P15, P09):
+    sys.path.insert(0, p)
+CACHE = os.path.join(P09, "cache")
+
+from rubric3 import score3                     # noqa: E402
+from split_signals import signals_at, frames   # noqa: E402
+import ranks as R                              # noqa: E402
+
+T_R3 = {"cluster_k": 4, "ord_lo": 0.275, "ord_hi": 0.50, "dryup": 0.90, "len_ok": 26}
+DECILE = 0.90
+MOVE_FLOOR = 25.0
+SCALE = 3.0          # split.pkl is a 1-in-3 sweep of bar-dates
+N_NIGHTS = 120
+US_UNIVERSE = 1966   # ticket 05, via ticket 19 harness.py and ticket 18 crossings.py
+
+
+def main(n_nights):
+    t0 = time.time()
+    sp = pd.read_pickle(os.path.join(CACHE, "split.pkl"))
+    sp["date"] = pd.to_datetime(sp.date).dt.strftime("%Y-%m-%d")
+    rk, _, _ = R.load_or_build()
+    sectors = pd.read_pickle(os.path.join(CACHE, "sectors_us.pkl"))
+    fr = frames("US")
+
+    # Night selection copies lnd_cost.py exactly — drawn from the has_base population, so nights
+    # with no qualifying candidate still count as a night. Selecting on `tight & caught_up`
+    # instead over-samples busy nights and inflates every count.
+    pool = sp[(sp.market == "US") & sp.has_base & (sp.move_gain >= MOVE_FLOOR)]
+    rng = np.random.default_rng(25)
+    nights = np.array(sorted(pool.date.unique()))
+    nights = nights[rng.permutation(len(nights))[:n_nights]]
+    us = pool[pool.caught_up & pool.tight].copy()
+
+    rows = []
+    for night in nights:
+        d = us[us.date == night]
+        for _, r in d.iterrows():
+            if r.symbol not in fr:
+                continue
+            pm = R.prior_move_pct(rk, r.symbol, night)
+            if pm is None or pm < DECILE:
+                continue
+            sig = signals_at(fr[r.symbol], int(r.end))
+            if sig is None:
+                continue
+            ss = R.sector_share_loo(rk, sectors, r.symbol, night)
+            s = score3({**sig, "adr": r.adr}, pm, ss, "boolean", T=T_R3)
+            rows.append({"night": night, "symbol": r.symbol, "line_ok": bool(r.line_ok),
+                         "machine": s["stars"], "cluster_k": sig.get("cluster_k"),
+                         "touch_zones": r.get("touch_zones"),
+                         "overshoot_adr": r.get("overshoot_adr")})
+    df = pd.DataFrame(rows)
+    print(f"{len(df):,} scored rows over {df.night.nunique()} nights "
+          f"({time.time()-t0:.0f}s)\n")
+
+    per = df.groupby("night").agg(all_rows=("symbol", "size"),
+                                  accepted=("line_ok", "sum"))
+    per = per.reindex(nights, fill_value=0)      # empty nights are nights
+    per["marginal"] = per.all_rows - per.accepted
+    n_scanned = pool.symbol.nunique()
+    uscale = US_UNIVERSE / n_scanned
+    print("=== nightly US list, as specified vs with the line test demoted "
+          f"(x{SCALE:.0f} for the 1-in-3 sweep)")
+    print(f"  as specified (line_ok only):   {per.accepted.mean()*SCALE:5.2f} names/night")
+    print(f"  with the marginal names:       {per.all_rows.mean()*SCALE:5.2f} names/night "
+          f"(+{per.all_rows.sum()/per.accepted.sum()-1:.0%})")
+    print(f"  marginal share of the list:    {per.marginal.sum()/per.all_rows.sum():5.0%}")
+
+    print(f"\n=== the same list scaled to ticket 05's real universe "
+          f"({n_scanned} names scanned -> {US_UNIVERSE}, x{uscale:.2f})")
+    print("  ticket 18's digest figures are already scaled this way (crossings.py: 1966/names);")
+    print("  ticket 25's list figures are NOT, which is why the two are not comparable as written.")
+    print(f"  as specified (line_ok only):   {per.accepted.mean()*SCALE*uscale:5.1f} names/night")
+    print(f"  with the marginal names:       {per.all_rows.mean()*SCALE*uscale:5.1f} names/night")
+    print("  CAVEAT: the scan pool is a random Nasdaq draw plus a 39-name momentum core, not")
+    print("  ticket 05's liquidity-gated universe, so this transfers a per-name rate across")
+    print("  populations of different composition. The +59% RATIO does not depend on it.")
+
+    print("\n=== where they land in ticket 11's star-descending sort")
+    print(f"{'':22s} {'accepted':>10s} {'marginal':>10s}")
+    print(f"{'mean machine star':22s} {df[df.line_ok].machine.mean():10.2f} "
+          f"{df[~df.line_ok].machine.mean():10.2f}")
+    for cut in (4.0, 3.5, 3.0):
+        a = (df[df.line_ok].machine >= cut).mean()
+        m = (df[~df.line_ok].machine >= cut).mean()
+        print(f"{'share >= ' + str(cut) + '*':22s} {a:10.0%} {m:10.0%}")
+
+    print("\n=== the top of the list, which is the part ticket 11 says gets read")
+    for top in (3, 5, 10):
+        share, cnt = [], []
+        for night, g in df.groupby("night"):
+            g = g.sort_values("machine", ascending=False).head(top)
+            share.append((~g.line_ok).mean())
+            cnt.append((~g.line_ok).sum())
+        print(f"  top {top:2d} rows: {np.mean(share):5.0%} marginal "
+              f"({np.mean(cnt)*1.0:.2f} rows of {top})")
+
+    print("\n=== how many 4*+ rows a night, before and after")
+    a4 = df[df.line_ok & (df.machine >= 4)].groupby("night").size().reindex(
+        per.index, fill_value=0)
+    t4 = df[df.machine >= 4].groupby("night").size().reindex(per.index, fill_value=0)
+    print(f"  as specified: {a4.mean()*SCALE:5.2f} names/night at >=4*")
+    print(f"  with marginal: {t4.mean()*SCALE:5.2f} names/night at >=4* "
+          f"(+{t4.sum()/max(a4.sum(),1)-1:.0%})")
+
+    print("\n=== if the penalty were keyed on the overshoot sub-test only")
+    z = df.touch_zones.fillna(0)
+    o = df.overshoot_adr.fillna(0)
+    over = (~df.line_ok) & (o > 1.0)
+    touch = (~df.line_ok) & (o <= 1.0) & (z < 2)
+    print(f"  marginal rows failing overshoot: {over.sum()/max((~df.line_ok).sum(),1):5.0%} "
+          f"({over.sum()/df.night.nunique()*SCALE:.2f} names/night)")
+    print(f"  marginal rows failing touches:   {touch.sum()/max((~df.line_ok).sum(),1):5.0%} "
+          f"({touch.sum()/df.night.nunique()*SCALE:.2f} names/night)")
+    print(f"  mean machine star, overshoot subset {df[over].machine.mean():.2f}, "
+          f"touches subset {df[touch].machine.mean():.2f}")
+
+    out = os.path.join(HERE, "out")          # gitignored, like every other prototype's out/
+    os.makedirs(out, exist_ok=True)
+    df.to_csv(os.path.join(out, "nightly_mix.csv"), index=False)
+    print(f"\nwrote nightly_mix.csv ({len(df):,} rows)")
+
+
+if __name__ == "__main__":
+    n = N_NIGHTS
+    for a in sys.argv[1:]:
+        if a.startswith("nights="):
+            n = int(a.split("=")[1])
+    main(n)


### PR DESCRIPTION
Resolves [ticket 26](.scratch/screening-dashboard/issues/26-the-line-penalty-and-the-longer-list.md) — the shape of the `line_ok` penalty ticket 25 chose, and whether ticket 11's list survives the longer list.

Grilling ticket: no new grading. Every number is recomputed from evidence that already existed — deck F's 105 grades, ticket 15's published rubric, ticket 25's `split.pkl` scan, ticket 18's cached consecutive-bar scan.

## The decisions

- **A silent tiebreak.** `line_ok` sorts below an accepted name at equal star score and does nothing else — no dimension, no refit, no second grading round, no tunable. Keyed on any line failure, not the overshoot sub-test.
- **Nothing marks it** — no glyph, no column, and the chart draws the fitted line as for any other name.
- **The digest takes them**, ~7.0 → ~9.6 US rows a night.
- **Ticket 11's screen is unchanged**, judged against the corrected list size below.

## What the session measured

- **The machine returns the same null as the eye.** Deck F's cards had only ever been graded; scored with ticket 15 R4's thresholds, `line_not_drawable` reads **−0.03★** (CI −0.46 to +0.40) against the eye's −0.12★. Two rulers, one null — so the score was not already demoting these names, and any demotion is deliberate.
- **Marginal names break through their trigger at 0.62× the accepted rate** (3.04% vs 4.90% of detection-nights), not explained by distance to the level and holding inside every base-length bucket. First non-eye evidence about this population on the map. Deliberately **not** priced into the score.
- **Every list-size level on this map is a sample count.** `split.pkl` scans **628 US symbols** against ticket 05's **1,966**; ticket 25 scaled for the 1-in-3 date grid but not the universe, while ticket 18's `crossings.py` scaled for both. The nightly list is **~19 → ~30**, not 5.98 → 9.5. The **+59% ratio is unaffected**.

## Changes

- `issues/26-…md` — resolved, R1–R8
- `map.md` — Decisions-so-far entry, standing-risk update, two fog patches (unmeasured list levels; the break-rate question folded into validation)
- `prototypes/26-line-penalty/` — `deckF_machine.py`, `nightly_mix.py`, `digest_volume.py`, FINDINGS, README

`nightly_mix.py` reproduces ticket 25's 5.98 → 9.52 exactly before rescaling, which is how the scaling error was isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)