### PR TITLE
Resolve ticket 27: the star is a label for a rank, so the guardrail falls

### DIFF
--- a/.scratch/screening-dashboard/issues/27-level-or-order.md
+++ b/.scratch/screening-dashboard/issues/27-level-or-order.md
@@ -1,7 +1,7 @@
 # Does a 4★ have to mean 4★, or is the star number a label for a rank?
 
 Type: grilling
-Status: open
+Status: claimed
 Blocked by: —
 
 ## Question

--- a/.scratch/screening-dashboard/issues/27-level-or-order.md
+++ b/.scratch/screening-dashboard/issues/27-level-or-order.md
@@ -1,7 +1,7 @@
 # Does a 4★ have to mean 4★, or is the star number a label for a rank?
 
 Type: grilling
-Status: claimed
+Status: resolved
 Blocked by: —
 
 ## Question
@@ -51,3 +51,80 @@ and fittable.
 
 **Do not re-litigate** ticket 24 (the score stays stop-blind) or ticket 22 (one threshold set covers
 both markets). Both survive either answer.
+
+## Answer
+
+**The star number is a label for a rank plus its cut points, and nothing on this map reads it as a
+magnitude — so the guardrail that blocked a rank objective by 0.01★ was defending a property no
+consumer has.** Every reader of the score was traced before the question was put:
+
+| consumer | reads |
+| --- | --- |
+| the watchlist sort ([ticket 11](11-dashboard-information-architecture.md) I3) | **order** — it is the sort key |
+| row column 2 and the digest's star column ([ticket 18](18-digest-rule-under-the-clamped-trigger.md)) | **displayed**, and the one rendered example is a whole star, `AAOI 3★` |
+| §3.5's own trading rule, *"4–5 at full size; 3 at half size or not at all; below 3, don't"* | **two cut points**, at 4 and at 3 |
+| ticket 15 R5's trade line | **one cut point**, at 4★ |
+| §7 / §8 sizing, ticket 10's regime posture | **nothing** — [ticket 24](24-should-the-score-know-about-the-stop.md) made the score stop-blind, §8 is out of scope, and the regime posture is advisory words |
+
+Nothing consumes 3.2 as a quantity. The difference between a card at 3.2 and one at 3.4 changes
+nothing on screen, nothing in the digest and nothing about sizing, unless it crosses 4. That is the
+escape clause [ticket 21](21-the-fitting-objective-does-not-identify-the-dimensions.md) pre-registered
+for itself — *"if nothing does, the level guardrail should never have been binding and `cindex` wins
+outright, band included"* — so **`cindex` is adopted as the fitting objective**, and with it the
+orderliness band and R6 F2's stable thresholds. The rule is not relaxed after the fact; the rule is
+found to have been measuring the wrong object, which is what this ticket existed to determine.
+
+**§3.5's `points ÷ 2` mapping stands unchanged — trader's call, and it costs nothing.** No isotonic
+stage, no separately fitted band boundaries, **no new tunable**. The alternative on the table was to
+split the sort key from the printed label (sort raw, print a five-bucket star), which would have
+preserved ρ in full at the price of an amendment to ticket 11's I4; it was put and declined. The
+open number that choice left — where the 4★ line lands once the thresholds move — was then measured
+rather than assumed, and the answer is that **the trade line improves**: out-of-fold, `cindex` beats
+`mae` on precision (**0.49 vs 0.47**) *and* recall (**0.40 vs 0.26**), calling 50 names where `mae`
+calls 35. Frozen on E3, precision at 4★ goes 0.50 → 0.51. The worry that motivated R6 §2's guardrail
+does not materialise at the one place the level is read.
+
+It also turns out **nothing gates on the cut** — ticket 11's I3 refused a star floor as a tunable and
+ticket 18's digest excludes new 4–5★ setups — so the 4★ line is a **label, not a gate**, and its
+recall is descriptive. No screen behaviour rides on where it falls.
+
+**Three thresholds are published: `cluster_k` 5, `ord_lo` 0.30, `ord_hi` 0.60.** The incumbent `T3`
+already carried `cluster_k` 5 and `ord_hi` 0.60, so **adopting the rank objective moves exactly one
+published number, by one grid step** (`ord_lo` 0.275 → 0.30). `len_ok` and `dryup` stay at `T3`'s 14
+and 0.95, on R6 §4's own finding that those two are unfitted at this n and no loss function rescues
+them — `len_ok`'s modal 20 ranges 4–26 across fits. Full adoption of all five would buy ~+0.019 ρ
+and pay for it with two numbers that move across half their grid between folds; stable-only is equal
+or better at the 4★ line everywhere (precision 0.52 / 0.54 against 0.51 / 0.54). **This is the first
+round on this map to publish a threshold since ticket 15.**
+
+**The fitting pool becomes 432 cards.** Ticket 21's 366 (A3 + E3 + C3, which pool on a rank
+criterion because the +0.30★ level offset `REFIT_FINDINGS.md` F3 called disqualifying is invisible
+to one) plus deck F's **33 detections and 33 `line_not_drawable`** — the latter now live, since
+[tickets 25](25-the-line-not-drawable-path.md) and [26](26-the-line-penalty-and-the-longer-list.md)
+demoted that rule from a gate to a silent tiebreak, so those names appear on the nightly list. Deck
+F's 33 `not_caught_up` are **excluded** (still gated out, so the rubric would learn to rank names the
+app never shows) and its 6 repeats are excluded as A3 duplicates. Wiring deck F's grades into
+`load_cards` is work, and it belongs to ticket 28.
+
+**Two corrections to what ticket 21 recorded.** `ord_hi` 0.60 (E3) versus 0.70 (pooled) is **not a
+disagreement between the populations**: 0 of 194 E3 cards and 1 of 366 pooled have an orderliness
+value in (0.60, 0.70], so the region is empty and the two settings are behaviourally identical on
+every card either fit saw. That also qualifies F2's headline — part of `ord_hi`'s 25-of-25 stability
+is an empty upper tail, so it is less *tested* than the count suggests.
+
+**Carried, not fixed:** the rubric runs **cold**, printing ≥4★ for 25.3% of E3 where the eye grades
+32.0% (pooled 19.1% against 35.0%), a bias of −0.24★ to −0.31★. It inverts round 2's generosity
+problem, it is **not** caused by this decision (the incumbent does it too, at 28.9% / 24.0%), and it
+is harmless while nothing gates on the cut. Parked as fog rather than ticketed.
+
+**No amendment to ticket 11.** Under the ÷2 decision the sort key and the printed star remain one
+object, which is what I4 already assumes. **Ticket 28 unblocks**, inheriting the 432-card pool, the
+published three, and `rubric3`'s fast-path/`score3` NaN defect — which must stay fixed, because
+pooling now includes the IDX cards that expose it.
+
+**Not re-litigated**, per this ticket's own instruction: ticket 24 (the score stays stop-blind) and
+ticket 22 (one threshold set covers both markets). Both survive this answer, and ticket 22 gets
+stronger — a rank objective is invariant to exactly the level offset separating the markets.
+
+Assets: [`CUTPOINT_FINDINGS.md`](../prototypes/15-grading-round-2/CUTPOINT_FINDINGS.md) ·
+`cutpoints.py` · `CUTPOINTS_OUTPUT.txt`

--- a/.scratch/screening-dashboard/issues/28-the-retired-dimensions.md
+++ b/.scratch/screening-dashboard/issues/28-the-retired-dimensions.md
@@ -38,11 +38,33 @@ care about the sign of its correlation; the sign only sets which way the point i
 rule to read |ρ| in this round's pre-registration** and re-screen everything, including candidates
 already dismissed on one-sided grounds.
 
-**Why it is blocked on [ticket 27](27-level-or-order.md).** Adding or swapping a dimension is a
-fitting decision, and ticket 21 established there is no usable fitter until the level-versus-order
-question is settled: under `mae` every threshold on 366 cards is degenerate and unstable, so a fit
-that "adds churn" would be measuring nothing. Once 26 answers, this is a re-fit over grades that
-already exist — **no grading sitting is required**, all 430 cards are collected.
+**Why it was blocked on [ticket 27](27-level-or-order.md) — now resolved, so this is takeable.**
+Adding or swapping a dimension is a fitting decision, and ticket 21 established there is no usable
+fitter until the level-versus-order question is settled: under `mae` every threshold on 366 cards is
+degenerate and unstable, so a fit that "adds churn" would be measuring nothing. This is a re-fit over
+grades that already exist — **no grading sitting is required**.
+
+**What ticket 27 hands down:**
+
+- **The objective is `cindex`.** The mae guardrail fell, because nothing in v1 reads the star as a
+  magnitude. Fit on order.
+- **The baseline is the published three** — `cluster_k` 5, `ord_lo` 0.30, `ord_hi` 0.60 — with
+  `len_ok` 14 and `dryup` 0.95 held at `T3`, both **deliberately unfitted** at this n. A candidate
+  dimension is judged against that set, not against the full `cindex` five.
+- **The pool is 432 cards**: ticket 21's 366 (A3 + E3 + C3) plus deck F's 33 detections and 33
+  `line_not_drawable`, excluding its 33 `not_caught_up` (still gated out, so the rubric would learn
+  to rank names the app never shows) and its 6 A3 repeats. **Loading deck F's grades is work this
+  ticket owns** — `objective6.load_cards` reads `grades3_{A,C,D,E}.txt`, and deck F's grades live in
+  `DECK_F_RESULTS.md` / `analyse_deckF.py`.
+- **Keep `rubric3`'s fast-path/`score3` NaN fix live.** The pool now contains IDX cards, which are
+  exactly what expose the disagreement, and `objective6.Fast` asserts the match before computing.
+- **`ord_hi`'s stability is partly an artefact**: 0 of 194 E3 and 1 of 366 pooled cards lie in
+  (0.60, 0.70], so its 25-of-25 modal share reflects an empty upper tail. Do not read it as the
+  best-tested threshold on the map.
+- §3.5's `÷ 2` mapping is fixed, so **adding a dimension changes what every printed star means** —
+  the points total is renormalised over a larger maximum. Ticket 15's warning that one completed ×1
+  dimension once reversed the top two bands applies with full force, and ticket 27 measured the
+  rubric already running cold at the 4★ line (25.3% against the eye's 32.0%).
 
 **Pre-register before fitting**, in the deck3 style: how much out-of-fold ρ an added dimension must
 buy to earn its place (ticket 15's history is that added dimensions reorder the top bands), whether

--- a/.scratch/screening-dashboard/map.md
+++ b/.scratch/screening-dashboard/map.md
@@ -101,6 +101,13 @@ is written during wayfinding.
   this map can be fitted until [ticket 27](issues/27-level-or-order.md) says whether the star number
   is a level or a label for a rank**, because the objective that passes the level guardrail produces
   degenerate thresholds and the one that produces stable thresholds fails it by 0.01★.
+  **Ticket 27 answered it and the fitter is unblocked**: the star is a label for a rank plus its cut
+  points, nothing reads the magnitude, so the guardrail falls and `cindex` is adopted. What is left
+  of this risk is much smaller than it has been at any point since ticket 09 — the rubric publishes
+  thresholds again for the first time since ticket 15, the trade line *improved* under the swap
+  (precision 0.47 → 0.49 with recall 0.26 → 0.40), and the ×2 dimensions are no longer in doubt: the
+  question is now which *additional* dimensions the blind instrument wrongly retired (ticket 28), not
+  whether the ones in the rubric are real.
 - **Standing property of the data layer** (found independently by tickets 01, 02 and 03): **Yahoo fails
   as silence.** Throttled requests return empty results — and for price history, the literal message
   "possibly delisted; no price data found". Every ingestion path must distinguish throttling from
@@ -669,6 +676,34 @@ is written during wayfinding.
   over 5 fold assignments where ticket 20's single assignment reported **+0.120** — no future
   decision should rest on one fold split.
 
+- [Does a 4★ have to mean 4★, or is the star number a label for a rank?](issues/27-level-or-order.md)
+  — **a label for a rank plus its cut points, so the guardrail falls and the fitter is unblocked.**
+  Every consumer of the score was traced before the question was put, and **nothing reads the
+  magnitude**: the watchlist reads *order* (it is the sort key), §3.5's trading rule and ticket 15
+  R5's trade line read *cut points*, and §7/§8 read **nothing** — ticket 24 made the score
+  stop-blind, §8 is out of scope, and ticket 10's regime posture is advisory words. A card at 3.2
+  and one at 3.4 differ nowhere unless one crosses 4. That is exactly the escape clause ticket 21
+  pre-registered, so **`cindex` is adopted** — the rule was not relaxed after the fact, it was found
+  to have been measuring the wrong object. **§3.5's `points ÷ 2` mapping stands unchanged** —
+  trader's call, no isotonic stage, no separately fitted boundaries, **no new tunable** — and
+  splitting the sort key from the printed label was put and declined. The number that choice left
+  open was measured rather than assumed, and **the trade line improves**: out-of-fold `cindex` beats
+  `mae` on precision (**0.49 vs 0.47**) *and* recall (**0.40 vs 0.26**), calling 50 names against 35,
+  so the worry behind the guardrail does not materialise where the level is actually read. It also
+  emerged that **nothing gates on the cut** (ticket 11's I3 refused a star floor; ticket 18's digest
+  excludes new 4–5★), making the 4★ line a label rather than a gate. **Three thresholds are
+  published — `cluster_k` 5, `ord_lo` 0.30, `ord_hi` 0.60 — the first since ticket 15**, and because
+  `T3` already carried two of them, **adopting the rank objective moves exactly one published number
+  by one grid step**. `len_ok` and `dryup` stay at `T3` on R6 §4's own finding that they are unfitted
+  at this n; taking them would buy ~+0.019 ρ with two numbers that range across half their grid
+  between folds. **The fitting pool becomes 432** — ticket 21's 366 plus deck F's detections and its
+  `line_not_drawable` arm, now live since ticket 26 demoted that rule to a tiebreak, excluding the
+  still-gated `not_caught_up` arm and 6 duplicate repeats. Two corrections to ticket 21: **`ord_hi`
+  0.60 vs 0.70 was never a disagreement** (0 of 194 E3 and 1 of 366 pooled cards lie between them —
+  the region is empty), which also qualifies its 25-of-25 stability as partly an empty upper tail.
+  Ticket 11 needs **no** amendment, and **ticket 28 unblocks** with the pool, the published three and
+  the `rubric3` NaN defect it must keep fixed now that IDX cards are in.
+
 ## Not yet specified
 
 - **Validation / backtest.** How do we know the screen actually surfaces the right names? History depth
@@ -842,6 +877,17 @@ is written during wayfinding.
   ticket 12's ingest makes the real number free to compute the day it exists. What would sharpen it
   into a ticket is a decision that actually turns on list length: a cap, a star floor, or any
   reading-cost argument, none of which v1 currently contains.
+- **The rubric runs cold, and nothing currently notices.** Found by
+  [ticket 27](issues/27-level-or-order.md): the machine prints ≥4★ for **25.3%** of E3 cards where
+  the eye grades 32.0% (pooled, 19.1% against 35.0%) — a level bias of −0.24★ to −0.31★ that
+  **inverts** round 2's generosity problem (+0.74★, later +0.25★). It is not caused by adopting a
+  rank objective; the incumbent `T3` does the same thing at 28.9%/24.0%, and it is the direct,
+  accepted consequence of keeping §3.5's `÷ 2` mapping while fitting on order. It is fog rather than
+  a ticket because **nothing in v1 gates on the cut** — ticket 11's I3 refused a star floor as a
+  tunable and ticket 18's digest excludes new 4–5★ setups — so the 4★ line is a label and its recall
+  is descriptive. What would sharpen it into a ticket is any decision that makes the cut load-bearing:
+  a star floor on the list, a digest rule that fires on a band, or a sizing posture computed from the
+  score rather than read off it. All three are currently ruled out, and each would reopen this.
 - **Survivorship bias.** Yahoo's screener enumerates only live names, so delisted history is not
   discoverable. Harmless for nightly scanning, potentially fatal for any backtest — folds into the
   validation patch above once that takes shape.

--- a/.scratch/screening-dashboard/prototypes/15-grading-round-2/CUTPOINTS_OUTPUT.txt
+++ b/.scratch/screening-dashboard/prototypes/15-grading-round-2/CUTPOINTS_OUTPUT.txt
@@ -1,0 +1,70 @@
+==============================================================================
+Ticket 27: the 4-star cut under the adopted objective
+==============================================================================
+E3 cards 194   pooled 366
+Fast/score3 agreement asserted on the pooled population.
+
+
+=== 1. FROZEN thresholds applied to E3 (no fitting, no folds)
+
+--- incumbent T3 (ticket 15, R5 measured 0.53 here)   (n=194)
+    printed stars: mean 2.74  SD 1.32  min 0.50  max 5.00
+    share printed >= 4.0: 28.9%   eye >= 4: 32.0%
+    mae 1.18   bias -0.19   rho +0.327
+        cut     n  precision   recall
+        3.0   100       0.46     0.74
+        3.5    76       0.46     0.56
+        4.0    56       0.50     0.45
+        4.5    38       0.53     0.32
+
+--- cindex thresholds, E3 fit   (n=194)
+    printed stars: mean 2.69  SD 1.24  min 0.50  max 5.00
+    share printed >= 4.0: 25.3%   eye >= 4: 32.0%
+    mae 1.12   bias -0.24   rho +0.357
+        cut     n  precision   recall
+        3.0    95       0.47     0.73
+        3.5    69       0.49     0.55
+        4.0    49       0.51     0.40
+        4.5    29       0.55     0.26
+
+--- cindex thresholds, pooled fit   (n=194)
+    printed stars: mean 2.69  SD 1.24  min 0.50  max 5.00
+    share printed >= 4.0: 25.3%   eye >= 4: 32.0%
+    mae 1.12   bias -0.24   rho +0.357
+        cut     n  precision   recall
+        3.0    95       0.47     0.73
+        3.5    69       0.49     0.55
+        4.0    49       0.51     0.40
+        4.5    29       0.55     0.26
+
+
+=== 2. OUT-OF-FOLD, 5 assignments x 5 folds
+
+--- mae: precision at 4.0*  median 0.47  range 0.39-0.54
+    recall    median 0.26   n called median 35
+
+--- cindex: precision at 4.0*  median 0.49  range 0.40-0.52
+    recall    median 0.40   n called median 50
+
+
+=== 3. FROZEN thresholds on the pooled 366
+
+--- incumbent T3   (n=366)
+    printed stars: mean 2.71  SD 1.28  min 0.00  max 5.00
+    share printed >= 4.0: 24.0%   eye >= 4: 35.0%
+    mae 1.15   bias -0.24   rho +0.358
+        cut     n  precision   recall
+        3.0   194       0.47     0.72
+        3.5   138       0.49     0.53
+        4.0    88       0.53     0.37
+        4.5    57       0.56     0.25
+
+--- cindex thresholds, pooled fit   (n=366)
+    printed stars: mean 2.64  SD 1.19  min 0.00  max 5.00
+    share printed >= 4.0: 19.1%   eye >= 4: 35.0%
+    mae 1.11   bias -0.31   rho +0.377
+        cut     n  precision   recall
+        3.0   185       0.48     0.69
+        3.5   118       0.51     0.47
+        4.0    70       0.54     0.30
+        4.5    40       0.57     0.18

--- a/.scratch/screening-dashboard/prototypes/15-grading-round-2/CUTPOINT_FINDINGS.md
+++ b/.scratch/screening-dashboard/prototypes/15-grading-round-2/CUTPOINT_FINDINGS.md
@@ -1,0 +1,65 @@
+# The 4-star cut under the adopted objective
+
+Measurement for [ticket 27](../../issues/27-level-or-order.md), run *after* the trader had answered
+its two questions and therefore **reporting a consequence, not choosing anything**. No threshold,
+cut or rule is selected here. Reproduce with `cutpoints.py`; raw output in `CUTPOINTS_OUTPUT.txt`.
+
+Ticket 27 settled that the star number is a label for a rank plus its cut points, so R6 §2's mae
+guardrail falls and `cindex` is adopted; and that §3.5's `points ÷ 2` mapping stands unchanged. The
+second choice leaves exactly one number open — [ticket 15](../../issues/15-star-score-second-grading-round.md)
+R5 measured precision at the 4★ line as 0.53 under the incumbent `T3`, and under `cindex`'s
+thresholds the printed level is no longer what any loss controls.
+
+## 1. The trade line is not damaged — it improves
+
+Like-for-like, both objectives fitted the same way (5 folds × 5 assignments, out-of-fold, E3):
+
+| objective | precision @4★ | recall @4★ | n called |
+| --- | --- | --- | --- |
+| `mae` (incumbent) | 0.47 (0.39–0.54) | 0.26 | 35 |
+| **`cindex`** | **0.49** (0.40–0.52) | **0.40** | **50** |
+
+`cindex` wins on **both** axes: it calls half again as many names and is slightly more precise doing
+it. The worry that motivated R6 §2's guardrail — that adopting a rank objective would wreck the
+level where the level is actually read — does not materialise at the one place it is read.
+
+Frozen (no fitting, no folds) on E3, precision at 4★ goes **0.50 → 0.51**.
+
+## 2. Which thresholds are worth publishing
+
+The incumbent `T3` **already** carries `cluster_k` 5 and `ord_hi` 0.60 — exactly `cindex`'s picks.
+So of the three thresholds R6 §4 calls stable, adopting `cindex` moves precisely one, by one grid
+step: `ord_lo` 0.275 → 0.30. Everything else `cindex` won comes from the two R6 §4 calls **unstable**.
+
+| published set | ρ (E3 / pooled) | mae | precision @4★ | recall @4★ |
+| --- | --- | --- | --- | --- |
+| `T3` incumbent | +0.327 / +0.358 | 1.18 / 1.15 | 0.50 / 0.53 | 0.45 / 0.37 |
+| **stable-only** (`T3` + `ord_lo` 0.30) | +0.338 / +0.361 | 1.17 / 1.15 | **0.52 / 0.54** | 0.44 / 0.31 |
+| full `cindex` (+ `dryup` 0.85, `len_ok` 20) | **+0.357 / +0.374** | **1.12 / 1.12** | 0.51 / 0.54 | 0.40 / 0.30 |
+
+Full adoption buys ~+0.019 ρ and pays with two numbers that move across half their grid between
+folds (`len_ok` modal 20 but ranging 4–26; `dryup` modal 0.85 at 52%). **Trader published the stable
+three.**
+
+## 3. `ord_hi` 0.60 versus 0.70 is a distinction without a difference
+
+R6 F1 reports `cindex` returning `ord_hi` 0.60 on E3 and 0.70 on the pooled 366, which reads as the
+two populations disagreeing. They do not: **0 of 194 E3 cards and 1 of 366 pooled cards have an
+orderliness value in (0.60, 0.70]**. The region is empty, the two settings are behaviourally
+identical on every card either fit saw, and their predictions match to every digit.
+
+This also qualifies F2's headline that `ord_hi` is the most stable threshold on the map, landing on
+0.60 in 25 fits out of 25. Part of that stability is the upper tail having nothing in it to move
+the boundary across. The threshold is not wrong — it is less *tested* than the count suggests.
+
+## 4. The rubric runs cold, and always did
+
+At the 4★ line the machine prints ≥4★ for **25.3%** of E3 where the eye grades 32.0% (pooled:
+19.1% against 35.0%), a level bias of −0.24★ to −0.31★. This is **not** caused by adopting `cindex`
+— the incumbent `T3` does the same thing (28.9% / 24.0%) — and it inverts round 2's problem, where
+the machine was too generous by +0.74★, later +0.25★.
+
+It is harmless under v1 as specified, because **nothing gates on the cut**: ticket 11's I3 refused a
+star floor as a tunable, and ticket 18's digest excludes new 4–5★ setups. The star is a label, so
+recall at the cut is descriptive. Recorded as fog on the map rather than fixed, because it would
+start mattering the moment anything did gate on it.

--- a/.scratch/screening-dashboard/prototypes/15-grading-round-2/cutpoints.py
+++ b/.scratch/screening-dashboard/prototypes/15-grading-round-2/cutpoints.py
@@ -1,0 +1,134 @@
+"""Ticket 27: where does the 4-star line land once `cindex` moves the thresholds?
+
+Ticket 27 settled two things by trader's call:
+
+  1. the star number is a **label for a rank plus its cut points** — nothing in v1 reads the
+     magnitude, so R6 section 2's mae guardrail was defending a property nothing consumes and
+     `cindex` is adopted;
+  2. **section 3.5's points/2 mapping stands unchanged** — no isotonic stage, no separately fitted
+     band boundaries, no new tunable.
+
+Choice 2 leaves exactly one number open, and it is a *consequence* of the decision rather than an
+input to it: ticket 15 R5 measured precision at the 4-star cut as 0.53 under the incumbent `T3`
+thresholds, and that is the number ticket 11's screen depends on. Under `cindex`'s thresholds the
+printed level is no longer what any loss controlled, so the cut has to be re-read.
+
+**This is reporting, not fitting.** Nothing here chooses a threshold, a cut or a rule. The
+thresholds are the ones `objective6` already published; the cuts are the four `analyse3` already
+prints. Anything that looks like a new decision belongs in a pre-registration, not here.
+"""
+
+import os
+import sys
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import objective6 as O6                                   # noqa: E402
+from rubric3 import T3                                    # noqa: E402
+
+# `cindex` on E3 and on the pooled 366, as OBJECTIVE_FINDINGS.md F1 reports them.
+T_CINDEX_E3 = {**T3, "cluster_k": 5, "ord_lo": 0.30, "ord_hi": 0.60, "dryup": 0.85, "len_ok": 20}
+T_CINDEX_POOLED = {**T3, "cluster_k": 5, "ord_lo": 0.30, "ord_hi": 0.70, "dryup": 0.85, "len_ok": 20}
+
+CUTS = (3.0, 3.5, 4.0, 4.5)
+TRADE_CUT = 4.0
+
+
+def cut_table(pred, eye):
+    """Precision and recall against the eye's own 4-star line, at each printed cut."""
+    rows = []
+    for cut in CUTS:
+        flag = pred >= cut
+        n = int(flag.sum())
+        if n == 0:
+            rows.append((cut, 0, float("nan"), 0.0))
+            continue
+        prec = float((eye[flag] >= 4).mean())
+        rec = float((flag & (eye >= 4)).sum() / max((eye >= 4).sum(), 1))
+        rows.append((cut, n, prec, rec))
+    return rows
+
+
+def show(label, pred, eye):
+    print(f"\n--- {label}   (n={len(eye)})")
+    print(f"    printed stars: mean {pred.mean():.2f}  SD {pred.std():.2f}  "
+          f"min {pred.min():.2f}  max {pred.max():.2f}")
+    print(f"    share printed >= 4.0: {float((pred >= TRADE_CUT).mean()):.1%}   "
+          f"eye >= 4: {float((eye >= 4).mean()):.1%}")
+    print(f"    mae {float(np.abs(pred - eye).mean()):.2f}   "
+          f"bias {float((pred - eye).mean()):+.2f}   "
+          f"rho {O6.spearman(pred, eye):+.3f}")
+    print(f"      {'cut':>5s} {'n':>5s} {'precision':>10s} {'recall':>8s}")
+    for cut, n, prec, rec in cut_table(pred, eye):
+        print(f"      {cut:5.1f} {n:5d} {prec:10.2f} {rec:8.2f}")
+
+
+def out_of_fold(rows, kind, seeds=O6.SEEDS):
+    """Median-over-assignments out-of-fold prediction, so the cut is read the way R5 read it.
+
+    Averaging predictions across fold assignments would smooth the very quantity being measured,
+    so each assignment is scored separately and the *median* cut statistic is reported.
+    """
+    f = O6.Fast(rows)
+    preds = []
+    for seed in seeds:
+        rng = np.random.default_rng(seed)
+        idx = rng.permutation(len(rows))
+        pred = np.zeros(len(rows))
+        for fold in range(O6.FOLDS):
+            te = idx[fold::O6.FOLDS]
+            tr = np.setdiff1d(np.arange(len(rows)), te)
+            sub = O6.Fast([rows[i] for i in tr])
+            T, _ = O6.fit(None, kind, fast=sub)
+            pred[te] = f.predict(T)[te]
+        preds.append(pred)
+    return preds, f.eye
+
+
+def main():
+    df = O6.load_cards()
+    pops = O6.populations(df)
+    e3 = O6.rows_of(pops["E3"], "E3")
+    pooled = O6.rows_of(pops["A3"], "A3") + e3 + O6.rows_of(pops["C3"], "C3")
+
+    print("=" * 78)
+    print("Ticket 27: the 4-star cut under the adopted objective")
+    print("=" * 78)
+    print(f"E3 cards {len(e3)}   pooled {len(pooled)}")
+
+    O6.assert_matches_score3(pooled)
+    print("Fast/score3 agreement asserted on the pooled population.")
+
+    # ---- 1. frozen thresholds, no fitting at all: the cleanest read of the decision
+    print("\n\n=== 1. FROZEN thresholds applied to E3 (no fitting, no folds)")
+    f = O6.Fast(e3)
+    eye = f.eye
+    show("incumbent T3 (ticket 15, R5 measured 0.53 here)", f.predict(T3), eye)
+    show("cindex thresholds, E3 fit", f.predict(T_CINDEX_E3), eye)
+    show("cindex thresholds, pooled fit", f.predict(T_CINDEX_POOLED), eye)
+
+    # ---- 2. out-of-fold, the way R5's 0.53 was produced
+    print("\n\n=== 2. OUT-OF-FOLD, 5 assignments x 5 folds")
+    for kind in ("mae", "cindex"):
+        preds, eye = out_of_fold(e3, kind)
+        stats = [cut_table(p, eye) for p in preds]
+        prec = [s[CUTS.index(TRADE_CUT)][2] for s in stats]
+        rec = [s[CUTS.index(TRADE_CUT)][3] for s in stats]
+        n = [s[CUTS.index(TRADE_CUT)][1] for s in stats]
+        print(f"\n--- {kind}: precision at {TRADE_CUT}*  "
+              f"median {np.nanmedian(prec):.2f}  range {np.nanmin(prec):.2f}-{np.nanmax(prec):.2f}")
+        print(f"    recall    median {np.median(rec):.2f}   "
+              f"n called median {int(np.median(n))}")
+
+    # ---- 3. the pooled population, since ticket 21 unlocked it on a rank criterion
+    print("\n\n=== 3. FROZEN thresholds on the pooled 366")
+    fp = O6.Fast(pooled)
+    show("incumbent T3", fp.predict(T3), fp.eye)
+    show("cindex thresholds, pooled fit", fp.predict(T_CINDEX_POOLED), fp.eye)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Resolves [ticket 27](.scratch/screening-dashboard/issues/27-level-or-order.md), the map's frontier.

## The finding

Every consumer of the star score was traced before the question was put to the trader, and **nothing in v1 reads the magnitude**:

| consumer | reads |
| --- | --- |
| the watchlist sort (ticket 11 I3) | **order** — it is the sort key |
| row column 2 and the digest star column | **displayed**, as a whole star |
| §3.5's *"4–5 at full size; 3 at half size"* | **two cut points** |
| ticket 15 R5's trade line | **one cut point**, at 4★ |
| §7 / §8 sizing, ticket 10's regime posture | **nothing** |

So R6 §2's mae guardrail — which blocked `cindex` by 0.01★ — was defending a property no consumer has. `cindex` is adopted under ticket 21's own pre-registered escape clause, not by relaxing a rule after the fact.

## Decisions

1. **The star is a label for a rank plus its cut points.** `cindex` adopted as the fitting objective.
2. **§3.5's `points ÷ 2` mapping stands unchanged** — trader's call. No isotonic stage, no separately fitted boundaries, **no new tunable**.
3. **Three thresholds published**: `cluster_k` 5, `ord_lo` 0.30, `ord_hi` 0.60 — the first since ticket 15. `len_ok` and `dryup` stay at `T3`, unfitted at this n.
4. **The fitting pool becomes 432** — ticket 21's 366 plus deck F's detections and its now-live `line_not_drawable` arm.

## What was measured, not assumed

Decision 2 left one number open, so `cutpoints.py` measured it: **the trade line improves.** Out-of-fold, `cindex` beats `mae` on precision (**0.49 vs 0.47**) *and* recall (**0.40 vs 0.26**), calling 50 names against 35. And since `T3` already carried `cluster_k` 5 and `ord_hi` 0.60, adopting the rank objective moves **exactly one published number, by one grid step**.

Two corrections to ticket 21: `ord_hi` 0.60 vs 0.70 was never a population disagreement — 0 of 194 E3 and 1 of 366 pooled cards lie between them — which also qualifies its 25-of-25 stability as partly an empty upper tail.

Ticket 11 needs no amendment. **Ticket 28 unblocks**, inheriting the pool, the published three, and the `rubric3` NaN defect it must keep fixed now IDX cards are in. The rubric running cold at the cut (25.3% ≥4★ against the eye's 32.0%) is parked as fog — harmless while nothing gates on the cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)