### PR TITLE
Record the tightness study as §3b, and add a plain-language companion doc

### DIFF
--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -1,0 +1,535 @@
+# Testing the app against Qullamägi's real trades — findings, in plain language
+
+*This is a plain-language retelling of [`qullamaggie-replay-findings.md`](qullamaggie-replay-findings.md).
+Same study, same numbers, same conclusions — just without assuming you already
+speak the project's vocabulary. Where the two ever disagree, **the technical
+version is the authority**, because that's the one whose figures are checked
+against the committed run output.*
+
+**Nothing in the app was changed by this study.** It produces evidence only. The
+point is that if a setting is ever changed later, there's a written record of
+*why*, with the measurement that justified it and the limitations that go with it.
+
+---
+
+## The vocabulary, up front
+
+Five terms carry most of the document:
+
+- **ADR — the stock's average daily swing.** How far a stock typically travels
+  from its low to its high in one day, averaged over the last 20 days. Used as a
+  measuring stick so a wild stock and a sleepy one can be compared fairly.
+- **R — profit compared to what was risked.** Risking $100 and making $200 is
+  "+2R". Losing the planned amount is "−1R".
+- **MFE — how far a trade went in your favour at its best moment**, whether or
+  not you kept it. Used to ask "did this setup actually run?" separately from
+  "did the exit rule capture it?"
+- **The field** — every stock the app would have shown on a given evening.
+- **The funnel** — the three checks a stock must pass to appear at all:
+  *is it liquid enough*, *is it among the strongest performers*, and *does it
+  look like a valid setup*.
+
+Two more that come up constantly:
+
+- **Recall** — of the trades he really made, what fraction would the app have
+  shown him? High recall means it isn't missing his trades.
+- **Precision** — of the stocks the app shows, what fraction are actually any
+  good? **This study cannot measure precision at all**, and that limitation
+  shapes almost every decision in it. See "the one-sided ruler" below.
+
+---
+
+## What was tested, and against what
+
+**The trade record:** 828 real trades by Kristjan Kullamägi, from October 2019 to
+November 2022, across 312 stocks. All US, all long, all breakout setups, all
+end-of-day.
+
+Each trade has a **real entry** — the date and price he actually bought — paired
+with a **simulated exit**, because his actual exits aren't recorded. The exit is
+reconstructed by a trailing rule (sell when price closes below its 10-day
+average). The study never blurs these two: the entry is fact, the exit is a
+reasonable guess.
+
+**The timing rule that makes this a fair test.** Every check is run against the
+**evening before he bought** — never the day of. So the question is always
+"*would the app have pointed at this stock while the trade was still ahead of
+him?*", not "can the app recognise a winner after the fact". That distinction is
+the whole value of the exercise.
+
+**Repeat entries are kept, not hidden.** When he adds to a position he already
+holds (another entry in the same stock within 5 trading days), that trade is
+*labelled* as a repeat but stays in every total. Every recall number is reported
+twice — once for all trades, once excluding repeats — and never with the repeats
+quietly removed to flatter the result.
+
+**One scoring category had to be dropped.** The app scores setups on eight
+qualities; one of them is the stock's business sector. Historical sector labels
+weren't kept, so a stock's 2020 sector can't be recovered. That category is
+**dropped rather than guessed**, which means every score in this study is out of
+9 points instead of 10 — always labelled as such so it's never mistaken for the
+app's own score.
+
+**The app is tested as-is.** The study calls the app's real functions rather than
+reimplementing them, so what's measured is the app that exists.
+
+---
+
+## The biggest limitation, stated before any result
+
+**About 29% of the stocks are simply missing, and not at random.**
+
+The price history is built from today's list of traded companies. Any company
+that was delisted, acquired or renamed since then has no history left to fetch.
+Those vanished companies are disproportionately the ones that *later blew up* —
+which is exactly the population a momentum screener surfaces. So the missing data
+is missing in the least convenient possible way.
+
+| | |
+|---|---|
+| Total trades in the record | 828 |
+| Stocks affected by the hole | **91** |
+| Trades lost to it | **170** |
+| Share of his total profit in those lost trades | **18.1%** |
+
+**The hole is bigger than first thought, for an interesting reason.** The first
+count asked "does this ticker symbol exist today?" But the study needs a stricter
+question: "does this symbol have price history *during the years we're
+replaying*?" Ten symbols pass the first test and fail the second — APXT, BNKU,
+EYES, FNGU, LAC, LAZR, NRGU, SI, SPWR, USLV. Each is a case of a **ticker symbol
+being recycled onto a completely unrelated company**. Counting them as usable
+wouldn't just overstate coverage — it would test one company's trade against a
+different company's price history. So survivorship here means delisting *plus*
+symbol recycling, and the recycled ones are dangerous precisely because they look
+fine.
+
+**This hole is now permanent.** Buying the missing history was investigated and
+closed: every provider that carries it charges money, retail plans start around
+$100/month, and there's no budget. Free sources give company *identity* but never
+historical *prices*. So this isn't a gap waiting on a ticket — it's a permanent
+property of the study, and every field-based result below carries it.
+
+---
+
+## The one-sided ruler (why this study refuses to "improve" things)
+
+**We can measure what the app misses. We cannot measure what it wrongly
+includes.** The trade record lists only stocks he *bought*. It never records a
+setup he looked at and rejected. So there's no way to compute a false-positive
+rate.
+
+This creates an obvious trap: you could raise recall to 100% simply by loosening
+every filter until the app shows everything. The numbers would look like a
+triumph, and the app would be useless.
+
+So the study adopts a strict rule, and enforces it throughout:
+
+> **A filter may only be loosened when the evidence shows that quality genuinely
+> doesn't matter *and* that there was enough variety in the data to have detected
+> it if it did.**
+
+That second half matters more than it sounds. Every trade in the sample already
+passed his judgement, so the qualities he applies *most* consistently barely vary
+— and anything that barely varies will correlate with nothing. **A flat result on
+such a quality is evidence of his discipline, not of the quality's
+irrelevance.** Confusing those two would systematically dismantle the parts of
+the method that work best.
+
+---
+
+## Test 1 — Which filter throws away his trades?
+
+**658 of the 828 trades could be replayed** (the other 170 are the coverage
+hole). 80 of those are repeat entries.
+
+Each of the three filters was tested *independently* on every trade, so no single
+blended number can hide a disaster at one stage:
+
+| Filter | Would have kept | Excluding repeat entries |
+|---|---|---|
+| Liquid enough? | **598/658 (90.9%)** | 523/578 (90.5%) |
+| Strong enough performer? | **395/658 (60.0%)** | 340/578 (58.8%) |
+| Valid-looking setup? | **380/658 (57.8%)** | 341/578 (59.0%) |
+
+**The "strongest performers" filter is the expensive one.** It discards **40% of
+his real trades on its own**, before the setup detector even looks — nearly five
+times what the liquidity check costs.
+
+**One oddity worth noting:** the setup detector is the only stage that scores
+*better* once repeat entries are removed (59.0% vs 57.8%). His add-on buys are
+harder for it to see than his first entries — which makes sense, since an add-on
+isn't a fresh setup and the detector was never designed to catch one.
+
+### Why the 40% figure shouldn't be acted on directly
+
+Broken into three groups, that loss is not one problem:
+
+| What the 263 misses actually are | Count | Share |
+|---|---|---|
+| The stock was missing from our data entirely | **64** | 24.3% |
+| Would be recovered by widening the filter modestly | **75** | 28.5% |
+| Genuinely not among the strongest performers by any measure | **124** | 47.1% |
+
+So a quarter of the "miss" is the coverage hole wearing a disguise, and nearly
+half were nowhere near qualifying. **The filter's real width problem is 75 trades,
+not 263** — and even that can't be acted on, because widening it would admit
+unknown amounts of junk that we have no way to count.
+
+### Which part of "valid setup" does the rejecting
+
+| Reason a setup was rejected | Count | Share of 278 |
+|---|---|---|
+| **Not quiet enough beforehand** ("cluster") | **171** | 61.5% |
+| Price too far from its moving average | 47 | 16.9% |
+| Base too long or too short | 37 | 13.3% |
+| Not enough price history | 23 | 8.3% |
+| Daily swing too small | 0 | — |
+| No prior run-up | 0 | — |
+
+The quietness check alone rejects more than the other three combined. Notably,
+the daily-swing requirement never rejected a single trade — though it does
+withhold a *scoring point* from a third of them, which is a separate issue
+covered later.
+
+---
+
+## Test 1a — Is the quietness check set too strictly?
+
+Since quietness causes 61.5% of setup rejections, it got its own investigation.
+
+**What the check does:** it looks at the last 3 to 7 days and asks whether any
+stretch was calm enough — specifically, covering 1.5 ADR or less. If even the
+calmest 3-day stretch was wider than that, the stock is judged to be *still in
+motion* rather than *coiled and resting*, and it's rejected.
+
+**An earlier draft predicted these rejections would mostly be his add-on buys.
+That prediction was wrong, and it's recorded as wrong rather than quietly
+dropped:**
+
+| The 171 rejections | Count | Share |
+|---|---|---|
+| **Fresh entries** (not add-ons) | **148** | 86.5% |
+| Add-on buys | 23 | 13.5% |
+| **Only just missed** (within 2.0 ADR) | **113** | 66.1% |
+| Genuinely wide open, no base at all | 58 | 33.9% |
+
+Two thirds only *just* missed, clustered at a typical 1.85 against a 1.5 cutoff.
+That's the shape of a boundary drawn slightly too tight — not of stocks wildly in
+motion.
+
+**The recommendation is still "change nothing", but now for one reason instead of
+three.** The one-sided-ruler rule forbids loosening it: quietness has clearly
+demonstrated signal (see Test 1b below), so the rule's precondition fails no
+matter how the rejections are distributed. That was always the load-bearing
+argument. The 113 near-misses are logged as **the open question**, and answering
+them properly needs the false-positive rate we don't have.
+
+---
+
+## Test 1b — What "tight" actually means in his own trades
+
+*This section comes from a separate throwaway experiment, not from the main
+study — see `backend/replay/prototype-tightness/` on the
+`worktree-prototype-tightness` branch. Treat it as preliminary.*
+
+The check above rejects stocks for not being quiet enough. But nobody had asked
+the reverse question: **among the trades he actually took, how quiet were they?**
+The 1.5 cutoff was inherited from an older tool and never checked against him.
+
+Measured over the same 649 trades:
+
+| Stretch examined | typical (median) | share under 1.5 ADR |
+|---|---|---|
+| **last 3 days** | **1.31 ADR** | **64.4%** |
+| last 4 days | 1.55 | 47.3% |
+| last 5 days | 1.86 | 33.1% |
+| last 6 days | 2.06 | 20.3% |
+| last 7 days | 2.25 | 13.9% |
+
+**Finding 1 — the 1.5 cutoff sits at about his 64th percentile.** It admits 418
+of his 649 trades and rejects 231. There's no gap or natural break at 1.5; his
+distribution runs straight through it. The number is reasonable, but it's a
+choice rather than something discovered in the data.
+
+**Finding 2 — one of the two settings can't do anything.** The "3 to 7 days"
+range is really just "3 days": a longer stretch can only contain *more* movement,
+never less, so the calmest stretch is always the 3-day one. Confirmed on all 649
+trades. This means **only the lower bound decides pass or fail** — the upper bound
+merely affects the *score* a stock gets afterwards. The two settings sit side by
+side in the code looking like a matched pair, but they do unrelated jobs.
+
+**Finding 3 — quietness genuinely predicts profit, and it does so smoothly.**
+
+| How quiet beforehand | Trades | Average result |
+|---|---|---|
+| under 1.0 ADR | 164 | **+2.02R** |
+| 1.0–1.5 | 254 | **+1.35R** |
+| 1.5–2.0 | 139 | **+0.84R** |
+| 2.0–3.0 | 82 | **+0.35R** |
+| over 3.0 | 10 | **−0.36R** |
+
+A clean, steady decline — and crucially, **nothing special happens at 1.5**. A
+trade at 1.6 performs about the same as one at 1.4.
+
+> **Why averages and not typical values here:** the typical trade in *every* row
+> above loses exactly what was risked. Most of his trades stop out; he makes
+> money because the occasional winner is enormous. Looking at the typical trade
+> would show a loss everywhere and suggest nothing works.
+
+At the current 1.5 cutoff, the trades kept average +1.61R and those rejected
+average +0.61R — so the cutoff does separate better from worse. But it costs
+**231 of his own trades (35.6%), carrying 17.4% of his total profit**, to express
+something that varies gradually.
+
+**Finding 4 — his stop-loss is a completely different measurement.**
+
+| measured on the same days | typical |
+|---|---|
+| width of the calm stretch | **1.310 ADR** |
+| his actual stop-loss distance | **0.345 ADR** |
+
+A **3.8× gap** between two things both called "tight". He risks that single day's
+move, not the whole base. This exactly reproduces a figure the main study already
+established (Test 4 below), by a different route — a good sign the measurement is
+sound.
+
+**What this does and doesn't justify.** It does **not** justify loosening the
+cutoff — if anything it makes the case against loosening stronger, since quietness
+now has *both* selection signal and outcome signal. What it adds is a **price tag**:
+we now know what the hard cutoff costs. The live question is no longer "is 1.5 the
+right number" but "should this be a pass/fail gate at all, rather than a graded
+score with a much looser safety net" — and that still can't be settled without the
+false-positive rate we don't have.
+
+---
+
+## Test 2 — Would his trades have appeared on the list he actually reads?
+
+Only **104 of 658** trades (15.8%) appeared in the app's field at all, and only
+**41** landed in the top 30 by score.
+
+**The headline result was negative, and it's the study's most consequential
+finding.** Under the scoring system live at the time, his hand-picked entries
+scored 3.5 stars or better **17.3%** of the time. The general population of
+setups scored that well **17.8%** of the time.
+
+In other words: his real, high-conviction trades landed at the top of the scale
+at *the same rate as the random background they were drawn from*. The scoring
+system was not distinguishing his picks from anything else.
+
+### The re-run, after the scoring weights changed
+
+The weights were later revised (see Test 3c). Re-run on the identical field, with
+the weights as the only thing that changed:
+
+| | Old weights | New weights |
+|---|---|---|
+| Appeared in the field | 15.8% | 15.8% — unaffected by scoring |
+| In the top 30 | 41/658 | **45/658** |
+| **His picks at ≥3.5★** | 17.31% | **14.42%** |
+| **The field at ≥3.5★** | 17.82% | **8.83%** |
+| **Gap** | **−0.52pp** | **+5.59pp** |
+| Statistical significance | none | **p = 0.055** |
+
+**Verdict: the negative result is weakened, not reversed.** His picks now score
+well at 1.63× the field's rate, in the right direction. But this must not be read
+as "the scoring works", for three independent reasons:
+
+1. **It's circular.** The new weights were *derived from* this very comparison of
+   his picks against the field, then tested on that same comparison. A scoring
+   system fitted to a separation will reproduce that separation. The honest
+   reading is "the reweight did what it was built to do", not "the scoring
+   ranks".
+2. **It's marginal anyway.** p = 0.055 — fitted in-sample and *still* short of
+   the conventional threshold.
+3. **29% of the field is still missing**, permanently.
+
+**And the mechanism is unflattering.** His picks' average score rose by +0.010.
+The field's average *fell* by −0.187. The reweight didn't recognise his entries —
+**it demoted everyone around them.** That's a considerably weaker claim than "the
+system found his picks".
+
+> **This test rests on the weakest foundation of the three.** It ranks his trades
+> against a field missing a quarter of its names, using a sixth of his record. No
+> ranking claim should be argued from it in either direction. Deliberately, **no
+> percentile or rank-position figure is ever produced** — those would look precise
+> while quietly flattering the system.
+
+---
+
+## Test 3a — Does the scoring predict which setups run?
+
+Each scoring quality was checked against how far trades actually ran, across the
+104 detected trades.
+
+**Nothing in the scoring predicts a run.** Every correlation is negligible; the
+largest is 0.158 and it points the *wrong way*. Four of the six testable
+qualities correlate *negatively* with how far a trade ran. On this sample size,
+none is distinguishable from zero.
+
+**Read this narrowly.** It says the scoring doesn't predict how far a trade runs
+*among trades he already chose*. That's the range-restriction problem from
+earlier doing real work: these all passed his eye already. And one quality — the
+prior run-up — is **untestable by construction**, since every setup examined had
+already cleared the strength filter, so it's 100% throughout and there's nothing
+to correlate.
+
+Also reported here, and worth pausing on — the shape of his results:
+
+| | typical | best | average |
+|---|---|---|---|
+| Realised R | **−1.00** | +104.02 | **+1.245** |
+
+The typical trade loses exactly what was risked. The average is strongly
+positive. One trade returned 104×. That's the whole method in one line: **be
+wrong cheaply, often, and be right enormously, rarely.**
+
+---
+
+## Test 3b — Which qualities does his eye actually select on?
+
+This compares the 69 setups he took against the 14,354 he didn't take on the same
+evenings. **No outcome data is involved** — this asks only what his eye favours.
+
+| Quality | Weight then | He took | He passed over | Difference |
+|---|---|---|---|---|
+| **Big daily swing (ADR)** | ×1 | **87.0%** | 57.6% | **+29.4** |
+| **Quietness before entry** | ×2 | **59.4%** | 38.6% | **+20.8** |
+| Near moving-average support | ×1 | 76.8% | 72.5% | +4.3 |
+| Volume pattern | ×1 | 36.2% | 40.1% | −3.9 |
+| Orderly base | ×2 | 27.5% | 36.6% | **−9.1** |
+| **Base length** | ×1 | **44.9%** | 58.3% | **−13.4** |
+| Prior run-up | ×1 | 100% | 100% | 0.0 |
+
+> **This is where the signal is, and it explains Test 2.** Two qualities separate
+> his picks sharply: **big daily swing** and **quietness**. That's what his eye is
+> doing.
+>
+> Three go the *other way*. He takes setups that hit the "orderly base" and "base
+> length" criteria **less** often than the ones he passes over — and orderliness
+> carried a **double** weight. So the app was **paying double for a property he
+> systematically avoids, and single for the one he selects on hardest.** That's a
+> coherent explanation for why Test 2 came back flat: a score built partly on the
+> inverse of his criteria won't rank his picks above the field.
+
+> **Important framing:** the setups he didn't take are a **comparison group, not a
+> rejection list**. He may never have seen most of them. Nothing here labels them
+> bad.
+
+---
+
+## Test 3c — The rescoring that shipped
+
+The selection contrast above justified a change, with one strict rule:
+
+> **The evidence justifies the *direction* of a weight, never its exact size.**
+
+The *signs* survive the coverage hole; the *magnitudes* don't. So each weight was
+set from the **ordering** of the differences — no weight reads a number off the
+table.
+
+| Quality | Was | Now | Why |
+|---|---|---|---|
+| Quietness | ×2 | ×2 | +20.8pp — second-strongest selector |
+| **Daily swing (ADR)** | ×1 | **×2** | **+29.4pp — the sharpest selector** |
+| **Orderly base** | ×2 | **×1** | **−9.1pp — hit less often than the field** |
+| **Base length** | ×1 | **×0** | **−13.4pp — the largest wrong-way signal** |
+| Prior run-up | ×1 | ×1 | identical in both groups — kept as documentation |
+| Moving-average support | ×1 | ×1 | +4.3pp — within noise |
+| Volume | ×1 | ×1 | −3.9pp — within noise |
+
+Base length keeps a **visible ×0 row** rather than being deleted, so a reader sees
+it was measured and found worthless, and gets routed to the reasoning. The ×0
+says *the quality as currently defined* earns nothing — not that base length is
+irrelevant. A specific suspect (the 14-day maximum) is named and left open.
+
+---
+
+## Test 4 — Two direct measurements
+
+### The app's suggested stop-loss was about 4× too wide. **Confirmed.**
+
+| | typical stop | within 1.0 ADR |
+|---|---|---|
+| What the app proposed | 1.28 ADR | 14.2% |
+| What he actually used | **0.345 ADR** | **98.15%** |
+
+The app was proposing a stop nearly four times wider than the trader's own
+convention. This made the "can I afford this position?" indicator nearly
+meaningless — not because positions were unaffordable, but because the stop
+convention was simply wrong.
+
+**Adopted.** The app now places its suggested stop at his measured convention —
+0.345 ADR below the trigger. Note carefully what this does and doesn't do: the
+score never looks at the stop, so **this cannot change the ranking at all.** It
+changes what the app proposes and what a card claims about risk. Nothing else.
+
+### The daily-swing requirement silently withholds a point from a third of his trades. **Confirmed.**
+
+The minimum daily swing is set at 5%. His actual swing at entry is 4.7% at the
+25th percentile — so the requirement withholds its scoring point from **30.7%** of
+his real entries.
+
+Since daily swing is the quality he selects on *most* sharply, a floor that
+withholds credit from the bottom third of his own trades is blunting the single
+dimension the record says matters most to him. Note this costs a *score point*
+only — the swing requirement never rejected a trade outright.
+
+---
+
+## The limitations, carried with the same weight as the results
+
+- **Survivorship.** 29% of stocks missing, skewed toward those that later died.
+  Permanent.
+- **Everyone already passed his eye.** The qualities he applies most consistently
+  vary least, so they correlate with nothing. A flat result there is evidence of
+  his discipline.
+- **No precision, ever.** No control group exists. Recall must never be optimised
+  on its own.
+- **Cold-start drift.** The simulation starts from nothing, so borderline stocks
+  may drift from what really happened. 126 days of warm-up settle this before any
+  measured day, but the drift is real and recorded rather than engineered away.
+  Prices are split-adjusted and won't match a 2020 broker screen.
+- **Scope.** US only, 2019–2022, with **86.6% of trades from 2020–21** — a
+  once-in-a-decade momentum market.
+
+---
+
+## What transfers to the Indonesian market
+
+**The *shape* of these findings travels. The *numbers* do not.**
+
+Carry the structural lessons — which filter is costing entries, that stop
+conventions should be measured against the trader's own risk rather than assumed,
+that a flat result must be read against how much variety there was. Carry **none**
+of the figures. No number here should be presented as an expectation for IDX; the
+trade record contains no IDX trade.
+
+---
+
+## What this study cannot say
+
+- **It cannot claim the ranking works.** Test 2's flat result under the old
+  weights is real. The improvement under new weights is in-sample and marginal.
+  Neither may be read as validation.
+- **It cannot give a false-positive rate.** No control group.
+- **It cannot say anything about the prior run-up quality.** It's 100% in every
+  group that can be constructed, so there is nothing to measure.
+- **It cannot speak to other setup types** (Episodic Pivot, Parabolic Short), to
+  intraday entries, or to any stock in the missing-data list.
+
+---
+
+## Reproducing it
+
+```
+python -m replay.study --store data/replay.duckdb
+```
+
+One command rebuilds the field once and computes coverage plus all four analyses
+against it, writing both a readable report and a machine-readable results file —
+both committed next to this document, so every figure above is checkable against
+the run that produced it rather than quoted from memory.
+
+The Test 1b figures are the exception: they come from the throwaway experiment
+and are rebuilt with `backend/replay/prototype-tightness/measure_tightness.py`.

--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -289,9 +289,18 @@ something that varies gradually.
 | his actual stop-loss distance | **0.345 ADR** |
 
 A **3.8× gap** between two things both called "tight". He risks that single day's
-move, not the whole base. This exactly reproduces a figure the main study already
-established (Test 4 below), by a different route — a good sign the measurement is
-sound.
+move, not the whole base.
+
+**And we now know exactly where his stop comes from.** A separate study (Test 5
+below) found that his stop width has **no relationship at all** to how far the
+stock is from its moving average — the correlation is essentially zero. Its
+conclusion: **he places his stop at the low of the day he buys.** So the stop is
+set by that one day's trading range. Not by the calm stretch before it, not by
+anything else. That's the mechanism behind the 3.8× gap.
+
+Three separate measurements of his stop now agree with each other (Test 4, Test 5,
+and this one — different subsets of trades, different calculation routes, same
+answer). This is about as solid as anything in the project gets.
 
 **What this does and doesn't justify.** It does **not** justify loosening the
 cutoff — if anything it makes the case against loosening stronger, since quietness
@@ -300,6 +309,27 @@ we now know what the hard cutoff costs. The live question is no longer "is 1.5 t
 right number" but "should this be a pass/fail gate at all, rather than a graded
 score with a much looser safety net" — and that still can't be settled without the
 false-positive rate we don't have.
+
+### A useful contrast with the "extended" study
+
+Test 5 below sets a hard cutoff for a *different* quality, and its reasoning is
+worth borrowing. It explicitly refuses to draw the line at "wherever most of his
+trades fall", on the grounds that **where his habits sit and where trades stop
+working are two different questions, and the outcome data should win.**
+
+Applying that same test to quietness gives the *opposite* answer, and that's the
+point:
+
+| | What the results look like | So the honest way to encode it |
+|---|---|---|
+| Distance from the moving average (Test 5) | A **cliff** — profit collapses past a specific point | A hard cutoff |
+| Quietness (Test 1b) | A **smooth slope** — no special point anywhere | A graded score |
+
+These two qualities genuinely differ in kind, so they shouldn't be built the same
+way. And note that the current 1.5 cutoff satisfies *neither* test: it isn't a
+percentile anyone deliberately chose (it was inherited, and merely happens to land
+at his 64th), and it isn't placed at a feature in the results, because there is no
+feature there to place it at.
 
 ---
 
@@ -464,6 +494,13 @@ convention was simply wrong.
 score never looks at the stop, so **this cannot change the ranking at all.** It
 changes what the app proposes and what a card claims about risk. Nothing else.
 
+**Independently confirmed twice since.** A later study (Test 5) measured his stop
+again on a different subset of trades, reading prices from a different source and
+calculating the daily swing a different way. It got **0.346** where this got
+0.345, and matched on every other quartile too. The tightness experiment (Test 1b)
+makes a third. Two independent routes to four matching figures is about as firm as
+this record gets.
+
 ### The daily-swing requirement silently withholds a point from a third of his trades. **Confirmed.**
 
 The minimum daily swing is set at 5%. His actual swing at entry is 4.7% at the
@@ -474,6 +511,82 @@ Since daily swing is the quality he selects on *most* sharply, a floor that
 withholds credit from the bottom third of his own trades is blunting the single
 dimension the record says matters most to him. Note this costs a *score point*
 only — the swing requirement never rejected a trade outright.
+
+---
+
+## Test 5 — How far above the moving average does he actually buy?
+
+*Full detail in [`qullamaggie-entry-ma-distance.md`](qullamaggie-entry-ma-distance.md).
+Matched on 579 trades.*
+
+The method notes claim his entries "hug the rising 10/20/50-day average", and that
+this is really the same rule as his stop-size limit. Neither half had a number
+attached. Both turn out to be checkable.
+
+**He does enter close — to the 10-day.** The typical entry sits **4.1% above the
+10-day average** (about 0.7× a normal day's swing). 70% of entries are within one
+day's swing of it; 92% within two.
+
+**But "10/20/50-day" is not one thing.** The typical entry is **2.11× ADR above the
+50-day** — he is not hugging that one in any meaningful sense. Only 21.5% are
+within one day's swing of it. Lumping the three together, as the method notes do,
+hides a real distinction.
+
+### Why buying "extended" hurts — not for the reason anyone assumed
+
+The assumed reason for staying near the average is that buying far away forces a
+wider stop, or gets you shaken out. **The data says that's wrong.** Trades bought
+far from the average get stopped out at about the *same* rate — the win rate holds
+steady out to 2× ADR, and the stop size he sets barely changes.
+
+**What collapses is the upside.** The share of big winners (3R or better) roughly
+halves between 1× and 2× ADR while the win rate stays flat. The trades still
+*work* about as often — they just stop *paying*.
+
+The interpretation: buying well above the 10-day means buying late into a move
+that's already largely spent. You get a normal win rate on truncated gains. And a
+strategy that only wins 23% of the time **cannot survive on truncated gains** — it
+needs the huge winners to carry everything.
+
+> **This distinction decides what a fix would even look like.** If the problem were
+> getting shaken out, a wider stop or smaller position would rescue an extended
+> entry. Since the problem is a spent move, **nothing about position management
+> rescues it.** The only correct action is to not take the trade.
+
+### The proposed definition of "extended"
+
+> **More than 1.5× ADR above the 10-day average.** Past that, the strategy's
+> expected return is zero. **Past 2.5× ADR, don't trade it at all** — that bucket
+> contains 24 trades and *zero* winners.
+
+At a typical 5.9% daily swing, 1.5× ADR is roughly **9% above the 10-day**, and the
+hard line about 15%. Encouragingly, that lands close to a rule of thumb he'd stated
+himself on stream from completely different reasoning ("already ~14% past the
+trigger — it's gone").
+
+**Two lines rather than one**, deliberately, because the data has two features: a
+zone where the edge thins (worth a warning) and a zone where it's absent (worth a
+refusal). One number would throw that distinction away.
+
+### One result that complicates it
+
+Entries *below* the 10-day do **badly** — worse than entries just above it
+(−0.20R average, 14.6% win rate). So being *near* the average isn't the goal;
+being near it **on the correct side** is. Below the 10-day means the breakout has
+already failed, or hasn't happened yet — a different setup wearing a breakout's
+clothes. Any "extended" rule must therefore be **one-sided**: it should disqualify
+far-above and stay silent about below, which is a separate problem.
+
+### And it settles a claim in the method notes
+
+The notes say the moving-average rule and the stop-size rule "are the same rule".
+**In this record they aren't even correlated** (essentially zero). Because he stops
+at the low of the day he buys, his stop is set by that day's range — not by how far
+price has run from the average.
+
+So these are two genuinely separate filters that fail for different reasons: one
+rejects trades you can't size, the other rejects trades whose move is already
+spent. **Both are needed.**
 
 ---
 
@@ -513,8 +626,17 @@ trade record contains no IDX trade.
   weights is real. The improvement under new weights is in-sample and marginal.
   Neither may be read as validation.
 - **It cannot give a false-positive rate.** No control group.
-- **It cannot say anything about the prior run-up quality.** It's 100% in every
-  group that can be constructed, so there is nothing to measure.
+- **It cannot say anything about the prior run-up quality** — it's 100% in every
+  group that can be constructed, so there's nothing to measure. **A partial way
+  around this has since been found:** Test 5 uses *distance above the 50-day
+  average* as a continuous stand-in for "how far has this already run". Unlike the
+  yes/no version, that has real variety in it, and across that range it correlates
+  weakly **positively** with results — the opposite sign to distance above the
+  10-day. This doesn't validate the existing check, which stays unmeasurable. It
+  shows the underlying quantity becomes measurable once expressed as a *degree*
+  rather than a *yes/no* — the same move proposed for quietness in Test 1b. The
+  caveat attached there applies at full force: a 2020–21 market rewarded
+  distance-from-the-50-day almost everywhere.
 - **It cannot speak to other setup types** (Episodic Pivot, Parabolic Short), to
   intraday entries, or to any stock in the missing-data list.
 
@@ -531,5 +653,9 @@ against it, writing both a readable report and a machine-readable results file �
 both committed next to this document, so every figure above is checkable against
 the run that produced it rather than quoted from memory.
 
-The Test 1b figures are the exception: they come from the throwaway experiment
-and are rebuilt with `backend/replay/prototype-tightness/measure_tightness.py`.
+Two sets of figures sit outside that command:
+
+- **Test 1b** comes from a throwaway experiment — rebuild with
+  `backend/replay/prototype-tightness/measure_tightness.py`.
+- **Test 5** is its own study — rebuild with `scripts/entry_ma_distance.py`, which
+  writes `references/qullamaggie-entry-ma-distance.csv` alongside its write-up.

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -412,6 +412,47 @@ model before either is tuned.
 > ADR. Anyone extending the study should use the ratio form. The range-in-ADR figures are computed
 > from bars alone and were never exposed to this.
 
+#### Read against the entry-to-MA study (#143) — one mechanism confirmed, one method borrowed
+
+Two points of contact with [`qullamaggie-entry-ma-distance.md`](qullamaggie-entry-ma-distance.md),
+which landed independently and measured a different quantity on an overlapping subset (n=579).
+
+**1. It supplies the mechanism for the 3.8× gap above.** That study finds stop width and
+entry-to-SMA10 distance are **uncorrelated across his book (Spearman −0.002)**, and concludes he
+stops at the low of the **entry day** — so the stop is set by that day's range, not by the base
+geometry and not by how far price has travelled from the MA. That is exactly the shape §3b
+measures from the other side: a stop at 0.345 ADR against a base of 1.310 ADR is not a base-derived
+stop, and now it is clear what it *is* derived from. Three independent measurements of the stop now
+agree (§6's 0.345, that study's 0.346 on a different subset and a different ADR basis, and §3b's
+reproduction), and the mechanism is no longer a guess.
+
+**2. Its method for setting a line is the right one, and applying it here gives the opposite
+answer.** That study explicitly refuses to set "extended" at a percentile of his habits —
+*"a percentile describes his habits; it does not describe where trades stop working. The two
+disagree, and the outcome data should win"* — and sets the line at 1.5 × ADR above the SMA10
+because the outcome data has a **feature** there: the ≥3R share halves between 1× and 2× while the
+win rate holds, and expectancy reaches zero past 1.5×. A cliff exists, so a threshold is the honest
+encoding of it.
+
+Applying the same test to tightness gives the opposite result. §3b's outcome table has **no such
+feature** — mean R declines monotonically and smoothly, and the decline through 1.5 is
+indistinguishable from the decline through 1.0 or 2.0. So the two dimensions genuinely differ in
+kind, and should not be encoded the same way:
+
+| | Outcome shape | Honest encoding |
+| --- | --- | --- |
+| Entry-to-MA distance (#143) | A cliff — expectancy → 0 past 1.5 ×ADR, ≥3R share halves | A threshold (plus a hard no-trade line past 2.5 ×) |
+| Tightness (§3b) | A smooth monotone decline, no feature anywhere | A graded score |
+
+Note also that `TIGHT_MULT = 1.5` is currently justified by neither test: it is not a percentile
+anyone chose (it is a borrowed q-scanner-v2 default that happens to land at his 64th) and it is not
+sited on a feature in the outcome data, because there is no feature to site it on.
+
+That study's **two-line design** — a soft zone that warns and a hard zone that refuses — is the
+pattern worth borrowing if tightness is ever restructured: a graded rubric input across the range
+where the signal varies, plus a far outlier guard, rather than one line doing both jobs. Filed as
+#145.
+
 #### What this does and does not license
 
 **It does not license loosening `TIGHT_MULT`, and §3a's verdict stands unchanged.** The calibration

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -7,6 +7,10 @@ app's funnel, field and rubric (PRD #114).
 `detection.py`, `score.py`, `universe.py` or `ranks.py` is touched by it, and none is
 touched by this write-up (PRD "Out of Scope"; #114 acceptance).
 
+**A plain-language version of this document** — same numbers, same conclusions, no assumed
+vocabulary — is at [`qullamaggie-replay-findings-plain.md`](qullamaggie-replay-findings-plain.md).
+This file remains the authority: its figures are the ones checked against the committed run output.
+
 This document exists so that any constant later changed has a **citable provenance**
 (user story 26): each figure below names the analysis and the module that produced it, and
 each carries the caveat that bounds it. The caveats are given the same weight as the
@@ -303,6 +307,130 @@ measurable — a control group of setups he *passed over* — so a recall gain c
 its false-positive cost; and an out-of-regime or IDX reference set, so the window is not tuned to a
 once-in-a-decade US momentum regime (§8). Absent those, the question is re-openable rather than
 settled by omission, and the machinery above is what a re-opening would read.
+
+---
+
+### 3b. What "tight" is in the trade record itself — the shape of the tightness signal (prototype, side-car)
+
+**Question.** §3a characterised the `cluster` **misses** and left the 113 marginal ones as its open
+question. It never asked the complementary question: across the trades he *did* take, what geometry
+did the tightness dimension actually have? `TIGHT_MULT = 1.5` and `TIGHT_K = 5` are borrowed
+q-scanner-v2 defaults; nothing in the study had yet placed them against his own distribution.
+
+**Method.** For each replayable trade, walk to the evaluation session (§1's convention — the last
+session strictly before entry) and record the raw trailing k-bar range in ADR for **every** k in
+3..7, gating nothing at measurement time. Same reference set, same ADR definition
+(`screener.indicators.adr_abs`), same n as §6: **649 of 828 (78.4%)**, the missing rows being 170
+tickers absent from the bar store, 7 short of 20 bars and 2 with no prior session. Because nothing
+is gated during measurement, any threshold can be re-derived afterwards without a rebuild.
+
+Produced by a **throwaway prototype**, not by `replay.study`: `backend/replay/prototype-tightness/`
+on branch `worktree-prototype-tightness` (see that directory's `FINDINGS.md`). It is a side-car to a
+side-car, and is **not** part of the reproducible study in §10 — the figures below are checkable by
+re-running `measure_tightness.py`, not by `python -m replay.study`. Treated as preliminary in the
+sense of §6, and flagged as such wherever cited.
+
+#### The distribution `TIGHT_MULT` is cutting into
+
+| Trailing window | p25 | median | p75 | p90 | max | share ≤ 1.5 ADR |
+| --- | --- | --- | --- | --- | --- | --- |
+| **k = 3** | 1.00 | **1.31** | 1.73 | 2.16 | 5.09 | **64.4%** |
+| k = 4 | 1.20 | 1.55 | 2.05 | 2.48 | 7.65 | 47.3% |
+| k = 5 | 1.36 | 1.86 | 2.31 | 2.84 | 13.12 | 33.1% |
+| k = 6 | 1.61 | 2.06 | 2.55 | 3.24 | 17.03 | 20.3% |
+| k = 7 | 1.77 | 2.25 | 2.81 | 3.55 | 17.50 | 13.9% |
+
+`TIGHT_MULT = 1.5` sits at roughly his **64th percentile** on the binding window: it admits 418 of
+his 649 replayable entries and declines 231. There is no gap, shoulder or inflection at 1.5 —
+the distribution runs straight through it.
+
+Note the last column against `TIGHT_K = 5`: only a third of his entries had a 5-bar window inside
+1.5 ADR, so the rubric's ×2 tightness dimension is a genuinely selective test rather than a
+formality — consistent with §5b's +20.8pp.
+
+#### `cluster_min_range_adr` is the 3-bar range, and only `K_MIN` can gate
+
+Range is monotone in `k`: a longer trailing window can only contain more high and more low, never
+less. So the minimum over `k ∈ 3..7` is **always** `k = 3` — confirmed on all 649 rows, identical to
+the last decimal. Two consequences for how §3a's machinery should be read:
+
+- `screener.detection.cluster_min_range_adr` reports **the 3-bar range** under a more general name.
+  §3a's "tightest-window range in ADR: median 1.85" over the misses is a 3-bar median.
+- **`K_MAX` cannot affect pass/fail.** `_find_cluster` scans downward from `K_MAX` and returns the
+  first window under the threshold, so widening or narrowing `K_MAX` changes only the *reported*
+  `cluster_k` — which is what the rubric's ×2 dimension then scores. `K_MIN` alone decides whether a
+  name clears the gate. The two constants sit together in `detection.py` as if they were a matched
+  pair; they are doing unrelated jobs.
+
+#### The signal is graded, and the decline is smooth through 1.5
+
+Grouping the taken trades by the 3-bar range they sat in, against the record's own 10-SMA exit:
+
+| 3-bar range (ADR) | Trades | Mean R | Median R | Win rate |
+| --- | --- | --- | --- | --- |
+| 0.0–1.0 | 164 | **+2.02** | −1.00 | 23.2% |
+| 1.0–1.5 | 254 | **+1.35** | −1.00 | 25.3% |
+| 1.5–2.0 | 139 | **+0.84** | −1.00 | 18.0% |
+| 2.0–3.0 | 82 | **+0.35** | −1.00 | 22.0% |
+| 3.0+ | 10 | **−0.36** | −1.00 | 20.0% |
+
+Monotone across the whole range and **smooth** — the decline through 1.5 looks like the decline
+through 1.0 or 2.0. Median R is −1.00 in every bucket: most of his trades stop out and the record
+lives in its tail, so mean R is the statistic here and the median is uninformative by construction.
+
+At the shipped 1.5 the gate splits mean R **1.61 kept vs 0.61 rejected**, keeping 64.4% of his
+trades and 82.6% of his summed R. Widened to ~3.0 it keeps 98.5% of trades and 100.4% of his R —
+over 100% because the rejected tail is net negative.
+
+**This corroborates §5b from the opposite direction.** §5b showed he *selects* for tightness
+(+20.8pp, second-strongest selector); §3b shows the dimension also *predicts outcome* among the
+trades he took, and does so continuously. Tightness is the best-evidenced dimension in the study.
+
+#### The stop is not the base — a 3.8× gap between two things called "tight"
+
+Measured on the same evaluation sessions:
+
+| | p25 | median | p75 | max |
+| --- | --- | --- | --- | --- |
+| The base (3-bar range, ADR) | 1.00 | **1.310** | 1.73 | 5.09 |
+| His stop width (ADR) | 0.238 | **0.345** | 0.490 | 2.753 |
+
+**Ratio of medians 3.80×**; median of the per-trade ratio 3.77×. The stop row **reproduces §6
+Finding 1 exactly** — every quantile, the 98.15% at-or-under-1.0-ADR share, and the same n — which
+is the provenance of `STOP_CONVENTION_ADR = 0.345` (#127). That is an independent reproduction by a
+different code path, not a new result, and is the main external check this prototype has passed.
+
+What is new is the pairing: base tightness and stop width are **different quantities by ~3.8×**, and
+both are called "tight" in the codebase and in the method notes. Worth separating in the domain
+model before either is tuned.
+
+> *Method note, recorded because the first pass got it wrong.* Both rows above are **ratios** — his
+> stop as a fraction of entry, ADR as a fraction of close — so a split cancels and all 649 rows
+> count. Measuring the stop as a *price difference* against a bar-derived ADR does **not** work: the
+> reference set's prices are raw while the stored bars are split-adjusted, so any ticker that split
+> after the trade puts the two on different scales, yielding a median of 0.36 and a max of 30.94
+> ADR. Anyone extending the study should use the ratio form. The range-in-ADR figures are computed
+> from bars alone and were never exposed to this.
+
+#### What this does and does not license
+
+**It does not license loosening `TIGHT_MULT`, and §3a's verdict stands unchanged.** The calibration
+rule (§7) permits a loosening only when A3 shows the dimension has **no signal and real spread**.
+§3b makes the precondition fail *harder*: tightness now has demonstrated selection signal (§5b)
+*and* demonstrated outcome signal (above). Nothing here is a licence to widen a gate.
+
+**What it adds is a price tag on the current shape.** §3a left the 113 marginal misses as the open
+question and noted that answering it needs a false-positive rate the study does not have. §3b does
+not supply that rate — it cannot, being conditioned entirely on trades he took. It supplies the
+other half of the ledger: the hard cut at 1.5 declines **231 of his own entries (35.6%)** carrying
+**17.4% of his summed R**, to express a signal that varies smoothly. That cost was previously
+unquantified.
+
+**The re-openable question this reframes.** The live proposal is no longer "is 1.5 the right cutoff"
+but "should tightness be a cutoff at all, or a graded rubric input with a much looser outlier
+guard". That is a larger change than §3a considered, it is still unpriceable without a control group
+of setups he passed over (§7, §9), and it is filed rather than acted on. No constant is touched by
+this section.
 
 ---
 


### PR DESCRIPTION
> Rebased onto `main` after #143 merged. That study turned out to bear on this one substantively, so §3b gained a subsection rather than a cross-reference — see "Read against #143" below.

## What this adds

**§3b in `references/qullamaggie-replay-findings.md`.** §3a characterised the `cluster` *misses* and left the 113 marginal ones as its open question. Nobody had asked the complementary question: across the trades he **took**, what geometry did the tightness dimension actually have? §3b measures it over the same 649 replayable entries, gating nothing at measurement time.

| Finding | Figure |
| --- | --- |
| Where `TIGHT_MULT = 1.5` sits in his own distribution | ~64th percentile — admits 418, declines 231, no gap or inflection at 1.5 |
| `cluster_min_range_adr` | Always the 3-bar range (range is monotone in k) — so **`K_MAX` cannot affect pass/fail**, only `K_MIN` gates |
| Tightness vs outcome, among taken trades | mean R 2.02 → 1.35 → 0.84 → 0.35 → −0.36, smooth through 1.5 |
| Base width vs his stop width | 1.310 ADR vs 0.345 ADR — **3.8×** |

**`references/qullamaggie-replay-findings-plain.md`** retells the whole study without assuming the project's vocabulary. ADR, R, MFE, recall and precision are defined up front, and the one-sided-ruler constraint (no measurable precision) gets its own section, since it governs nearly every decision in the study. Same numbers, same conclusions, same caveats. The technical doc stays the authority; the two cross-link.

## Read against #143 — one mechanism confirmed, one method borrowed

**1. #143 supplies the mechanism for §3b's 3.8× gap.** It finds stop width and entry-to-SMA10 distance **uncorrelated (Spearman −0.002)** and concludes he stops at the low of the **entry day** — so the stop is set by that day's range, not by base geometry. That is exactly what §3b measures from the other side: 0.345 ADR against a 1.310 ADR base is not a base-derived stop, and now it's clear what it *is* derived from. **Three independent measurements of the stop now agree** — §6's 0.345, #143's 0.346 (different subset, different ADR basis), and §3b's reproduction.

**2. #143's method for siting a line is the right one, and applying it here gives the opposite answer.** #143 refuses to set "extended" at a percentile of his habits — *"a percentile describes his habits; it does not describe where trades stop working"* — and sites 1.5 ×ADR on a real feature: expectancy hits zero, the ≥3R share halves while the win rate holds. A cliff exists, so a threshold is the honest encoding.

§3b's outcome table has **no such feature**. So the two dimensions differ in kind:

| | Outcome shape | Honest encoding |
| --- | --- | --- |
| Entry-to-MA distance (#143) | A cliff — expectancy → 0 past 1.5 ×ADR | A threshold (+ hard no-trade past 2.5 ×) |
| Tightness (§3b) | A smooth monotone decline, no feature | A graded score |

Worth stating plainly: **`TIGHT_MULT = 1.5` satisfies neither test.** It isn't a percentile anyone chose (a borrowed q-scanner-v2 default that happens to land at his 64th), and it isn't sited on a feature in the outcome data, because there is none to site it on.

## What it does *not* do

**No constant is touched, and §3a's verdict stands unchanged.** The calibration rule (§7) permits loosening a gate only on a dimension with *no signal*. §3b makes that precondition fail *harder* — tightness now has demonstrated selection signal (§5b, +20.8pp) **and** demonstrated outcome signal. Nothing here is a licence to widen anything.

What it adds is a **price tag**: the hard cut at 1.5 declines 231 of his own entries (35.6%) carrying 17.4% of his summed R, to express a signal that varies smoothly. Previously unquantified. The re-openable question is reframed from *"is 1.5 the right cutoff"* to *"should tightness be a cutoff at all"* — still unpriceable without a control group (§7, §9), so it is filed (#145) rather than acted on.

## Verification

- The stop-width row **reproduces §6 Finding 1 exactly** — median 0.345, p25 0.238, p75 0.490, max 2.753, 98.15% at-or-under-1.0-ADR, same n=649 — by a different code path.
- Every Test 5 figure carried into the plain doc was checked against `qullamaggie-entry-ma-distance.md`.
- Backend test suite: **488 passed**.
- Docs-only diff. No production code in this PR.

## Provenance and a method note

§3b is sourced from a **throwaway prototype** on branch `worktree-prototype-tightness` (`backend/replay/prototype-tightness/`), deliberately kept out of this PR and out of `main`. Flagged as preliminary and outside §10's reproducible path wherever cited.

One method note is recorded because the first pass got it wrong: the stop must be measured as a **ratio** (stop as a fraction of entry ÷ ADR as a fraction of close), not as a price difference against a bar-derived ADR. The reference set's prices are raw while the stored bars are split-adjusted, so the naive form gives a median of 0.36 and a max of 30.94 ADR. The ratio form makes splits cancel and needs no exclusions.

## Follow-ups filed

- #145 — should Tightness be a gate at all, or a graded rubric input? (depends on #141's inflation ratio)
- #146 — rename `cluster_min_range_adr`; document that `K_MAX` cannot gate
- #147 — separate base tightness from stop width in the domain model
- Commented on #141 with the benefit-side evidence for its sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LbNsBStkZorPhUWmaepGj
