### PR TITLE
Add a gated recompute for a published session after an enumeration fix (#111)

### DIFF
--- a/backend/screener/app.py
+++ b/backend/screener/app.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Callable
 
@@ -118,7 +118,21 @@ def create_app(
         )
 
     @app.post("/api/runs/{market}", response_model=RunTriggerResponse)
-    def trigger_run(market: str) -> RunTriggerResponse:
+    def trigger_run(
+        market: str,
+        recompute: bool = Query(
+            False,
+            description="Operator override (issue #111): re-pull and replace a "
+            "published session after an enumeration fix, instead of the ordinary "
+            "run-on-open. The swap only lands if the fresh pull clears the "
+            "completeness gate, so a throttled retry cannot downgrade good data.",
+        ),
+        session: date | None = Query(
+            None,
+            description="The session to recompute (default: last final). Ignored "
+            "unless recompute=true.",
+        ),
+    ) -> RunTriggerResponse:
         market = market.upper()
         if market not in MARKETS:
             raise HTTPException(status_code=404, detail=f"unknown market {market!r}")
@@ -126,10 +140,17 @@ def create_app(
             # No coordinator wired (e.g. a read-only deployment without a source);
             # the tab falls back to showing the last published session unchanged.
             raise HTTPException(status_code=503, detail="run trigger not configured")
-        # Single-flight: a second open mid-run joins the running run rather than
-        # starting a duplicate (spec §7.3). The tab polls /api/runs until running
+        # ``recompute`` defaults False, so ordinary run-on-open polling — which
+        # POSTs with no query — is untouched: the override is reachable only by an
+        # explicit ``?recompute=true`` an operator opts into, never by a tab
+        # opening (issue #111). Single-flight is shared: a recompute and a
+        # run-on-open of the same market cannot race — either joins whichever is
+        # already in flight (spec §7.3). The tab polls /api/runs until running
         # clears, then reloads the now-complete session.
-        triggered = run_manager.trigger(market)
+        if recompute:
+            triggered = run_manager.trigger_recompute(market, session)
+        else:
+            triggered = run_manager.trigger(market)
         return RunTriggerResponse(
             market=market, triggered=triggered, running=run_manager.is_running(market)
         )
@@ -388,10 +409,13 @@ def _default_run_manager() -> RunManager:
     run the scheduled CLI performs, so a run-on-open and a scheduled run are
     byte-for-byte the same work. Each run owns its store connection, so the tab
     stays responsive and the write path never shares the app's read connection.
+    :func:`screener.run.recompute_live` is wired as the operator override so a
+    ``POST /api/runs/{market}?recompute=true`` re-pulls a published session
+    (issue #111) through the same coordinator and single-flight flag.
     """
-    from .run import run_live
+    from .run import recompute_live, run_live
 
-    return RunManager(run_live)
+    return RunManager(run_live, recompute_live)
 
 
 app = create_app(run_manager=_default_run_manager())

--- a/backend/screener/pipeline.py
+++ b/backend/screener/pipeline.py
@@ -567,6 +567,7 @@ def _compute_session(
     unresolved: set[str],
     digests_dir: Path,
     refresh_labels_now: bool,
+    capture_regime: bool = True,
 ) -> None:
     """Recompute one session's derivable streams from stored bars (stages 4–10).
 
@@ -580,6 +581,12 @@ def _compute_session(
     with the run date and never backfilled, so ``refresh_labels`` fires only on
     the target session (``refresh_labels_now``) — a missed night leaves a visible
     gap in ``labels.as_of`` rather than a fabricated per-session stamp.
+
+    ``capture_regime`` is cleared only by an operator recompute (issue #111): the
+    follow-through row is the forward, unbiased regime record, kept write-once
+    even as the enumeration-derived streams are replaced, so its already-recorded
+    row is preserved rather than re-captured (spec §7.2, §4.9). Every ordinary run
+    and backfill leaves it ``True`` and captures the stream as usual.
     """
     members = rebuild_universe(
         store, market, session, instruments=instruments, unresolved=unresolved
@@ -588,7 +595,8 @@ def _compute_session(
     rebuild_detections(store, market, session)
     if refresh_labels_now:
         refresh_labels(store, source, market, members, session)
-    capture_follow_through(store, market, session)
+    if capture_regime:
+        capture_follow_through(store, market, session)
     write_digest(store, market, session, digests_dir=digests_dir)
 
 
@@ -648,6 +656,7 @@ def run_market_universe(
     digests_dir: Path = DEFAULT_DIGESTS_DIR,
     workers: int = DEFAULT_RESOLVE_WORKERS,
     progress: Callable[[str], None] = emit_progress,
+    recompute: bool = False,
 ) -> RunRecord | None:
     """The nightly per-market run: ingest bars, rebuild the universe, record it.
 
@@ -688,6 +697,23 @@ def run_market_universe(
     is superseded rather than left to refuse every retry until the calendar rolls
     (issue #103). The returned record is the target session's run, or ``None``
     when the target had already published and there was nothing to compute.
+
+    ``recompute`` is the operator override for correcting a *published* target
+    built from a known-buggy enumeration (issue #111): it re-pulls and, **only if
+    the fresh pull clears the completeness gate**, replaces that session's
+    enumeration-derived streams (:meth:`Store.supersede_published_session`) and
+    stamps a fresh published run. The safety the issue asks for is *gating*, not a
+    transaction: a throttled recompute falls through the same gate as any run and
+    returns ``None`` with the good published session untouched (the gate is
+    checked *before* anything is cleared), so a short pull can never downgrade
+    served data to an empty session. A recompute that clears the gate and is then
+    killed mid-recompute leaves the same debris any interrupted run does — a
+    session cleared but not yet re-stamped — which the next run heals exactly as
+    it heals #46 debris; the commit point is still the run record, written last.
+    The forward regime record (follow-through) is kept, staying write-once even
+    here; write-once for published data is relaxed only for the
+    enumeration-derived streams the fix actually changes, and only on an explicit
+    operator request.
 
     The pull runs ``workers`` resolves at once and heartbeats every
     :data:`PROGRESS_EVERY` symbols (issue #96). Both are properties of the *loop*
@@ -888,7 +914,11 @@ def run_market_universe(
             # served session with a banner on strictly worse evidence. Nothing is
             # recorded and the published record stands — the same "nothing to
             # compute" answer the publishing path below gives for a session that
-            # is already in the store.
+            # is already in the store. This gate is also what keeps ``recompute``
+            # safe (issue #111): it is checked *before* the published session is
+            # cleared, so a recompute whose fresh pull falls short lands here and
+            # leaves the good session intact rather than superseding it into an
+            # empty one.
             return None
         # A throttled pull quarantines the whole run: no universe, no ranks, no
         # backfill — the last good data keeps serving (spec §3.4 rule 7).
@@ -919,16 +949,42 @@ def run_market_universe(
     # every candidate that produced no bars tonight — a refused listing among
     # them, which is right: it has no bars to reclassify from either.
     unresolved = {s for s in candidates if status.get(s, "unresolved") != "resolved"}
+    # A recompute only supersedes the target when it is *currently published* —
+    # that is the recorded history #111 exists to correct. Aimed at a session that
+    # never published (absent or quarantined), ``--recompute`` degrades to an
+    # ordinary forced run: backfill already recomputes it, so the flag simply
+    # skips the gate the scheduler would have applied.
+    recorded_target = store.run(market, session)
+    target_published = recorded_target is not None and recorded_target.status == "published"
+    # The one condition that turns this run into the gated published override: an
+    # operator recompute (issue #111) aimed at a session that is *currently
+    # published*. Anything else — an ordinary run, or a recompute of a session
+    # that never published — takes the normal discard-and-recompute path.
+    gated_override = recompute and target_published
+    # Every unpublished session up to the target is (re)computed as always. On the
+    # override the target is published, so backfill skips it (§7.2); it is added
+    # back explicitly — the one published session this run is allowed to replace,
+    # now that its fresh pull has cleared the gate above (issue #111).
+    sessions = _sessions_to_backfill(store, market, session)
+    if gated_override and session not in sessions:
+        sessions = sorted([*sessions, session])
     record: RunRecord | None = None
-    for backfill_session in _sessions_to_backfill(store, market, session):
-        # A previous run may have died after writing some of this session's
-        # derived streams but before stamping its run record — rows that belong
-        # to no session, and that the write-once guard would otherwise refuse to
-        # let this run recompute, wedging the market permanently. The sessions
-        # reaching here have by construction never published, so anything found
-        # is either that debris or an earlier attempt's quarantine (issue #103),
-        # and both are cleared before recomputing.
-        store.discard_session(market, backfill_session)
+    for backfill_session in sessions:
+        recomputing_target = gated_override and backfill_session == session
+        if recomputing_target:
+            # The gated override: drop the published target's enumeration-derived
+            # streams and its run record, keeping the forward regime record, so
+            # the corrected enumeration can be written over it (issue #111).
+            store.supersede_published_session(market, backfill_session)
+        else:
+            # A previous run may have died after writing some of this session's
+            # derived streams but before stamping its run record — rows that
+            # belong to no session, and that the write-once guard would otherwise
+            # refuse to let this run recompute, wedging the market permanently.
+            # The sessions reaching here have by construction never published, so
+            # anything found is either that debris or an earlier attempt's
+            # quarantine (issue #103), and both are cleared before recomputing.
+            store.discard_session(market, backfill_session)
         _compute_session(
             store,
             source,
@@ -940,6 +996,9 @@ def run_market_universe(
             # The label cache is as-of-only: stamp it once, on the target session,
             # never per backfilled night (spec §7.3).
             refresh_labels_now=backfill_session == session,
+            # A recompute keeps the forward regime row it preserved above rather
+            # than re-capturing it — write-once holds for that stream (issue #111).
+            capture_regime=not recomputing_target,
         )
         if backfill_session == session:
             # The failures describe *this* pull, so they belong to the target

--- a/backend/screener/run.py
+++ b/backend/screener/run.py
@@ -15,8 +15,9 @@ a bare invocation fails loudly rather than pulling nothing.
 
 from __future__ import annotations
 
+import argparse
 import sys
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -51,6 +52,33 @@ def run_once(
     )
 
 
+def recompute_once(
+    store: Store,
+    source: Source,
+    market: str,
+    session: date,
+    *,
+    now: datetime,
+    digests_dir: Path = DEFAULT_DIGESTS_DIR,
+) -> RunRecord | None:
+    """Operator override: re-pull ``session`` and replace it if the pull is clean.
+
+    The supported answer to "we shipped an enumeration fix, now make this
+    published session reflect it" (issue #111). Unlike :func:`run_once` it does
+    *not* gate on :func:`run_is_due` — a published session is never "due", which
+    is the whole reason the correction had no supported path — and it targets the
+    session the operator names rather than the last final one. The replacement is
+    a safe atomic swap: :func:`run_market_universe` re-pulls, and only if the
+    fresh pull clears the completeness gate does it supersede the published
+    session; a throttled recompute returns ``None`` and leaves the good session
+    standing. Returns the fresh :class:`RunRecord`, or ``None`` when the pull fell
+    short and the existing session was kept.
+    """
+    return run_market_universe(
+        store, source, market, session, now=now, digests_dir=digests_dir, recompute=True
+    )
+
+
 def run_live(market: str) -> RunRecord | None:
     """Wire the real store and source and run ``market``'s due session.
 
@@ -80,14 +108,80 @@ def run_live(market: str) -> RunRecord | None:
         store.close()
 
 
+def recompute_live(market: str, session: date | None = None) -> RunRecord | None:
+    """Wire the real store and source and recompute one published ``session``.
+
+    The live counterpart of :func:`recompute_once` — the operator path for
+    correcting a published session after an enumeration fix (issue #111). Opens
+    the file-backed store and live source exactly as :func:`run_live` does, and
+    prints the fresh pull's account while the store is open. ``session`` defaults
+    to the last final session — the #110 case is "correct *today's* published
+    universe" — but any published session can be named. Returns the fresh
+    :class:`RunRecord`, or ``None`` when the pull fell short and the existing
+    session was kept.
+    """
+    from .app import DEFAULT_DB_PATH
+    from .source import default_source
+
+    now = datetime.now(ZoneInfo(EXCHANGE[market]["tz"]))
+    target = session if session is not None else last_final_session(market, now)
+    store = Store.open(DEFAULT_DB_PATH)
+    try:
+        record = recompute_once(store, default_source(), market, target, now=now)
+        if record is not None:
+            print(summarize_pull(record, store.run_failures(market, record.session)))
+        return record
+    finally:
+        store.close()
+
+
 def main(argv: list[str] | None = None) -> int:
-    """CLI: ``screener.run <MARKET>``. Runs the due session for one market
-    against the live store and source."""
-    args = sys.argv[1:] if argv is None else argv
-    if len(args) != 1 or args[0].upper() not in EXCHANGE:
-        print("usage: python -m screener.run <IDX|US>", file=sys.stderr)
+    """CLI: ``screener.run <MARKET> [--recompute [SESSION]]``.
+
+    With no flag, runs the due session for one market against the live store and
+    source (what launchd invokes). ``--recompute`` is the operator override for
+    correcting a *published* session after an enumeration fix (issue #111): it
+    re-pulls and replaces that session only if the fresh pull clears the
+    completeness gate, so a throttled retry can never downgrade good data.
+    ``SESSION`` is an ``YYYY-MM-DD`` date and defaults to the last final session.
+    """
+    parser = argparse.ArgumentParser(prog="screener.run")
+    parser.add_argument("market", type=str.upper, choices=sorted(EXCHANGE))
+    parser.add_argument(
+        "--recompute",
+        nargs="?",
+        const="",
+        metavar="SESSION",
+        help="re-pull and replace a published session (default: last final); "
+        "the swap only lands if the fresh pull clears the completeness gate",
+    )
+    try:
+        args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    except SystemExit:
         return 2
-    market = args[0].upper()
+    market = args.market
+
+    if args.recompute is not None:
+        try:
+            session = (
+                date.fromisoformat(args.recompute) if args.recompute else None
+            )
+        except ValueError:
+            print(
+                f"invalid --recompute session {args.recompute!r}; "
+                "expected YYYY-MM-DD",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            record = recompute_live(market, session)
+        except Exception as exc:  # a mis-aimed recompute explains itself
+            print(f"{market}: recompute failed — {exc}", file=sys.stderr)
+            return 1
+        if record is None:
+            print(f"{market}: recompute pull fell short, published session kept")
+        return 0
+
     # A run that happened has already printed its own account of the pull
     # (:func:`summarize_pull`, called in ``run_live`` while the store is open);
     # only the no-run case is left to say here.

--- a/backend/screener/runner.py
+++ b/backend/screener/runner.py
@@ -13,11 +13,18 @@ call :func:`screener.pipeline.run_market_universe` for the due session. Reads ar
 never served from a half-written session: every read endpoint keys off the last
 *published* run record, which :func:`run_market_universe` writes last, so the
 new session only becomes visible once the whole run has landed.
+
+An optional ``recompute_runner`` (``market, session -> None``) drives the
+operator override — re-pulling a published session after an enumeration fix
+(issue #111). It shares the same single-flight flag, so a recompute and a
+run-on-open of the same market cannot run at once; either joins whichever is
+already in flight.
 """
 
 from __future__ import annotations
 
 import threading
+from datetime import date
 from typing import Callable, Literal
 
 RunState = Literal["idle", "running", "failed"]
@@ -26,36 +33,58 @@ RunState = Literal["idle", "running", "failed"]
 class RunManager:
     """Coordinates one background pipeline run per market, single-flight."""
 
-    def __init__(self, runner: Callable[[str], None]) -> None:
+    def __init__(
+        self,
+        runner: Callable[[str], None],
+        recompute_runner: Callable[[str, date | None], None] | None = None,
+    ) -> None:
         self._runner = runner
+        self._recompute_runner = recompute_runner
         self._lock = threading.Lock()
         self._state: dict[str, RunState] = {}
         self._threads: dict[str, threading.Thread] = {}
         self._error: dict[str, str] = {}
 
     def trigger(self, market: str) -> bool:
-        """Start a run for ``market`` unless one is already in flight.
+        """Start a run-on-open for ``market`` unless one is already in flight.
 
         Returns ``True`` when a run was started, ``False`` when one was already
         running (the run-on-open that arrives mid-run is a no-op, not a
         duplicate). The status flips to ``running`` before the thread starts, so
         a caller that sees ``True`` can rely on :meth:`is_running`.
         """
+        return self._start(market, lambda: self._runner(market))
+
+    def trigger_recompute(self, market: str, session: date | None = None) -> bool:
+        """Start an operator recompute of ``session`` for ``market`` (issue #111).
+
+        The same single-flight contract as :meth:`trigger` — ``False`` when a run
+        (of either kind) is already in flight — but drives the recompute runner,
+        which re-pulls and replaces a published session only if the fresh pull
+        clears the completeness gate. ``session`` defaults to the last final
+        session. Raises :class:`RuntimeError` when no recompute runner was wired.
+        """
+        if self._recompute_runner is None:
+            raise RuntimeError("no recompute runner configured")
+        recompute = self._recompute_runner
+        return self._start(market, lambda: recompute(market, session))
+
+    def _start(self, market: str, job: Callable[[], None]) -> bool:
         with self._lock:
             if self._state.get(market) == "running":
                 return False
             self._state[market] = "running"
             self._error.pop(market, None)
             thread = threading.Thread(
-                target=self._run, args=(market,), name=f"run-{market}", daemon=True
+                target=self._run, args=(market, job), name=f"run-{market}", daemon=True
             )
             self._threads[market] = thread
         thread.start()
         return True
 
-    def _run(self, market: str) -> None:
+    def _run(self, market: str, job: Callable[[], None]) -> None:
         try:
-            self._runner(market)
+            job()
         except Exception as exc:  # a failed pull must clear the running flag
             with self._lock:
                 self._state[market] = "failed"

--- a/backend/screener/store.py
+++ b/backend/screener/store.py
@@ -240,21 +240,31 @@ class SessionExistsError(RuntimeError):
     """
 
 
-# The derived streams one session computes — every table keyed (market, session)
-# and guarded by :meth:`Store._guard_absent`, minus ``runs`` itself, which is the
-# commit point over them rather than one of them (:meth:`discard_session` clears
-# it separately, and only for a session that never published). ``bars`` is
-# deliberately not here: bars are the ingest substrate, committed per symbol so a
-# killed pull keeps what it already fetched (spec §3.3), and a re-pull appends
-# them idempotently rather than recomputing them.
-_DERIVED_TABLES = (
+# The enumeration-derived streams one session computes off its own pull — every
+# table keyed (market, session), guarded by :meth:`Store._guard_absent`, whose
+# contents are a function of *which symbols the run enumerated and resolved*.
+# These are exactly the streams a fixed enumeration changes, so a recompute
+# (:meth:`supersede_published_session`, issue #111) replaces them.
+#
+# ``follow_through`` is deliberately *not* here: it is the forward, unbiased
+# regime record (spec §4.9), a function of the index alone and not of the
+# candidate enumeration, and it stays write-once even under an operator
+# recompute (spec §7.2). ``runs`` is not here either — it is the commit point
+# over these streams rather than one of them, cleared separately below. ``bars``
+# is the ingest substrate, committed per symbol so a killed pull keeps what it
+# already fetched (spec §3.3), and a re-pull appends them idempotently.
+_ENUMERATION_DERIVED_TABLES = (
     "universe",
     "ranks",
-    "follow_through",
     "detections",
     "digest_breaks",
     "run_failures",
 )
+
+# Everything a run writes and :meth:`discard_session` clears for a never-published
+# session: the enumeration-derived streams *plus* the forward regime record, which
+# a session that never published never captured either.
+_DERIVED_TABLES = (*_ENUMERATION_DERIVED_TABLES, "follow_through")
 
 
 class SchemaDriftError(RuntimeError):
@@ -401,14 +411,61 @@ class Store:
                 f"({market}, {session}) carries a published run record; a "
                 "published session's rows are never discarded"
             )
+        return self._delete_session_rows((*_DERIVED_TABLES, "runs"), market, session)
+
+    def _delete_session_rows(
+        self, tables: tuple[str, ...], market: str, session: date
+    ) -> int:
+        """Delete ``(market, session)`` from each of ``tables``, counting the rows.
+
+        The shared mechanics behind :meth:`discard_session` and
+        :meth:`supersede_published_session` — they differ only in *which* tables
+        clear (and in the inverse guard each applies first), never in how a
+        session's rows are removed. Returns the total rows deleted.
+        """
         discarded = 0
-        for table in (*_DERIVED_TABLES, "runs"):
+        for table in tables:
             deleted = self._cursor().execute(
                 f"DELETE FROM {table} WHERE market = ? AND session = ? RETURNING 1",
                 [market, session],
             ).fetchall()
             discarded += len(deleted)
         return discarded
+
+    def supersede_published_session(self, market: str, session: date) -> int:
+        """Clear a **published** session's enumeration-derived rows so an operator
+        can recompute it, keeping the forward regime record (issue #111).
+
+        The deliberate inverse of :meth:`discard_session`, and gated the other
+        way: that method refuses a published session to protect write-once; this
+        one *requires* one, because it exists only to correct a session built
+        from a known-buggy enumeration (e.g. the truncated IDX universe of #110).
+        A session that never published is not superseded here — it is not
+        recorded history to correct but a hole to fill, and
+        :meth:`discard_session` already makes it retriable.
+
+        Only the :data:`_ENUMERATION_DERIVED_TABLES` and the run record go — the
+        streams a fixed enumeration changes, plus the commit point over them.
+        ``follow_through`` stays: it is the unbiased forward record, a function of
+        the index and not the candidate list, so correcting the enumeration must
+        not rewrite it (spec §7.2, §4.9). The caller re-pulls and recomputes the
+        cleared streams and stamps a fresh published run; the swap is safe only
+        because the caller clears *after* a fresh pull has cleared the
+        completeness gate, never on a throttled retry that would leave the
+        session empty.
+
+        Returns the number of rows discarded, the run record included.
+        """
+        recorded = self.run(market, session)
+        if recorded is None or recorded.status != "published":
+            raise SessionExistsError(
+                f"({market}, {session}) has no published run record; only a "
+                "published session is superseded — an absent or quarantined one "
+                "is made retriable by discard_session instead"
+            )
+        return self._delete_session_rows(
+            (*_ENUMERATION_DERIVED_TABLES, "runs"), market, session
+        )
 
     def _guard_absent(self, table: str, market: str, session: date) -> None:
         existing = self._cursor().execute(

--- a/backend/tests/test_recompute.py
+++ b/backend/tests/test_recompute.py
@@ -1,0 +1,166 @@
+"""Operator recompute of a published session (issue #111).
+
+There was no supported way to correct a published session built from a
+known-buggy enumeration (e.g. the truncated IDX universe of #110): the store's
+write-once guard refused to discard a published session and the scheduler refused
+to re-run one. ``run_market_universe(..., recompute=True)`` is that supported
+path — it re-pulls and replaces the session *only if* the fresh pull clears the
+completeness gate, so a throttled retry can never downgrade good data to an empty
+session. The forward regime record (follow-through) stays write-once even here.
+
+The source is injected so the whole swap is exercised without the network; its
+enumeration is mutable so a test can widen it between the first publish and the
+recompute, exactly as the #110 fix widened the live one.
+"""
+
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from screener.pipeline import run_market_universe
+from screener.source import Instrument, Source
+from screener.store import Store
+
+WIB = ZoneInfo("Asia/Jakarta")
+CAL = [date(2026, 7, 1) + timedelta(days=i) for i in range(30)]
+NOW = datetime(2026, 8, 20, 20, 0, tzinfo=WIB)  # past every session's close
+SESSION = CAL[-1]
+
+
+def _row(session, *, close, volume, adj_close=None):
+    return {
+        "Date": session, "Open": close, "High": close + 1, "Low": close - 1,
+        "Close": close, "Adj Close": adj_close if adj_close is not None else close,
+        "Volume": volume,
+    }
+
+
+class _MutableClient:
+    """A fake client whose enumeration and bars can be swapped between runs."""
+
+    def __init__(self, instruments, bars):
+        self.instruments = instruments
+        self.bars = bars
+
+    def enumerate(self, market):
+        return self.instruments
+
+    def fetch(self, symbol, start=None):
+        return self.bars.get(symbol, [])
+
+    def fetch_info(self, symbol):
+        return {"sector": "Technology", "industry": "Software"}
+
+
+def _index_bars():
+    # Climbs to a fresh high on the last session, so the run captures a breakout.
+    return [_row(s, close=1000.0 + i, volume=1_000_000) for i, s in enumerate(CAL)]
+
+
+def _liquid(adj_start=100.0):
+    return [
+        _row(s, close=2000.0, volume=1_000_000, adj_close=adj_start + i)
+        for i, s in enumerate(CAL)
+    ]
+
+
+def _source(client, **kwargs):
+    return Source(client, rate_per_sec=1000, sleep=lambda s: None, **kwargs)
+
+
+def test_recompute_replaces_the_universe_from_a_widened_enumeration():
+    # The #110 shape: publish under a buggy enumeration that only saw one
+    # candidate, then fix the enumeration and recompute the same session. The
+    # universe must grow to reflect the fix while the session stays a single
+    # published run.
+    store = Store.memory()
+    try:
+        client = _MutableClient(
+            [
+                Instrument(market="IDX", symbol="^JKSE", role="reference"),
+                Instrument(market="IDX", symbol="AAA", role="candidate", name="Alpha Tbk"),
+            ],
+            {"^JKSE": _index_bars(), "AAA": _liquid(), "BBB": _liquid()},
+        )
+        first = run_market_universe(store, _source(client), "IDX", SESSION, now=NOW)
+        assert first.status == "published"
+        assert store.universe("IDX", SESSION) == ["AAA"]
+
+        # The enumeration is fixed: BBB was always there, the buggy pull just
+        # never enumerated it.
+        client.instruments.append(
+            Instrument(market="IDX", symbol="BBB", role="candidate", name="Beta Tbk")
+        )
+        record = run_market_universe(
+            store, _source(client), "IDX", SESSION, now=NOW, recompute=True
+        )
+
+        assert record is not None and record.status == "published"
+        assert store.universe("IDX", SESSION) == ["AAA", "BBB"], "universe widened"
+        assert [r.session for r in store.runs("IDX")] == [SESSION], "still one run"
+    finally:
+        store.close()
+
+
+def test_recompute_keeps_the_forward_regime_record_write_once():
+    # follow-through is a function of the index, not the candidate enumeration, so
+    # correcting the enumeration must not rewrite it (spec §7.2, §4.9). One row
+    # before, the same one row after.
+    store = Store.memory()
+    try:
+        client = _MutableClient(
+            [
+                Instrument(market="IDX", symbol="^JKSE", role="reference"),
+                Instrument(market="IDX", symbol="AAA", role="candidate", name="Alpha Tbk"),
+            ],
+            {"^JKSE": _index_bars(), "AAA": _liquid()},
+        )
+        run_market_universe(store, _source(client), "IDX", SESSION, now=NOW)
+        before = store.follow_through("IDX")
+        assert [r.session for r in before] == [SESSION]
+
+        run_market_universe(
+            store, _source(client), "IDX", SESSION, now=NOW, recompute=True
+        )
+
+        after = store.follow_through("IDX")
+        assert [(r.session, r.broke_out, r.index_close) for r in after] == [
+            (r.session, r.broke_out, r.index_close) for r in before
+        ], "the forward record is untouched by the recompute"
+    finally:
+        store.close()
+
+
+def test_a_throttled_recompute_keeps_the_good_published_session():
+    # The safety property: a recompute whose fresh pull falls below the
+    # completeness floor must not downgrade the served session to an empty one. It
+    # returns None and the original universe stands (the atomic swap).
+    store = Store.memory()
+    try:
+        client = _MutableClient(
+            [
+                Instrument(market="IDX", symbol="^JKSE", role="reference"),
+                Instrument(market="IDX", symbol="AAA", role="candidate", name="Alpha Tbk"),
+            ],
+            {"^JKSE": _index_bars(), "AAA": _liquid()},
+        )
+        run_market_universe(store, _source(client), "IDX", SESSION, now=NOW)
+        assert store.universe("IDX", SESSION) == ["AAA"]
+
+        # The recompute pull goes silent on every candidate — only the index
+        # answers — so it falls under the resolution floor and quarantines.
+        client.bars = {"^JKSE": _index_bars()}
+        record = run_market_universe(
+            store,
+            _source(client, max_attempts=1),
+            "IDX",
+            SESSION,
+            now=NOW,
+            recompute=True,
+        )
+
+        assert record is None, "the throttled recompute recorded nothing"
+        assert store.universe("IDX", SESSION) == ["AAA"], "the good universe stands"
+        run = store.run("IDX", SESSION)
+        assert run.status == "published", "the published record is intact"
+    finally:
+        store.close()

--- a/backend/tests/test_run_api.py
+++ b/backend/tests/test_run_api.py
@@ -103,6 +103,49 @@ def test_post_triggers_a_run_and_reports_running(store: Store):
     manager.join("IDX")
 
 
+def test_post_recompute_drives_the_operator_override_with_its_session(store: Store):
+    # ``?recompute=true`` routes to the recompute runner and passes the named
+    # session through, so an operator can correct a published session over the
+    # API (issue #111).
+    recomputed: list[tuple[str, object]] = []
+    manager = RunManager(
+        lambda market: None,
+        lambda market, session: recomputed.append((market, session)),
+    )
+    app = create_app(store=store, run_manager=manager, clock=lambda: FIXED_NOW)
+
+    resp = app_post_recompute(app, "IDX", session="2026-08-05")
+    assert resp.status_code == 200
+    assert resp.json()["triggered"] is True
+    manager.join("IDX", timeout=5)
+    assert recomputed == [("IDX", date(2026, 8, 5))]
+
+
+def test_post_without_recompute_never_touches_the_override(store: Store):
+    # The guard: an ordinary run-on-open POST — no query — must drive the plain
+    # runner, never the destructive override, however a tab polls (issue #111).
+    ran: list[str] = []
+    override: list[str] = []
+    manager = RunManager(
+        lambda market: ran.append(market),
+        lambda market, session: override.append(market),
+    )
+    app = create_app(store=store, run_manager=manager, clock=lambda: FIXED_NOW)
+
+    TestClient(app).post("/api/runs/IDX")
+    manager.join("IDX", timeout=5)
+
+    assert ran == ["IDX"]
+    assert override == [], "a plain open never triggers a recompute"
+
+
+def app_post_recompute(app, market: str, *, session: str | None = None):
+    params = {"recompute": "true"}
+    if session is not None:
+        params["session"] = session
+    return TestClient(app).post(f"/api/runs/{market}", params=params)
+
+
 def test_post_without_a_run_manager_is_503(store: Store):
     app = create_app(store=store, clock=lambda: FIXED_NOW)
     assert TestClient(app).post("/api/runs/IDX").status_code == 503

--- a/backend/tests/test_run_cli.py
+++ b/backend/tests/test_run_cli.py
@@ -9,7 +9,7 @@ session-selection logic are tested without the network.
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from screener.run import run_once
+from screener.run import main, recompute_once, run_once
 from screener.store import Store
 from screener.source import Instrument, Source
 
@@ -121,3 +121,52 @@ def test_run_once_is_a_noop_when_not_due(tmp_path):
         assert record is None  # already current — no run
     finally:
         store.close()
+
+
+def _wide_source() -> Source:
+    """``_source`` plus a second liquid candidate — a *fixed* enumeration."""
+    sessions = _weekdays_ending(date(2026, 8, 5), 25)
+    instruments = [
+        Instrument(market="IDX", symbol="^JKSE", role="reference"),
+        Instrument(market="IDX", symbol="LIQ", role="candidate", name="Liquid Tbk"),
+        Instrument(market="IDX", symbol="LIQ2", role="candidate", name="Liquid Two Tbk"),
+    ]
+    bars = {
+        "^JKSE": [_row(s, 100.0, 1) for s in sessions],
+        "LIQ": [_row(s, 2000.0, 1_000_000) for s in sessions],
+        "LIQ2": [_row(s, 2000.0, 1_000_000) for s in sessions],
+    }
+    return Source(_FakeClient(instruments, bars), rate_per_sec=1000, sleep=lambda s: None)
+
+
+def test_recompute_once_replaces_a_published_session_that_is_not_due(tmp_path):
+    # The #111 gap: the last final session already published, so run_once is a
+    # no-op (nothing is due) — yet a fixed enumeration must still be able to
+    # correct it. recompute_once bypasses the due-gate and replaces the universe.
+    store = Store.memory()
+    try:
+        now = datetime(2026, 8, 5, 20, 0, tzinfo=WIB)
+        run_once(store, _source(), "IDX", now=now, digests_dir=tmp_path)
+        assert store.universe("IDX", date(2026, 8, 5)) == ["LIQ"]
+        # run_once now sees nothing due — the exact dead end #111 describes.
+        assert run_once(store, _wide_source(), "IDX", now=now, digests_dir=tmp_path) is None
+
+        record = recompute_once(
+            store, _wide_source(), "IDX", date(2026, 8, 5), now=now, digests_dir=tmp_path
+        )
+
+        assert record is not None and record.status == "published"
+        assert store.universe("IDX", date(2026, 8, 5)) == ["LIQ", "LIQ2"]
+    finally:
+        store.close()
+
+
+def test_main_rejects_a_malformed_recompute_date(capsys):
+    # A mistyped session is caught before any pull is attempted, so a typo never
+    # opens the live store or spends the network.
+    assert main(["IDX", "--recompute", "not-a-date"]) == 2
+    assert "expected YYYY-MM-DD" in capsys.readouterr().err
+
+
+def test_main_rejects_an_unknown_market(capsys):
+    assert main(["MARS"]) == 2

--- a/backend/tests/test_runner.py
+++ b/backend/tests/test_runner.py
@@ -8,6 +8,9 @@ session.
 """
 
 import threading
+from datetime import date
+
+import pytest
 
 from screener.runner import RunManager
 
@@ -80,3 +83,45 @@ def test_a_failed_run_is_recorded_and_the_market_is_runnable_again():
     assert manager.trigger("IDX") is True
     manager.join("IDX")
     assert manager.status("IDX") == "failed"
+
+
+def test_trigger_recompute_drives_the_recompute_runner_with_its_session():
+    # The operator override (issue #111): trigger_recompute runs the second
+    # callable, handing it the market and the session to correct.
+    calls: list[tuple[str, date | None]] = []
+    manager = RunManager(
+        lambda market: calls.append((market, "run")),
+        lambda market, session: calls.append((market, session)),
+    )
+
+    assert manager.trigger_recompute("IDX", date(2026, 8, 5)) is True
+    manager.join("IDX")
+
+    assert calls == [("IDX", date(2026, 8, 5))]
+    assert manager.status("IDX") == "idle"
+
+
+def test_recompute_shares_the_single_flight_flag_with_run_on_open():
+    # A recompute and a run-on-open of the same market must not race: whichever is
+    # in flight blocks the other rather than both writing the session at once.
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_run(market: str) -> None:
+        started.set()
+        release.wait(timeout=5)
+
+    manager = RunManager(slow_run, lambda market, session: None)
+    assert manager.trigger("IDX") is True
+    assert started.wait(timeout=5)
+    # The run-on-open holds the flag, so a recompute is refused mid-run.
+    assert manager.trigger_recompute("IDX") is False
+
+    release.set()
+    manager.join("IDX")
+
+
+def test_trigger_recompute_without_a_runner_is_an_error():
+    manager = RunManager(lambda market: None)  # no recompute runner wired
+    with pytest.raises(RuntimeError):
+        manager.trigger_recompute("IDX")

--- a/backend/tests/test_store_seam.py
+++ b/backend/tests/test_store_seam.py
@@ -287,6 +287,49 @@ def test_discarding_a_published_session_is_still_refused(store: Store):
     assert store.universe("US", date(2026, 8, 5)) == sorted(enumerated)
 
 
+# -- superseding a published session for an operator recompute (issue #111) ---
+
+
+def test_superseding_clears_the_enumeration_streams_but_keeps_follow_through(store: Store):
+    # The gated override for correcting a bad enumeration (#111): the session's
+    # universe/ranks/... and its run record go, so the corrected pull can be
+    # written over them, but the forward regime record — a function of the index,
+    # not the candidate list — stays write-once (spec §7.2, §4.9).
+    session = date(2026, 8, 5)
+    enumerated = [f"S{i}" for i in range(100)]
+    run_market(
+        store, "US", session, enumerated=enumerated, resolved=enumerated,
+        now=datetime(2026, 8, 5, 22, 10),
+    )
+    store.append_follow_through("US", session, broke_out=True, index_close=42.0)
+
+    store.supersede_published_session("US", session)
+
+    assert store.run("US", session) is None, "the run record is cleared"
+    assert store.universe("US", session) == [], "the universe is cleared"
+    rows = store.follow_through("US")
+    assert [(r.session, r.index_close) for r in rows] == [(session, 42.0)], (
+        "the forward regime record is preserved"
+    )
+
+
+def test_superseding_a_non_published_session_is_refused(store: Store):
+    # The inverse of discard_session's guard: supersede exists only to correct
+    # *recorded* history. A quarantined session published nothing, so it is a hole
+    # to fill (discard_session), not a session to correct — refused here.
+    enumerated = [f"S{i}" for i in range(100)]
+    run_market(
+        store, "US", date(2026, 8, 5), enumerated=enumerated, resolved=enumerated[:50],
+        now=datetime(2026, 8, 5, 22, 10),
+    )
+    assert store.last_run("US").status == "quarantined"
+    with pytest.raises(SessionExistsError):
+        store.supersede_published_session("US", date(2026, 8, 5))
+    # And an absent session — one that never ran at all — is refused too.
+    with pytest.raises(SessionExistsError):
+        store.supersede_published_session("US", date(2026, 8, 4))
+
+
 # -- opening a database that older code created ------------------------------
 
 

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -1398,6 +1398,37 @@
               "title": "Market",
               "type": "string"
             }
+          },
+          {
+            "description": "Operator override (issue #111): re-pull and replace a published session after an enumeration fix, instead of the ordinary run-on-open. The swap only lands if the fresh pull clears the completeness gate, so a throttled retry cannot downgrade good data.",
+            "in": "query",
+            "name": "recompute",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Operator override (issue #111): re-pull and replace a published session after an enumeration fix, instead of the ordinary run-on-open. The swap only lands if the fresh pull clears the completeness gate, so a throttled retry cannot downgrade good data.",
+              "title": "Recompute",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "The session to recompute (default: last final). Ignored unless recompute=true.",
+            "in": "query",
+            "name": "session",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The session to recompute (default: last final). Ignored unless recompute=true.",
+              "title": "Session"
+            }
           }
         ],
         "responses": {

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -904,7 +904,12 @@ export interface operations {
     };
     trigger_run_api_runs__market__post: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Operator override (issue #111): re-pull and replace a published session after an enumeration fix, instead of the ordinary run-on-open. The swap only lands if the fresh pull clears the completeness gate, so a throttled retry cannot downgrade good data. */
+                recompute?: boolean;
+                /** @description The session to recompute (default: last final). Ignored unless recompute=true. */
+                session?: string | null;
+            };
             header?: never;
             path: {
                 market: string;


### PR DESCRIPTION
Closes #111.

## What & why

A published run built from a known-buggy enumeration (e.g. the truncated IDX universe of #110) had **no supported correction**: the store's write-once guard refused to discard a published session and the scheduler refused to re-run one. The only options were waiting a full day for the next natural run, or unsupported raw-SQL surgery that risks leaving the session empty.

This adds an operator-initiated **recompute** that re-pulls against the live source and replaces the published session **only if the fresh pull clears the completeness gate**. The gate is checked *before* anything is cleared, so a throttled retry returns `None` and leaves the good session intact rather than downgrading it to an empty one.

The forward regime record (follow-through) stays **write-once** even here: it is a function of the index, not the candidate enumeration, so only the enumeration-derived streams the fix actually changes are replaced.

## Changes

- **store** — `supersede_published_session`: the deliberate inverse of `discard_session` (requires published rather than refusing it). Clears universe/ranks/detections/digest_breaks/run_failures + the run record, preserves `follow_through`. Shared delete mechanics factored into `_delete_session_rows`.
- **pipeline** — `run_market_universe(recompute=)`; `_compute_session(capture_regime=)` keeps the forward stream on the override.
- **CLI** — `python -m screener.run <MARKET> --recompute [SESSION]` (bypasses the `run_is_due` gate; session defaults to the last final session).
- **API** — `POST /api/runs/{market}?recompute=true[&session=]` through the same single-flight coordinator; the flag defaults false so ordinary run-on-open polling can never trigger the override.

## Safety note

The swap is *gated*, not transactional: a throttled recompute is refused before anything is cleared. A recompute that clears the gate and is then killed mid-recompute leaves the same debris any interrupted run does, which the next run heals exactly as it heals #46 debris — the commit point is still the run record, written last.

## Tests

+13 tests covering the store guards, universe replacement from a widened enumeration, follow-through preservation, the throttled-recompute-keeps-good-data property, and both CLI and API surfaces. Full suite green: **398 backend + 173 frontend**; frontend typecheck clean; OpenAPI contract regenerated.

Reviewed on both axes via `/code-review` (Standards + Spec); findings applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)