### PR TITLE
Land the #133 decile-gate ADRs, and accept ADR 0003 on the full run

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -57,8 +57,15 @@ A name's percentile within its market and lookback on a session. The shared subs
 there is exactly one definition of "strong".
 
 **Decile**:
-Top 10% of a lookback's own population. The gate is the union of the five deciles
-(~29% of the universe, not 10%).
+Top 10% of a lookback's own population. The union of all five lookbacks' deciles is the
+breadth substrate — 27.2% of the universe, not 10%. It is not the gate the detector runs;
+see **Detection gate**.
+
+**Detection gate**:
+The union of the top deciles of the *three* detection lookbacks (`1m`, `3m`, `6m`) — 19.4%
+of the universe. The cut a name must clear before the detector is consulted. Distinct from
+the five-lookback union, and materially tighter; conflating the two misattributes the
+gate's cost.
 
 **Board / leaderboard**:
 Top 30 names by raw return for one market and lookback. Five boards per market.
@@ -113,7 +120,7 @@ silent tiebreak.
 never exceed it.
 
 **Detection**:
-A name with a valid base, cluster and MA catch-up, inside the decile gate, on a session.
+A name with a valid base, cluster and MA catch-up, inside the detection gate, on a session.
 A dated row.
 
 **Break**:
@@ -134,6 +141,12 @@ gaps, never their magnitude. The three-weight ordinal swap inside that recalibra
 What the rubric is fitted to encode — the method's revealed selection, evidenced by the
 executed trades. Neither our own grading (a superseded proxy) nor outcome (measured, null).
 _Avoid_: ground truth, benchmark.
+
+**Calibration rule**:
+What evidence licenses loosening a gate. Two limbs — one for score dimensions, one for
+cross-sectional cuts — because precision is not measurable and recall alone would widen
+every gate. Stated in `docs/adr/0002-what-evidence-licenses-loosening-a-gate.md`; not
+restated anywhere else.
 
 **Constant dimension**:
 A score dimension true for every detection by construction, so it shifts every score equally
@@ -173,6 +186,14 @@ A ticker in the reference set with no bars in the store, because the provider re
 nothing for delisted, acquired or renamed names. 81 of 312 tickers, 141 trades, 11.7% of
 total R. The measured size of the store's survivorship hole.
 _Avoid_: missing ticker, delisted.
+
+**Coverage gap**:
+A ticker that has bars in the store but was not a universe member at the evaluation
+session, so the replayed field could not rank it. A defect in the replay, not a verdict
+about the name — kept apart from a ticker present but ranked outside the gate, which is a
+real ranking verdict. Distinct from a **blind-spot ticker**, which has no bars at all: two
+different holes, and conflating them corrupts the decile stage's accounting.
+_Avoid_: missing from field, not in universe.
 
 **Funnel stage**:
 One gate an executed trade must pass for the app to have surfaced it, evaluated at the

--- a/docs/adr/0002-what-evidence-licenses-loosening-a-gate.md
+++ b/docs/adr/0002-what-evidence-licenses-loosening-a-gate.md
@@ -1,0 +1,86 @@
+---
+status: accepted
+---
+
+# What evidence licenses loosening a gate
+
+PRD #114 wrote down a calibration rule to stop one number driving an unguarded change:
+
+> A gate may be loosened on the strength of an A1 recall miss only when A3 shows that
+> dimension has no signal *and* that dimension shows real spread.
+
+The rule exists because **precision is not measurable**. The reference set records no setup
+Kullamägi declined, so there is no control group and no false-positive rate; recall is
+one-sided by construction, and widening a gate always improves it. The A3 two-condition test
+was the instrument: a dimension may only be loosened away on a null that is not merely range
+restriction.
+
+The instrument does not fit every gate. The rule was written contemplating **score
+dimensions**, and it silently assumed every gate has an A3 dimension standing behind it. The
+decile gate does not. Its dimension, `Prior move`, is 100% in the executed trades *and* 100%
+in the not-taken detections, with spread 0.000 in both — every detection cleared the decile
+gate by construction, so the contrast that exists precisely to buy back missing variance
+cannot restore it. No study this project can run will ever supply the evidence the rule asks
+for.
+
+That left the single largest measured loss in the funnel — the decile gate discards ~40% of
+his real entries, against liquidity's 9% — governed by a test it can never pass. §7 of
+`references/qullamaggie-replay-findings.md` resolved this by carve-out, ruling that the rule
+governs score dimensions and that the decile gate, being "a cross-sectional cut whose loss is
+measured directly by A1", falls outside it. That is technically correct and practically
+inverted: it exempts the most expensive gate in the system from the only guard the project
+has.
+
+**Decided (#133): the calibration rule has two limbs, one per kind of gate.**
+
+**A score dimension** may be loosened only when A3 shows that dimension has no signal *and*
+that dimension shows real spread. Unchanged from #114.
+
+**A cross-sectional cut** — a gate that ranks a name against the field rather than measuring
+the name itself — may be loosened only when all four hold:
+
+1. **The loss is measured directly.** A1 reports the stage's recall miss unconditionally, not
+   inferred from an A3 null.
+2. **The loss is shown not to be a coverage artefact.** The miss is decomposed into names
+   absent from the replayed field and names present but ranked outside, and the ranking half
+   is what is being acted on. A coverage gap is a defect in the replay, not evidence about
+   the gate.
+3. **The change is structural, not a threshold move.** A discrete widening of what the gate
+   unions has no magnitude to get wrong. Moving a threshold does, and a threshold move still
+   requires the score-dimension limb above.
+4. **The population cost is stated.** The change must name how many more names the gate admits
+   per trade recovered, as a share of the universe.
+
+Condition 4 is the load-bearing one. It is the substitute for the precision measurement that
+does not exist: false positives cannot be counted, but the *population* a looser gate admits
+can be, and that ratio is the honest denominator. A recall improvement quoted without it is
+the one-sided number the original rule was written to prevent.
+
+## Considered options
+
+- **Hold the original rule unchanged.** The decile gate can never be loosened, because A3 can
+  never speak to `Prior move`. Rejected: a rule that cannot be satisfied by any obtainable
+  evidence is not a guard, it is a freeze — and it freezes the stage costing the most.
+- **Keep §7's carve-out.** Cross-sectional cuts sit outside the calibration rule and are
+  argued from A1 alone. Rejected: A1 recall is exactly the one-sided metric the rule exists to
+  guard, so an exemption from the rule for the gate with the largest recall miss inverts the
+  rule's purpose.
+- **Require a precision measurement.** Rejected as impossible, not merely expensive. It would
+  need a record of setups he declined, which no part of the reference set contains.
+
+## Consequences
+
+- The rule now composes with ADR 0001's companion constraint (#128, Q2): the replay licenses a
+  change's *direction*, never its *magnitude*. Condition 3 is why this bites less on
+  cross-sectional cuts — a structural widening has no magnitude to license.
+- §7 of `references/qullamaggie-replay-findings.md` cites this ADR rather than restating the
+  rule. The rule's authoritative wording no longer lives in a GitHub issue body.
+- The first change this licenses is not made here. ADR 0003 applies the four conditions to the
+  decile gate and reaches `proposed`, not `accepted`, because condition 2 is only 46%
+  measured pending #131.
+- The rule is stated in terms of *kinds* of gate, so the liquidity floor — also
+  cross-sectional through its hysteresis band — falls under the same four conditions if it is
+  ever argued about. It currently costs 9% and nobody is arguing.
+- This is hard to reverse in the direction that matters: any gate loosened under these
+  conditions changes which detections exist, and every digest written afterwards freezes
+  scores computed over a different field. Tightening back does not recover the record.

--- a/docs/adr/0003-the-decile-gate.md
+++ b/docs/adr/0003-the-decile-gate.md
@@ -1,0 +1,129 @@
+---
+status: accepted
+---
+
+# The decile gate is not loosened on this evidence
+
+A1 measured the decile gate discarding **40% of Kullamägi's real entries** (recall 395/658,
+60.0%) at the session before entry, against liquidity's 90.9%. It is the largest single loss
+in the funnel and the finding most likely to be acted on wrongly, which is why #133 was raised
+as a spike rather than a change.
+
+This ADR records the option space and the reasoning.
+
+**Accepted on the full run.** It was raised `proposed` because the decomposition ADR 0002
+condition 2 requires was only 46% measured — 312 of 658 replayable trades, skewed to 2021–22.
+#131 has since supplied the full forward chain, and `decompose_decile_misses` now covers all
+658 (findings §3). The figures below are the full-run ones; the partial-run table this ADR
+was drafted against is kept in **Appendix: what the partial run said**, because the two
+disagree on one number in a way that matters.
+
+## The gate is tighter than the parent spec says
+
+PRD #114 (user story 8) and §3 of `references/qullamaggie-replay-findings.md` both describe
+the gate as cutting "to roughly 29% of the universe". That figure belongs to a **different
+gate**. There are two decile unions in the codebase:
+
+- `ranks.py:107` unions **five** lookbacks (`1w`, `1m`, `3m`, `6m`, `12m`) at
+  `percentile >= TOP_DECILE`. This is the breadth substrate, and it admits **27.2%** of the
+  universe — the source of the ~29% figure.
+- `detection.py:396`, `detection_gate`, unions only **three**: `DETECTION_LOOKBACKS =
+  ("1m", "3m", "6m")`. This is the gate A1 measured, and it admits **19.4%**.
+
+Measured over the 505 sessions the replay store still holds ranks for (2020-12-30 to
+2022-12-30, mean universe 1876 names). The gate costing 40% of his entries is a third tighter
+than every document describing it has said. `CONTEXT.md` carried the same conflation and is
+corrected; #114 is left as the historical record of what was specified, with the discrepancy
+noted here.
+
+## What the loss is made of
+
+Decile verdicts across all **658** replayable trades, from the single forward chain #131
+supplies (`decompose_decile_misses`, findings §3):
+
+| | count | share of 658 |
+| --- | --- | --- |
+| Passes the 3-lookback detection gate | 395 | **60.0%** |
+| Coverage gap — in the store, not a universe member | 64 | **9.7%** |
+| Present, recovered only by widening 3→5 lookbacks | 75 | **11.4%** |
+| Present, outside even the 5-lookback union | 124 | **18.8%** |
+
+**The loss is still not mostly a coverage artefact — but it is more of one than this ADR
+first claimed.** The partial run put absent-from-field at 5.4% of trades (13.3% of the
+misses). The full run puts it at **9.7% of trades — 24.3% of the misses**, close to double.
+Three quarters of the loss remains a genuine ranking verdict, so ADR 0002 condition 2 is
+satisfied and the conclusion holds; but "only 5.4% is absent-from-field" was an artefact of
+the 2021–22-skewed subset and is corrected here rather than left standing.
+
+**18.8% sit outside any decile construction** (was 22.8% on the partial run). That population
+is not reachable by widening what the gate unions, and it is the honest ceiling on what
+loosening can recover.
+
+## Considered options
+
+- **Widen the gate from three lookbacks to five.** Recovers **75 trades — 11.4pp, about a
+  third of the loss** — taking decile recall from **60.0% to 71.4%**, at a gate population of
+  27.2% instead of 19.4%. **The leading candidate, and it remains so on the full run.** It is
+  the only option that widens the gate without changing what "top decile" means, and it is
+  structural rather than a threshold move, so ADR 0002 condition 3 is satisfied and there is
+  no magnitude to get wrong. Its population cost is **7.8 points of universe for 75 trades**.
+
+  *Restated against the full run.* The recovered share slipped from 12.8pp to 11.4pp and the
+  coverage gap it competes with nearly doubled, so the case is modestly weaker than drafted —
+  the same 7.8 points of universe now buys a slightly smaller fraction of the loss. It is
+  nonetheless still the leading candidate, because nothing about *why* it leads depends on the
+  magnitude: it is the only structural option, the only one confined to a constant nothing
+  else reads, and the only one with no threshold to justify. The alternatives were rejected on
+  blast radius and on constant-count, and the full run moves neither of those arguments.
+- **Move `TOP_DECILE` below 0.90.** The only option reaching into the 18.8% outside every
+  union. Rejected on blast radius: `TOP_DECILE` is read by `ranks.py`, `sectors.py` and
+  `boards.py` as well as `detection.py`, so moving it silently rewrites sector strength, the
+  breadth badge `k/5` and every board — surfaces this study measured nothing about. It is also
+  a threshold move, so ADR 0002 routes it to the score-dimension limb, which `Prior move` can
+  never satisfy.
+- **Per-lookback thresholds** — keep 0.90 on `1m`, relax `3m`/`6m`. Rejected: it introduces
+  three constants needing independent justification to buy an effect the structural widening
+  buys with none, and each new constant is a threshold move under ADR 0002.
+- **Leave the gate.** The status quo, and the outcome if #131 contradicts the decomposition
+  above. Not a null option: it costs 40% of his entries knowingly, which is defensible only
+  because the gate is what makes the sample tractable at all.
+
+## Consequences
+
+- **No constant changes.** This ADR settles the *reasoning*, not the edit. Adopting 3→5 is
+  separate work and needs its own ticket; nothing here authorises touching
+  `DETECTION_LOOKBACKS`.
+- **The evidence this ADR was waiting for has arrived.** The full 658-trade decomposition into
+  coverage gap / recovered-by-5 / outside-any-union now rides the single forward chain (#131)
+  and is committed in findings §3. The earlier obstacle — `append_ranks` pruning beyond
+  `RANK_RETENTION_YEARS` as the chain advanced, leaving `ranks` for only the last 505 of 928
+  sessions while 450 of 828 trades entered before that cutoff — no longer bounds the result.
+- **One figure in this ADR moved materially on the full run** (the coverage gap, 5.4% → 9.7%
+  of trades). Anyone citing the partial-run numbers from before this revision should re-read
+  the appendix below.
+- Should 3→5 be adopted, the change is confined to `DETECTION_LOOKBACKS`. Nothing outside
+  `detection.py` reads it, so the breadth badge, sector strength and the boards are untouched.
+- The **18.8%** is a standing statement about what this funnel cannot do. If those entries
+  matter, the answer is a different selection stage, not a looser decile.
+- Scoped to US 2019–2022. No figure here is an IDX expectation; the shape — that the decile
+  stage is the expensive one and that its loss is mostly a ranking verdict rather than a
+  coverage hole — is what transfers.
+
+## Appendix: what the partial run said
+
+Kept so a reader can see which figures moved, and by how much, rather than finding a silently
+different table. These are the 312 replayable trades entering after 2020-12-30, with universe
+membership read off the persisted chain rather than recomputed:
+
+| | partial (312 trades) | full (658 trades) |
+| --- | --- | --- |
+| Passes the 3-lookback detection gate | 59.0% | **60.0%** |
+| Coverage gap | 5.4% | **9.7%** |
+| Recovered by widening 3→5 | 12.8% (40) | **11.4% (75)** |
+| Outside even the 5-lookback union | 22.8% | **18.8%** |
+
+The pass rate landing within a point of the study's headline was cited at the time as evidence
+the approximation was sound. That held — but soundness on the headline did not imply soundness
+on the decomposition: the coverage gap, the one figure the subset's 2021–22 skew would most
+distort, is the one that nearly doubled. Worth remembering the next time a partial run is
+offered as a stand-in for a full one.

--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -128,6 +128,22 @@ So the study adopts a strict rule, and enforces it throughout:
 > doesn't matter *and* that there was enough variety in the data to have detected
 > it if it did.**
 
+The rule has **two limbs**, because the app has two different kinds of filter, and
+what counts as evidence differs between them:
+
+- **Scoring qualities** (is the base tidy? is the stock swinging enough?) — the
+  test above applies as written.
+- **Cross-sectional cuts** (is this among the strongest performers?) — these can't
+  be tested the same way, because everything that reaches the scoring stage has
+  already passed them, so there's no variety left to measure. Instead the loss must
+  be measured directly, shown *not* to be an artefact of missing data, fixed
+  **structurally** rather than by nudging a threshold, and quoted with its cost in
+  how much wider the net gets.
+
+An earlier version of this study exempted cross-sectional cuts from the rule
+entirely. **That exemption was wrong** and was replaced — the second limb exists so
+those cuts are governed rather than unguarded.
+
 That second half matters more than it sounds. Every trade in the sample already
 passed his judgement, so the qualities he applies *most* consistently barely vary
 — and anything that barely varies will correlate with nothing. **A flat result on
@@ -154,6 +170,14 @@ blended number can hide a disaster at one stage:
 **The "strongest performers" filter is the expensive one.** It discards **40% of
 his real trades on its own**, before the setup detector even looks — nearly five
 times what the liquidity check costs.
+
+> **This filter is a third tighter than every document said.** There are two
+> versions of "strongest performers" in the code, and they were being conflated.
+> One combines five time horizons and lets through 27.2% of all stocks; the other —
+> **the one the detector actually uses** — combines only three (1-month, 3-month,
+> 6-month) and lets through just **19.4%**. Every write-up quoted the looser figure
+> while measuring the tighter gate. Corrected throughout; the glossary now names
+> them separately.
 
 **One oddity worth noting:** the setup detector is the only stage that scores
 *better* once repeat entries are removed (59.0% vs 57.8%). His add-on buys are

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -150,12 +150,17 @@ tagged `continuation`.
 | Stage | Recall (headline) | Recall (ex-continuation) | Notes |
 | --- | --- | --- | --- |
 | Liquidity | **598/658 (90.9%)** | **523/578 (90.5%)** | The one stage where a rejected name never reaches any tab — a miss here is otherwise invisible (user story 7). Cheapest of the three. |
-| Decile | **395/658 (60.0%)** | **340/578 (58.8%)** | The most aggressive filter — cuts to ~29% of the universe before the detector looks (user story 8). Depends on the replayed field → coverage attached. |
+| Decile | **395/658 (60.0%)** | **340/578 (58.8%)** | The most aggressive filter — cuts to **19.4%** of the universe before the detector looks. Depends on the replayed field → coverage attached. |
 | Detection | **380/658 (57.8%)** | **341/578 (59.0%)** | Failures broken down by geometric condition below (user stories 9, 10). |
 
 > **The decile gate is the expensive one.** It discards **40% of his real entries on its
 > own**, before the detector is ever consulted — the largest single loss in the funnel, and
-> nearly five times the liquidity stage's. Each stage is evaluated *unconditionally* on
+> nearly five times the liquidity stage's. **Correction (#133):** this table originally
+> quoted the gate as cutting to "~29% of the universe", following PRD #114 user story 8.
+> That figure is the *five*-lookback union (`ranks.py`, 27.2% measured); the gate this row
+> measures is `detection_gate`, which unions only `1m`/`3m`/`6m` and admits **19.4%**. The
+> gate is a third tighter than the parent spec describes. See
+> `docs/adr/0003-the-decile-gate.md`. Each stage is evaluated *unconditionally* on
 > every row, so these are not sequential survivors: decile (60.0%) and detection (57.8%)
 > are close because they are two independent measurements, not a funnel product.
 >
@@ -1059,23 +1064,28 @@ kept in both places because it bounds §5b — the evidence the ADR reweight res
 
 ### The calibration rule
 
-A gate may be loosened on the strength of an A1 recall miss **only when A3 shows that
-dimension has no signal _and_ that dimension shows real spread.** This is the guard against
-the one-sided recall metric: because precision is not measurable, recall is never optimised
-on its own, and a dimension is never widened away on a null that is really range restriction.
+The rule is stated in `docs/adr/0002-what-evidence-licenses-loosening-a-gate.md` and is not
+restated here. It has two limbs — one for score dimensions, one for cross-sectional cuts —
+and both exist to guard the same thing: precision is not measurable, so recall is never
+optimised on its own.
 
 **How the measured results sit against the rule.** Every testable dimension shows a null in
-§5a *and* spread ≈0.4–0.5, so all six clear both conditions. `Prior move` clears neither and
-never can: it is 100% in the executed trades, 100% in the not-taken detections, and its
-spread is 0.000 in both. It must not be touched on the strength of this study.
+§5a *and* spread ≈0.4–0.5, so all six clear the score-dimension limb. `Prior move` clears
+neither condition and never can: it is 100% in the executed trades, 100% in the not-taken
+detections, and its spread is 0.000 in both. It must not be touched on the strength of this
+study.
 
-The rule governs the *score dimensions*. It does not license the two changes the study most
-directly supports, which are not dimension-loosenings at all:
+Two of the changes this study most directly supports are not dimension-loosenings and are
+governed differently:
 
 - the **stop convention** (§6, finding 1) is a detector output and a card claim, measured
-  against his own risk rather than inferred from a null; and
-- the **decile gate** (§3), which costs 40% of his entries, is a cross-sectional cut whose
-  loss is measured directly by A1 rather than argued from an A3 null.
+  against his own risk rather than inferred from a null — outside the rule entirely; and
+- the **decile gate** (§3), which costs 40% of his entries, is a **cross-sectional cut** and
+  falls under the rule's second limb: the loss must be measured directly by A1, shown not to
+  be a coverage artefact, addressed structurally rather than by a threshold move, and quoted
+  with its population cost. This document originally exempted the gate from the rule
+  altogether; that carve-out was wrong, and #133 replaced it — see ADR 0002. The gate's own
+  option space is in `docs/adr/0003-the-decile-gate.md`.
 
 ---
 


### PR DESCRIPTION
Brings `spike/133-decile-gate`'s two unmerged ADRs onto current `main`, and refreshes ADR 0003 against the full-run decomposition that has since landed.

Applied as a fresh branch off `main` rather than a rebase of the shared branch, so nothing had to be force-pushed. **ADR 0001 was already on main** and is untouched — only 0002 and 0003 are new.

## This fixes a wrong number that is live on main

Findings §3 and `CONTEXT.md` both describe the decile gate as cutting to **"~29% of the universe"**. That figure belongs to a *different gate*:

| | unions | admits |
| --- | --- | --- |
| `ranks.py` five-lookback union | `1w` `1m` `3m` `6m` `12m` | 27.2% — the breadth substrate |
| **`detection_gate`** (`detection.py`) | **`1m` `3m` `6m`** | **19.4%** — the gate A1 measured |

Verified against `DETECTION_LOOKBACKS` in `detection.py:459`. **The gate costing 40% of his entries is a third tighter than every document describing it has said.** Corrected in both files, and `CONTEXT.md` now carries `Decile` and `Detection gate` as separate glossary entries so the two unions can't be conflated again.

## ADR 0002 is the load-bearing one

It splits the calibration rule into **two limbs** — one for score dimensions, one for cross-sectional cuts — replacing the findings §7 carve-out that had exempted cross-sectional cuts from the rule *altogether*. That carve-out was wrong. §7 now defers to the ADR instead of restating it.

This matters for work already queued: §3a, §3b and #145 all reason against "the calibration rule (§7)", and until now main carried the unsharpened version while the sharpened one sat on an unmerged branch. **#141 and #145 should run after this lands**, since both turn on which limb applies.

## ADR 0003: `proposed` → `accepted`

It was blocked on #131 supplying the full 658-trade decomposition. That run has landed and is committed in findings §3, so the condition is met. Tables refreshed from the 312-trade subset to all 658:

| | partial (312) | full (658) |
| --- | --- | --- |
| Passes the gate | 59.0% | **60.0%** |
| Coverage gap | 5.4% | **9.7%** |
| Recovered by 3→5 | 12.8% (40) | **11.4% (75)** |
| Outside any union | 22.8% | **18.8%** |

**One figure moved materially, and it cuts against the ADR's own argument.** The coverage gap nearly doubled — 13.3% → 24.3% as a share of the misses. The claim *"the loss is not a coverage artefact"* survives, since three quarters are still genuine ranking verdicts, but *"only 5.4% is absent-from-field"* was an artefact of the subset's 2021–22 skew and is corrected rather than left standing.

The partial-run table is kept as an appendix so the movement is visible rather than silent. The lesson recorded there: the partial run's pass rate landed within a point of the headline and was cited as evidence the approximation was sound — it was, on the headline, but **soundness on the headline did not imply soundness on the decomposition**, and the coverage gap was exactly the figure the subset's skew would most distort.

## 3→5 stays the leading candidate

Per maintainer decision. Stated honestly: the recovered share slipped 12.8pp → 11.4pp against a coverage gap twice as large, so the case is **modestly weaker than drafted**. It leads anyway because nothing about *why* it leads depends on the magnitude — it is the only structural option, the only one confined to a constant nothing else reads (`DETECTION_LOOKBACKS`), and the only one with no threshold to justify. The alternatives were rejected on blast radius and constant-count, and the full run moves neither argument.

## Scope

- **No constant changes.** Adopting 3→5 is separate work and needs its own ticket.
- Docs-only: `CONTEXT.md`, two ADRs, and both findings docs. No production code.
- Arithmetic re-derived from the committed §3 figures: 395 + 64 + 75 + 124 = 658 ✓; widen 3→5 gives (395+75)/658 = 71.4%.
- The plain-language doc gains the two-limb rule and the gate-width correction, so it doesn't teach the superseded version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LbNsBStkZorPhUWmaepGj
