### PR TITLE
Page the IDX screener so the universe covers the whole exchange (#110)

### DIFF
--- a/backend/screener/source.py
+++ b/backend/screener/source.py
@@ -96,6 +96,12 @@ SWEEP_WORKERS = max(1, DEFAULT_RESOLVE_WORKERS // 4)
 # role is ``reference`` (spec §2, §4.9).
 MARKET_INDEX = {"US": "^IXIC", "IDX": "^JKSE"}
 
+# Yahoo's screener serves the exchange one fixed-size page at a time, at most
+# this many quotes per call (issue #110). A single un-paged request returned only
+# the first page and silently truncated IDX to 250 names against the ~840 the
+# screener actually carries — so the enumeration pages by offset until the end.
+IDX_SCREEN_PAGE = 250
+
 # The Nasdaq Trader listing files (spec §3.1): common stocks plus the ETF flag
 # that separates funds. Served over HTTPS, pipe-delimited, with a trailing
 # "File Creation Time" footer line.
@@ -542,11 +548,36 @@ class YFinanceSourceClient:
         return info or {}
 
     def _screen_idx(self) -> list[str]:
+        """Enumerate every JKT-listed equity, paging the screener (issue #110).
+
+        The screener serves at most :data:`IDX_SCREEN_PAGE` quotes per call, so a
+        single request sees only the first page. Ask by ``offset`` until a short
+        (or empty) page marks the end, sorting by a stable key so successive
+        pages neither skip nor repeat a listing; overlap is deduped defensively
+        so a provider that ignores ``offset`` cannot inflate the count.
+        """
         import yfinance as yf
         from yfinance import EquityQuery
 
-        result = yf.screen(EquityQuery("eq", ["exchange", "JKT"]), size=250)
-        return [q["symbol"] for q in result.get("quotes", [])]
+        query = EquityQuery("eq", ["exchange", "JKT"])
+        seen: set[str] = set()
+        symbols: list[str] = []
+        offset = 0
+        while True:
+            result = yf.screen(
+                query, offset=offset, size=IDX_SCREEN_PAGE,
+                sortField="dayvolume", sortAsc=False,
+            )
+            quotes = result.get("quotes", [])
+            for quote in quotes:
+                symbol = quote["symbol"]
+                if symbol not in seen:
+                    seen.add(symbol)
+                    symbols.append(symbol)
+            if len(quotes) < IDX_SCREEN_PAGE:
+                break  # a short or empty page is the last one
+            offset += IDX_SCREEN_PAGE
+        return symbols
 
 
 def _http_get(url: str) -> str:

--- a/backend/tests/test_yfinance_client.py
+++ b/backend/tests/test_yfinance_client.py
@@ -20,6 +20,7 @@ import types
 import pytest
 
 from screener.source import (
+    IDX_SCREEN_PAGE,
     PermanentlyUnavailableError,
     RateLimitedError,
     YFinanceSourceClient,
@@ -161,6 +162,72 @@ def test_an_incremental_fetch_asks_from_the_start_and_sets_no_period(monkeypatch
 
     assert kwargs.get("start") == date(2026, 7, 1)
     assert "period" not in kwargs
+
+
+# -- the IDX screener pages the whole exchange (issue #110) -------------------
+
+
+def _install_paging_screener(monkeypatch, all_symbols):
+    """A fake yfinance whose ``screen`` serves ``all_symbols`` one page at a time,
+    honouring ``offset``/``size`` exactly as Yahoo's screener does — so the client
+    is forced to page to see past the first :data:`IDX_SCREEN_PAGE` names."""
+    module = types.ModuleType("yfinance")
+    calls: list[int] = []
+
+    def screen(query, *, offset, size, **_kwargs):
+        calls.append(offset)
+        page = all_symbols[offset:offset + size]
+        return {"quotes": [{"symbol": s} for s in page], "total": len(all_symbols)}
+
+    module.screen = screen
+    module.EquityQuery = lambda *a, **k: object()
+    monkeypatch.setitem(sys.modules, "yfinance", module)
+    return calls
+
+
+def test_the_idx_screener_pages_the_whole_exchange(monkeypatch):
+    # A single un-paged call saw only the first 250 names and truncated the IDX
+    # universe to that (issue #110). The client must page by offset until the
+    # exchange is exhausted — here 840 names across four pages.
+    universe = [f"S{i:04d}.JK" for i in range(840)]
+    calls = _install_paging_screener(monkeypatch, universe)
+
+    symbols = YFinanceSourceClient()._screen_idx()
+
+    assert symbols == universe  # every name, in order, not just the first page
+    assert calls == [0, 250, 500, 750]  # paged by offset until a short page ended it
+
+
+def test_a_single_short_page_needs_no_second_request(monkeypatch):
+    # A market smaller than one page ends on the first call — the short page is
+    # the terminator, so there is no wasted second request.
+    universe = [f"S{i}.JK" for i in range(IDX_SCREEN_PAGE - 3)]
+    calls = _install_paging_screener(monkeypatch, universe)
+
+    assert YFinanceSourceClient()._screen_idx() == universe
+    assert calls == [0]
+
+
+def test_paging_dedupes_overlap_across_pages(monkeypatch):
+    # If the provider ignores offset and repeats a full page, dedup keeps the
+    # count honest rather than letting the same names inflate the universe.
+    module = types.ModuleType("yfinance")
+    page = [{"symbol": f"S{i}.JK"} for i in range(IDX_SCREEN_PAGE)]
+    served: list[int] = []
+
+    def screen(query, *, offset, size, **_kwargs):
+        served.append(offset)
+        # Two identical full pages, then an empty one to terminate.
+        return {"quotes": page if len(served) <= 2 else []}
+
+    module.screen = screen
+    module.EquityQuery = lambda *a, **k: object()
+    monkeypatch.setitem(sys.modules, "yfinance", module)
+
+    symbols = YFinanceSourceClient()._screen_idx()
+
+    assert len(symbols) == IDX_SCREEN_PAGE  # the repeat added nothing
+    assert len(set(symbols)) == len(symbols)
 
 
 # -- the provider's wire form for a share class (issue #105) ------------------


### PR DESCRIPTION
## What

The IDX universe was enumerated from a single `size=250` Yahoo screener call with **no `offset` pagination**, so it silently truncated to the first 250 names (250 candidates + the `^JKSE` index = 251) against the ~840 the screener actually carries. Every run reported a clean `251/251` because the missing names were never enumerated — so they never registered as silent or refused, and the completeness gate saw a perfect run.

## Change

`_screen_idx` now pages the screener by `offset` until a short (or empty) page marks the end of the exchange, sorting by `dayvolume` (a stable key) so successive pages neither skip nor repeat a listing, and deduping overlap so a provider that ignores `offset` can't inflate the count. The per-call page size is a named constant, `IDX_SCREEN_PAGE`.

## Verification

Three new tests in `test_yfinance_client.py`: full 840-name exchange paged across four requests, a sub-page market that ends in one call, and overlap dedup.

A live forced re-pull of the 2026-08-10 IDX session (see #111 for why that needed an override):
- candidates enumerated: **250 → 839**
- measurable resolved: **838/838, 0 silent, 0 refused**
- tradeable universe: **83 → 300 members**

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)