### PR TITLE
Grow the setups mini chart so price-vs-trigger is legible (#108)

### DIFF
--- a/frontend/src/MiniChart.tsx
+++ b/frontend/src/MiniChart.tsx
@@ -10,9 +10,12 @@ const MINI_BARS = 60;
 // Prefetch a little before the frame scrolls in, so the shape is usually already
 // there when the eye arrives (spec §6.4).
 const ROOT_MARGIN = "200px";
-// A thumbnail is confirmation, not the primary read — short enough to sit under a
-// card's numbers without dominating it.
-const MINI_HEIGHT = 56;
+// The chart's height. It began as a 56px thumbnail — confirmation under the
+// numbers — but at that size the trigger/stop rules crowded the candles and you
+// could not read where price sat against them (issue #108). Grown to a full,
+// legible pane: the price-vs-trigger read is now the card's centre of gravity,
+// not a glance. Keep this in sync with `.mini-chart` height in index.css.
+const MINI_HEIGHT = 176;
 
 /**
  * A lazy mini chart (spec §6.4): the at-a-glance shape on a Setups card or a

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -323,7 +323,10 @@
  * layout already accounted for, not a jump.
  */
 .mini-chart {
-  height: 56px;
+  /* Kept in sync with MINI_HEIGHT in MiniChart.tsx. Tall enough that the
+     price-vs-trigger glance reads (issue #108); a fixed frame still, so a slow
+     or dead read leaves a reserved hole, not a jump. */
+  height: 176px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## What

The mini chart on Setups (and Leaders) cards was a fixed **56px** strip — too much layered into too little height (candles, MAs, volume, base/cluster bands, and the trigger/stop rules), so the price action was unreadable and, worst on narrow screens, you couldn't tell where price sat relative to the trigger.

This grows the fixed frame to **176px** so the price-vs-trigger read is legible.

## Notes

- **Frame stays fixed** — a slow or dead read still leaves a reserved hole, not a layout jump (the original rationale is preserved).
- **60-bar window unchanged** — the mini requests the same window the full sheet reads, so opening the sheet stays a cache hit.
- Height lives in two places that must agree — the `MINI_HEIGHT` constant and the `.mini-chart` CSS rule — both updated together.
- At this size the chart becomes the card's centre of gravity rather than a secondary glance; the code comments were updated to say so honestly.

## Verification

- All 173 frontend tests pass; typecheck clean.
- Confirmed visually in the browser on desktop (3-up grid) and narrow/mobile — charts render legibly in both.

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)