### PR TITLE
Remove the trigger and stop labels from the chart price lines

### DIFF
--- a/frontend/src/Chart.tsx
+++ b/frontend/src/Chart.tsx
@@ -86,8 +86,8 @@ export function Chart({ data, height = 360 }: { data: ChartResponse; height?: nu
     // Trigger and stop as horizontal rules read against the candles (spec §7). Two
     // real order levels — the cluster high and the cluster low.
     if (setup) {
-      candles.createPriceLine({ price: setup.trigger, color: TRIGGER_COLOR, lineWidth: 1, title: "trigger" });
-      candles.createPriceLine({ price: setup.stop, color: STOP_COLOR, lineWidth: 1, title: "stop" });
+      candles.createPriceLine({ price: setup.trigger, color: TRIGGER_COLOR, lineWidth: 1 });
+      candles.createPriceLine({ price: setup.stop, color: STOP_COLOR, lineWidth: 1 });
     }
 
     // The daily MA set as line series (spec §5.1).


### PR DESCRIPTION
The trigger and stop rules on the chart carried inline `title` text that rode on the price axis. This drops the labels while keeping both lines — same colors (green trigger, red stop), same widths, same positions.

Checks: `tsc --noEmit` clean; 29 tests pass across `ChartSheet.test.tsx`, `MiniChart.test.tsx`, and `Setups.test.tsx`. The ChartSheet test asserts on price-line *prices*, not titles, so no test changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
