### PR TITLE
Match a trade's bars to the listing that existed at its entry (#139)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -179,13 +179,27 @@ counterfactual. Never blur it with the executed trade's entry.
 _Avoid_: exit, result.
 
 **Replayable trade**:
-An executed trade whose ticker still has bars in the store. 686 of 827.
+An executed trade whose ticker has bars in the store **covering the session the trade is
+evaluated at** — not merely bars somewhere under that symbol, which a **recycled symbol**
+also has. 656 of 828. The test is "can this trade be evaluated?", so the same ticker can be
+replayable at one entry and a blind spot at another.
 
 **Blind-spot ticker**:
-A ticker in the reference set with no bars in the store, because the provider returns
-nothing for delisted, acquired or renamed names. 81 of 312 tickers, 141 trades, 11.7% of
-total R. The measured size of the store's survivorship hole.
+A ticker in the reference set whose bars cannot cover a trade it is paired with, because
+the provider returns nothing for delisted, acquired or renamed names, or because the symbol
+was recycled onto a later listing. 92 of 312 tickers, 172 trades, 18.0% of total R,
+measured in the replay window (`2019-04..2022-12`). The measured size of the store's
+survivorship hole. Superseded measurements: 81 / 141 / 11.7% over all history, and
+91 / 170 / 18.15% under the has-any-bars test #139 replaced.
 _Avoid_: missing ticker, delisted.
+
+**Recycled symbol**:
+A ticker reassigned to an unrelated listing, so the bars the store holds under it belong to
+a different company than the one traded. Its bar history begins *after* the entry it is
+paired with (`FUSE`: entry 2021-01-04, bars from 2022-03-07). It is a **blind spot**, and
+the dangerous kind — absent from no list, it arrives looking replayable and, uncaught, is
+charged to the detector as a `history` stage failure.
+_Avoid_: reused ticker, symbol collision.
 
 **Coverage gap**:
 A ticker that has bars in the store but was not a universe member at the evaluation

--- a/backend/replay/contrast.py
+++ b/backend/replay/contrast.py
@@ -241,8 +241,8 @@ def run_contrast(
     outcome regression stands on, but reduced through an entirely separate code
     path into a separate result — the two are never merged), then contrasts the
     dimension distributions of the taken and not-taken detections. Only replayable
-    trades mark the field; blind-spot trades never appear as
-    a taken detection and ride only in the coverage count.
+    trades mark the field; blind-spot trades never appear as a taken detection and
+    ride only in the coverage count.
     """
     classified = classify(trades, store, market=market)
     replayable = [c.trade for c in classified if c.replayable]

--- a/backend/replay/contrast.py
+++ b/backend/replay/contrast.py
@@ -241,7 +241,7 @@ def run_contrast(
     outcome regression stands on, but reduced through an entirely separate code
     path into a separate result — the two are never merged), then contrasts the
     dimension distributions of the taken and not-taken detections. Only replayable
-    trades mark the field; blind-spot trades (ticker with no bars) never appear as
+    trades mark the field; blind-spot trades never appear as
     a taken detection and ride only in the coverage count.
     """
     classified = classify(trades, store, market=market)

--- a/backend/replay/funnel.py
+++ b/backend/replay/funnel.py
@@ -43,13 +43,17 @@ headline recall over all replayable trades **and** the ex-continuation recall
 together, and no code path emits the ex-continuation figure on its own (user
 story 6).
 
-Blind-spot trades (ticker with no bars) get no funnel row — they are recorded as
-a blind spot by :mod:`replay.reference`, not as a stage failure (PRD "A1 funnel").
+Blind-spot trades get no funnel row — they are recorded as a blind spot by
+:mod:`replay.reference`, not as a stage failure (PRD "A1 funnel"). That holds for
+a ticker the store has no bars for *and* for one whose bars do not cover the
+evaluation session: a symbol recycled onto a later listing would otherwise arrive
+here and fail the detector's :data:`COND_HISTORY` gate, charging a coverage hole
+to the detector (#139).
 """
 
 from __future__ import annotations
 
-from bisect import bisect_left, bisect_right
+from bisect import bisect_right
 from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Callable, Iterable, Sequence
@@ -76,7 +80,7 @@ from screener.store import Store
 from screener.universe import LIQUIDITY_FLOOR, median_dollar_volume
 
 from .chain import BURN_IN_SESSIONS, REPLAY_MARKET, SessionField, replay_chain
-from .reference import ClassifiedTrade, ExecutedTrade, classify
+from .reference import ClassifiedTrade, ExecutedTrade, classify, evaluation_session
 
 if TYPE_CHECKING:
     from .regression import Distribution
@@ -356,16 +360,9 @@ class FunnelReport:
 # -- evaluation session -------------------------------------------------------
 
 
-def evaluation_session(calendar: list[date], entry_date: date) -> date | None:
-    """The last session in ``calendar`` strictly before ``entry_date``.
-
-    ``calendar`` is the market's observed session dates, oldest first (the union of
-    bar dates — :meth:`screener.store.Store.sessions`), so the "session before"
-    lands correctly across weekends and market holidays with no holiday table: a
-    gap simply has no session in it. ``None`` when nothing precedes the entry.
-    """
-    idx = bisect_left(calendar, entry_date) - 1
-    return calendar[idx] if idx >= 0 else None
+# ``evaluation_session`` lives in :mod:`replay.reference`, which needs it to decide
+# replayability (#139) and cannot import this module. Re-exported here, where it
+# was first defined and where every reader of the funnel looks for it.
 
 
 def _session_index(calendar: list[date], when: date) -> int:
@@ -687,8 +684,8 @@ def run_funnel(
     the report as the coverage figure every decile-dependent output must carry
     (PRD user story 22).
 
-    Blind-spot trades (ticker with no bars) get no row — they are a blind spot, not
-    a stage failure. Continuation entries are tagged and kept in every denominator.
+    Blind-spot trades get no row — a ticker whose bars do not cover the trade's
+    evaluation session is a blind spot, not a stage failure. Continuation entries are tagged and kept in every denominator.
     """
     classified = classify(trades, store, market=market)
     calendar = store.sessions(market)

--- a/backend/replay/funnel.py
+++ b/backend/replay/funnel.py
@@ -360,9 +360,10 @@ class FunnelReport:
 # -- evaluation session -------------------------------------------------------
 
 
-# ``evaluation_session`` lives in :mod:`replay.reference`, which needs it to decide
-# replayability (#139) and cannot import this module. Re-exported here, where it
-# was first defined and where every reader of the funnel looks for it.
+# ``evaluation_session`` lives in :mod:`replay.reference`: replayability is now
+# defined in terms of it (#139), and that module cannot import this one. It is
+# imported above rather than re-exported — every caller reads it from
+# :mod:`replay.reference`.
 
 
 def _session_index(calendar: list[date], when: date) -> int:
@@ -685,7 +686,8 @@ def run_funnel(
     (PRD user story 22).
 
     Blind-spot trades get no row — a ticker whose bars do not cover the trade's
-    evaluation session is a blind spot, not a stage failure. Continuation entries are tagged and kept in every denominator.
+    evaluation session is a blind spot, not a stage failure. Continuation entries
+    are tagged and kept in every denominator.
     """
     classified = classify(trades, store, market=market)
     calendar = store.sessions(market)

--- a/backend/replay/placement.py
+++ b/backend/replay/placement.py
@@ -29,8 +29,9 @@ that is the single most valuable thing this study can return (issue #120).
 **Coverage and scope.** Every output carries its coverage number against the
 committed blind-spot tickers (user story 22), and the whole study is scoped to
 :data:`SCOPE` — US 2019–2022 — and is not presented as an IDX expectation (user
-story 35). A blind-spot trade (ticker with no bars) is *not* placed: it is a
-blind spot counted in coverage, never an absent-from-field verdict.
+story 35). A blind-spot trade — one whose bars do not cover its evaluation
+session — is *not* placed: it is a blind spot counted in coverage, never an
+absent-from-field verdict.
 """
 
 from __future__ import annotations
@@ -330,7 +331,7 @@ def run_placement(
 
     Runs the replayed field (:func:`replay.field.replay_field`) over the window,
     then for each replayable trade looks up the field for the session strictly
-    before its entry and places it. Blind-spot trades (ticker with no bars) get no
+    before its entry and places it. Blind-spot trades get no
     placement row — they are a blind spot counted in coverage, not an
     absent-from-field verdict. The picks distribution is the star scores of his
     in-field trades; the field distribution is the whole field on the same

--- a/backend/replay/placement.py
+++ b/backend/replay/placement.py
@@ -46,8 +46,7 @@ from screener.store import Store
 
 from .chain import BURN_IN_SESSIONS, REPLAY_MARKET
 from .field import FieldSession, ScoredDetection, replay_field, star_order_key
-from .funnel import evaluation_session
-from .reference import ExecutedTrade, classify
+from .reference import ExecutedTrade, classify, evaluation_session
 
 # The study is scoped to US 2019–2022 and no figure from it is to be presented as
 # an IDX expectation (PRD user story 35 / Out of Scope). Stamped on every output.
@@ -331,9 +330,8 @@ def run_placement(
 
     Runs the replayed field (:func:`replay.field.replay_field`) over the window,
     then for each replayable trade looks up the field for the session strictly
-    before its entry and places it. Blind-spot trades get no
-    placement row — they are a blind spot counted in coverage, not an
-    absent-from-field verdict. The picks distribution is the star scores of his
+    before its entry and places it. Blind-spot trades get no placement row — they
+    are a blind spot counted in coverage, not an absent-from-field verdict. The picks distribution is the star scores of his
     in-field trades; the field distribution is the whole field on the same
     sessions his trades were evaluated against.
     """

--- a/backend/replay/reference.py
+++ b/backend/replay/reference.py
@@ -24,11 +24,11 @@ trade's evaluation session, and the store holds only ``2019-04..2022-12``
 (:mod:`replay.store`). That is the operationally true test — it is exactly the
 condition under which the funnel and the field can say anything about a trade —
 and it is stricter than asking whether the provider returns the symbol at all
-today. The two differ by 10 tickers / 29
+today. The two differ by 11 tickers / 31
 trades, every one of them a **symbol-reuse** case: the ticker resolves today, but
 its bar history begins years after the entry it is paired with, because the
-symbol was recycled onto an unrelated listing (APXT, BNKU, EYES, FNGU, LAC, LAZR,
-NRGU, SI, SPWR, USLV). Counting those replayable would not merely understate the
+symbol was recycled onto an unrelated listing (APXT, BNKU, EYES, FNGU, FUSE, LAC,
+LAZR, NRGU, SI, SPWR, USLV). Counting those replayable would not merely understate the
 hole; at any window overlap it would replay one company's trade against another
 company's bars — which is exactly what a has-any-bars test did to ``FUSE`` until
 #139 (its entry is 2021-01-04; its bars run 2022-03-07..2022-12-22, so the ten
@@ -232,6 +232,30 @@ class ClassifiedTrade:
     replayable: bool
 
 
+@dataclass(frozen=True)
+class BarSpan:
+    """The sessions a ticker's bars run between, oldest to newest, inclusive.
+
+    The store answers "what bars are under this symbol?"; replayability asks the
+    narrower "was this symbol quoted on that night?" — so the span, not the bar
+    list, is what :func:`classify` keeps, one per ticker rather than one per trade.
+    A gap inside the span (a halt, a missing session) still counts as covered: the
+    listing existed, which is the question being asked.
+    """
+
+    first: date
+    last: date
+
+    @classmethod
+    def of(cls, bars: list) -> "BarSpan | None":
+        """The span of ``bars``, or ``None`` when the store holds none."""
+        return cls(first=bars[0].session, last=bars[-1].session) if bars else None
+
+    def covers(self, session: date) -> bool:
+        """True when ``session`` falls inside the span."""
+        return self.first <= session <= self.last
+
+
 def evaluation_session(calendar: list[date], entry_date: date) -> date | None:
     """The last session in ``calendar`` strictly before ``entry_date``.
 
@@ -269,20 +293,15 @@ def classify(
     read once and cached, so a name traded several times still costs one store
     read.
     """
-    spans: dict[str, tuple[date, date] | None] = {}
+    spans: dict[str, BarSpan | None] = {}
     calendar = store.sessions(market)
     classified: list[ClassifiedTrade] = []
     for trade in trades:
         if trade.ticker not in spans:
-            bars = store.bars(market, trade.ticker)
-            spans[trade.ticker] = (bars[0].session, bars[-1].session) if bars else None
+            spans[trade.ticker] = BarSpan.of(store.bars(market, trade.ticker))
         span = spans[trade.ticker]
         session = evaluation_session(calendar, trade.entry_date)
-        replayable = (
-            span is not None
-            and session is not None
-            and span[0] <= session <= span[1]
-        )
+        replayable = span is not None and session is not None and span.covers(session)
         classified.append(ClassifiedTrade(trade=trade, replayable=replayable))
     return classified
 

--- a/backend/replay/reference.py
+++ b/backend/replay/reference.py
@@ -7,30 +7,36 @@ entries, all US, each an *observed* entry paired with two *simulated* exits
 and the study must not blur them (PRD "Further Notes").
 
 This module reads the JSON into typed :class:`ExecutedTrade` rows, classifies
-each as **replayable** (its ticker has bars in the replay store) or a
-**blind-spot ticker** (it does not — a delisted, acquired or renamed name the
-provider returns nothing for), and reports the counts. The blind-spot ticker
-list is written to ``references/`` so the size of the store's survivorship hole
-is a fixed, citable fact rather than a vague worry (user story 23).
+each as **replayable** (the store's bars for its ticker cover the session the
+trade is evaluated at) or a **blind spot** (they do not — a delisted, acquired or
+renamed name the provider returns nothing for, or a symbol recycled onto a
+listing that did not exist at the entry), and reports the counts. The blind-spot
+ticker list is written to ``references/`` so the size of the store's survivorship
+hole is a fixed, citable fact rather than a vague worry (user story 23).
 
 The counts are computed, never hard-coded. :data:`REFERENCE_FIGURES` records the
 figures measured in #114 so a later change to the reference set or the store is
 caught as drift (:func:`assert_matches_reference`), not silently absorbed.
 
 **Blind spot is measured in the replay window, not over all history.** The
-classification asks whether the ticker has bars *in the replay store*, which
-:mod:`replay.store` populates only for ``2019-04..2022-12``. That is the
-operationally true test — it is exactly the condition under which the funnel and
-the field can say anything about a trade — and it is stricter than asking whether
-the provider returns the symbol at all today. The two differ by 10 tickers / 29
+classification asks whether the ticker has bars *in the replay store* covering the
+trade's evaluation session, and the store holds only ``2019-04..2022-12``
+(:mod:`replay.store`). That is the operationally true test — it is exactly the
+condition under which the funnel and the field can say anything about a trade —
+and it is stricter than asking whether the provider returns the symbol at all
+today. The two differ by 10 tickers / 29
 trades, every one of them a **symbol-reuse** case: the ticker resolves today, but
 its bar history begins years after the entry it is paired with, because the
 symbol was recycled onto an unrelated listing (APXT, BNKU, EYES, FNGU, LAC, LAZR,
 NRGU, SI, SPWR, USLV). Counting those replayable would not merely understate the
 hole; at any window overlap it would replay one company's trade against another
-company's bars. The #114 figures were first measured over all history
-(81 / 141 / 11.7%); the pins below are the window-measured figures the study
-actually runs on.
+company's bars — which is exactly what a has-any-bars test did to ``FUSE`` until
+#139 (its entry is 2021-01-04; its bars run 2022-03-07..2022-12-22, so the ten
+above escaped only because their replacement listings happen to begin after the
+window ends). The #114 figures were first measured over all history
+(81 / 141 / 11.7%), then in the window under a has-any-bars test
+(91 / 170 / 18.15%, 658 replayable); the pins below are the window-measured
+figures under the covers-the-entry test the study actually runs on.
 
 **Schema note.** The reference tool emits one exit block per simulated exit,
 named in the row keys — ``gain10smaPct`` / ``mfe10smaPct`` / ``r10sma`` for the
@@ -46,6 +52,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+from bisect import bisect_left
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
@@ -62,18 +69,20 @@ PRIMARY_EXIT = "10sma"
 # and ``r<exit>`` carry that exit's max-favourable-excursion and realised R.
 _GAIN_KEY = re.compile(r"^gain(?P<exit>.+)Pct$")
 
-# The figures measured over the committed reference set in #114. Recomputed by
-# the report every run; these exist only to detect drift and are never the source
-# of a reported number. The blind-spot figures are measured in the replay window
-# (see the module docstring); the all-history figures they replace were
-# 81 / 141 / 11.7%.
+# The figures measured over the committed reference set in #114, re-pinned in
+# #139. Recomputed by the report every run; these exist only to detect drift and
+# are never the source of a reported number. The blind-spot figures are measured
+# in the replay window, against bars covering each trade's evaluation session (see
+# the module docstring). The superseded measurements: 81 / 141 / 11.7% over all
+# history (#114), and 91 / 170 / 18.15% in the window under the has-any-bars test
+# #139 replaced.
 REFERENCE_FIGURES: dict[str, float] = {
     "total_rows": 828,
     "rows_with_outcomes": 827,
     "distinct_tickers": 312,
-    "blind_spot_tickers": 91,
-    "blind_spot_trades": 170,
-    "blind_spot_r_share": 0.181,
+    "blind_spot_tickers": 92,
+    "blind_spot_trades": 172,
+    "blind_spot_r_share": 0.180,
 }
 
 # The blind-spot R share is a float; a change below this tolerance is rounding,
@@ -223,20 +232,58 @@ class ClassifiedTrade:
     replayable: bool
 
 
+def evaluation_session(calendar: list[date], entry_date: date) -> date | None:
+    """The last session in ``calendar`` strictly before ``entry_date``.
+
+    ``calendar`` is the market's observed session dates, oldest first (the union of
+    bar dates — :meth:`screener.store.Store.sessions`), so the "session before"
+    lands correctly across weekends and market holidays with no holiday table: a
+    gap simply has no session in it. ``None`` when nothing precedes the entry.
+
+    This is the session every replay study evaluates a trade at — the night the
+    app would have had to name the stock while the entry was still ahead of the
+    trader — so it also defines what :func:`classify` asks the store to cover.
+    Re-exported by :mod:`replay.funnel`, which is where it was first defined.
+    """
+    idx = bisect_left(calendar, entry_date) - 1
+    return calendar[idx] if idx >= 0 else None
+
+
 def classify(
     trades: list[ExecutedTrade], store: Store, *, market: str = "US"
 ) -> list[ClassifiedTrade]:
-    """Tag each trade replayable iff its ticker has bars in the replay store.
+    """Tag each trade replayable iff the store's bars for its ticker **cover the
+    session the trade is evaluated at** (#139).
 
-    A ticker is looked up once and cached, so a name traded several times costs
-    one store read rather than one per entry.
+    Not "does this symbol exist in the store?" but "can this trade be evaluated?".
+    The two answers diverge on a **recycled symbol**: a ticker reassigned to an
+    unrelated listing carries bars that begin years after the entry it is paired
+    with. A has-any-bars test calls that replayable, and the trade then enters the
+    funnel denominator and fails the detector's ``history`` gate — charged to the
+    detector as a stage failure when it is a coverage hole (``FUSE``, entry
+    2021-01-04, bars from 2022-03). Bars that *end* before the evaluation session
+    fail the same test for the same reason.
+
+    The verdict is therefore per *trade*, not per ticker: the same name can be
+    replayable at one entry and a blind spot at another. Each ticker's bar span is
+    read once and cached, so a name traded several times still costs one store
+    read.
     """
-    has_bars: dict[str, bool] = {}
+    spans: dict[str, tuple[date, date] | None] = {}
+    calendar = store.sessions(market)
     classified: list[ClassifiedTrade] = []
     for trade in trades:
-        if trade.ticker not in has_bars:
-            has_bars[trade.ticker] = bool(store.bars(market, trade.ticker))
-        classified.append(ClassifiedTrade(trade=trade, replayable=has_bars[trade.ticker]))
+        if trade.ticker not in spans:
+            bars = store.bars(market, trade.ticker)
+            spans[trade.ticker] = (bars[0].session, bars[-1].session) if bars else None
+        span = spans[trade.ticker]
+        session = evaluation_session(calendar, trade.entry_date)
+        replayable = (
+            span is not None
+            and session is not None
+            and span[0] <= session <= span[1]
+        )
+        classified.append(ClassifiedTrade(trade=trade, replayable=replayable))
     return classified
 
 

--- a/backend/replay/regression.py
+++ b/backend/replay/regression.py
@@ -63,8 +63,13 @@ from .field import (
     replay_field,
     seven_dimension_score,
 )
-from .funnel import evaluation_session
-from .reference import PRIMARY_EXIT, ExecutedTrade, classify, load_trades
+from .reference import (
+    PRIMARY_EXIT,
+    ExecutedTrade,
+    classify,
+    evaluation_session,
+    load_trades,
+)
 
 # The dimensions regressed here: the app's eight less the dropped sector
 # dimension, in the score's published order. Named off the app's own table so a

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -37,7 +37,6 @@ from replay.funnel import (
     FunnelReport,
     characterise_cluster_misses,
     diagnose_detection,
-    evaluation_session,
     run_funnel,
 )
 from replay.reference import (
@@ -49,6 +48,7 @@ from replay.reference import (
     assert_matches_reference,
     build_report,
     classify,
+    evaluation_session,
     load_trades,
     parse_trades,
     write_blind_spot_list,

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -27,6 +27,7 @@ import pytest
 from replay.funnel import (
     COND_BASE_LENGTH,
     COND_CLUSTER,
+    COND_HISTORY,
     FUNNEL_STAGES,
     MARGINAL_TIGHT_MULT,
     STAGE_DECILE,
@@ -416,7 +417,7 @@ def test_load_trades_unwraps_the_envelope_on_synthetic_rows(tmp_path):
 
 
 def test_trade_with_bars_is_replayable_without_bars_is_blind_spot(store: Store):
-    store.append_bars("US", "AAA", [_bar(date(2020, 5, 1))])
+    store.append_bars("US", "AAA", [_bar(date(2020, 4, 30)), _bar(date(2020, 5, 1))])
     trades = parse_trades(
         [_trade_record("AAA", "2020-05-01"), _trade_record("ZZZ", "2020-05-01")]
     )
@@ -426,12 +427,52 @@ def test_trade_with_bars_is_replayable_without_bars_is_blind_spot(store: Store):
     assert classified == {"AAA": True, "ZZZ": False}
 
 
+def test_replayable_asks_whether_bars_cover_the_evaluation_session(store: Store):
+    """Replayability is "can this trade be evaluated?", not "does the store hold
+    this symbol?" — a recycled symbol whose listing begins after the entry, and a
+    name whose bars end before it, are both blind spots however many bars they
+    carry under the ticker (#139)."""
+    store.append_bars("US", "OLD", [_bar(d) for d in _daily(date(2020, 5, 4), 5)])
+    store.append_bars("US", "RECY", [_bar(d) for d in _daily(date(2020, 6, 1), 5)])
+    trades = parse_trades(
+        [
+            _trade_record("OLD", "2020-05-08"),   # bars span the eval session
+            _trade_record("RECY", "2020-05-08"),  # listing begins a month later
+            _trade_record("OLD", "2020-06-04"),   # bars ended before the entry
+            _trade_record("ZZZ", "2020-05-08"),   # no bars at all
+        ]
+    )
+
+    classified = [(c.trade.ticker, c.trade.entry_date, c.replayable)
+                  for c in classify(trades, store)]
+
+    assert classified == [
+        ("OLD", date(2020, 5, 8), True),
+        ("RECY", date(2020, 5, 8), False),
+        ("OLD", date(2020, 6, 4), False),
+        ("ZZZ", date(2020, 5, 8), False),
+    ]
+
+
+def test_trade_before_the_first_session_has_no_night_to_evaluate(store: Store):
+    """No session precedes the entry, so there is no night the app could have
+    named the stock on: a blind spot, not a stage failure (#139)."""
+    store.append_bars("US", "AAA", [_bar(d) for d in _daily(date(2020, 5, 1), 3)])
+
+    (classified,) = classify(parse_trades([_trade_record("AAA", "2020-05-01")]), store)
+
+    assert classified.replayable is False
+
+
 # -- the count report ------------------------------------------------------
 
 
 def test_report_counts_and_blind_spot_r_share(store: Store):
-    store.append_bars("US", "AAA", [_bar(date(2020, 5, 1))])
-    store.append_bars("US", "BBB", [_bar(date(2020, 5, 1))])
+    store.append_bars(
+        "US", "AAA",
+        [_bar(date(2020, 4, 30)), _bar(date(2020, 5, 1)), _bar(date(2020, 6, 1))],
+    )
+    store.append_bars("US", "BBB", [_bar(date(2020, 4, 30)), _bar(date(2020, 5, 4))])
     # AAA/BBB have bars (replayable); ZZZ does not (blind spot). One outcome-less row.
     trades = parse_trades(
         [
@@ -456,7 +497,7 @@ def test_report_counts_and_blind_spot_r_share(store: Store):
 
 
 def test_write_blind_spot_list_is_sorted_and_committed(tmp_path, store: Store):
-    store.append_bars("US", "AAA", [_bar(date(2020, 5, 1))])
+    store.append_bars("US", "AAA", [_bar(date(2020, 4, 30)), _bar(date(2020, 5, 1))])
     trades = parse_trades(
         [
             _trade_record("ZZZ", "2020-05-01"),
@@ -476,7 +517,7 @@ def test_write_blind_spot_list_is_sorted_and_committed(tmp_path, store: Store):
 
 
 def test_drift_detection_fails_loudly_on_mismatch(store: Store):
-    store.append_bars("US", "AAA", [_bar(date(2020, 5, 1))])
+    store.append_bars("US", "AAA", [_bar(date(2020, 4, 30)), _bar(date(2020, 5, 1))])
     report = build_report(parse_trades([_trade_record("AAA", "2020-05-01")]), store)
 
     # A three-row fixture cannot match the 828-row reference figures.
@@ -737,6 +778,27 @@ def test_blind_spot_trade_gets_no_funnel_row(store: Store):
     report = run_funnel(trades, store)
 
     assert [r.ticker for r in report.rows] == ["RAMP"]  # ZZZ is not a stage failure
+
+
+def test_recycled_symbol_is_a_blind_spot_not_a_history_stage_failure(store: Store):
+    """A ticker whose bars begin after the entry it is paired with is a *different
+    listing* under the same symbol. It must be recorded as a blind spot, never
+    charged to the detector as a ``history`` miss (#139 — the live ``FUSE`` case)."""
+    dates = _daily(date(2020, 1, 1), 90)
+    store.append_bars("US", "RAMP", _bars_from_hlc(dates, _ramp_hlc(90)))
+    later = _daily(dates[89] + timedelta(days=10), 90)
+    store.append_bars("US", "RECY", _bars_from_hlc(later, _ramp_hlc(90)))
+    trades = parse_trades(
+        [
+            _funnel_record("RAMP", dates[89] + timedelta(days=1)),
+            _funnel_record("RECY", dates[50]),  # entry predates RECY's listing
+        ]
+    )
+
+    report = run_funnel(trades, store)
+
+    assert [r.ticker for r in report.rows] == ["RAMP"]
+    assert COND_HISTORY not in report.condition_counts
 
 
 # -- continuation entries stay in every denominator ------------------------

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -223,7 +223,7 @@ detects must land *before* the denominator is built, or the run is stale on arri
 
 | Ticket | Relation | Land by |
 | --- | --- | --- |
-| **#139** — match a trade's bars to the listing that existed at its entry | The recycled-ticker rule this plan already requires, and it **re-pins figures cited below**: blind-spot 91 → **92** tickers, 170 → **172** trades, 18.15% → **18.02%** of R, replayable 658 → **656** | Phase 2 |
+| **#139** — match a trade's bars to the listing that existed at its entry | **Landed.** The recycled-ticker rule this plan requires; it re-pinned the figures cited below: blind-spot 91 → **92** tickers, 170 → **172** trades, 18.15% → **18.02%** of R, replayable 658 → **656** | Phase 2 |
 | **#145** — Tightness as a graded rubric input (**decided**, implementation outstanding) | Changes what passes the funnel, so it changes the denominator *and* the detected-count anchor. File the implementation ticket if none exists. | Phase 3 |
 | **#149** — `DETECTION_LOOKBACKS` 3 → 5 | Same class: adopt or reject on evidence, then freeze. A rejection recorded is as good as an adoption; an open question is not. | Phase 3 |
 | **#146**, **#147** — naming and the domain model | The run persists full `Detection` records and the write-up uses this vocabulary. Cheap now, a dead language later. | Phase 3 |
@@ -255,16 +255,18 @@ silently absent is survivorship bias entering through the back door.
 
 Treat this as a measurement with its own deliverable, ahead of any performance number.
 
-**The floor is already known.** Findings §2 measured it over a four-year window: **91 of 312
-tickers (29.2%)** and **170 of 828 trades (20.5%)** absent from the store, carrying **18.1% of
+**The floor is already known.** Findings §2 measured it over a four-year window: **92 of 312
+tickers (29.5%)** and **172 of 828 trades (20.8%)** the store cannot cover, carrying **18.0% of
 the trader's realised R** — names delisted, acquired or renamed inside four years. A 2012 start
 reaches further back, so expect worse. For IDX the research note measured the same hole from
 the other side: the Yahoo screener enumerates ~840 names against IDX's ~963 listed, and the
 missing ones are the suspended and delisted.
 
-**And the hole has a silent half.** §2's correction is the part to carry: ten of those tickers
-*resolve today* but their bar history begins years after the entry they are paired with,
-because the symbol was recycled onto an unrelated listing. Survivorship here is delisting
+**And the hole has a silent half.** §2's correction is the part to carry: eleven of those
+tickers *resolve today* but their bar history begins years after the entry they are paired
+with, because the symbol was recycled onto an unrelated listing. Ten of them fall outside the
+window and were excluded by the build; the eleventh, `FUSE`, has bars *inside* it and was
+caught only once #139 made replayability mean "bars cover the evaluated session". Survivorship here is delisting
 **plus ticker recycling**, and recycled names are absent from no list — they arrive as
 plausible bars for the wrong company.
 
@@ -363,8 +365,8 @@ before reading any new figure:
 | Median trailing 3-bar range at his entries | **1.31 ADR** | Findings §3b |
 | Median trailing 5-bar range at his entries | **1.86 ADR** | Findings §3b, §3c |
 | Median 20-day ADR at entry eve | **6.08%** | Findings §3c |
-| Blind-spot tickers / trades, 2019–2022 | **91 / 170** (of 312 / 828) | Findings §2 |
-| Trades detected by the funnel | **104 of 658 replayable** | Findings §4 |
+| Blind-spot tickers / trades, 2019–2022 | **92 / 172** (of 312 / 828) | Findings §2 |
+| Trades detected by the funnel | **104 of 658 replayable** (the 658 is the pre-#139 denominator §4 was measured under; it is 656 now) | Findings §4 |
 
 These are the same reference set through a differently-built pipeline. Matching them says the
 new pipeline computes what the old one computed; a mismatch is a bug in the new store or the

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -223,7 +223,7 @@ detects must land *before* the denominator is built, or the run is stale on arri
 
 | Ticket | Relation | Land by |
 | --- | --- | --- |
-| **#139** — match a trade's bars to the listing that existed at its entry | **Landed.** The recycled-ticker rule this plan requires; it re-pinned the figures cited below: blind-spot 91 → **92** tickers, 170 → **172** trades, 18.15% → **18.02%** of R, replayable 658 → **656** | Phase 2 |
+| **#139** — match a trade's bars to the listing that existed at its entry | **Landed.** The recycled-ticker rule this plan requires; it re-pinned the figures cited below: blind-spot 91 → **92** tickers, 170 → **172** trades, 18.15% → **18.0%** of R, replayable 658 → **656** | Phase 2 |
 | **#145** — Tightness as a graded rubric input (**decided**, implementation outstanding) | Changes what passes the funnel, so it changes the denominator *and* the detected-count anchor. File the implementation ticket if none exists. | Phase 3 |
 | **#149** — `DETECTION_LOOKBACKS` 3 → 5 | Same class: adopt or reject on evidence, then freeze. A rejection recorded is as good as an adoption; an open question is not. | Phase 3 |
 | **#146**, **#147** — naming and the domain model | The run persists full `Detection` records and the write-up uses this vocabulary. Cheap now, a dead language later. | Phase 3 |
@@ -366,7 +366,7 @@ before reading any new figure:
 | Median trailing 5-bar range at his entries | **1.86 ADR** | Findings §3b, §3c |
 | Median 20-day ADR at entry eve | **6.08%** | Findings §3c |
 | Blind-spot tickers / trades, 2019–2022 | **92 / 172** (of 312 / 828) | Findings §2 |
-| Trades detected by the funnel | **104 of 658 replayable** (the 658 is the pre-#139 denominator §4 was measured under; it is 656 now) | Findings §4 |
+| Trades detected by the funnel | **104 of 656 replayable** (§4 measured 104 of 658; #139 removed `FUSE`'s 2 trades, neither of which was detected) | Findings §4 |
 
 These are the same reference set through a differently-built pipeline. Matching them says the
 new pipeline computes what the old one computed; a mismatch is a bug in the new store or the

--- a/references/blind_spot_tickers.json
+++ b/references/blind_spot_tickers.json
@@ -26,6 +26,7 @@
   "FMCI",
   "FNGU",
   "FSR",
+  "FUSE",
   "FUV",
   "GAN",
   "GBT",

--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -88,9 +88,9 @@ is missing in the least convenient possible way.
 | | |
 |---|---|
 | Total trades in the record | 828 |
-| Stocks affected by the hole | **91** |
-| Trades lost to it | **170** |
-| Share of his total profit in those lost trades | **18.1%** |
+| Stocks affected by the hole | **92** |
+| Trades lost to it | **172** |
+| Share of his total profit in those lost trades | **18.0%** |
 
 **The hole is bigger than first thought, for an interesting reason.** The first
 count asked "does this ticker symbol exist today?" But the study needs a stricter
@@ -102,6 +102,18 @@ wouldn't just overstate coverage — it would test one company's trade against a
 different company's price history. So survivorship here means delisting *plus*
 symbol recycling, and the recycled ones are dangerous precisely because they look
 fine.
+
+**And an eleventh was hiding in plain sight.** Asking "does this symbol have any
+price history in the replay years?" still isn't strict enough — the right question
+is "does it have history covering *the night we'd have had to spot the trade*?"
+`FUSE` was traded in January 2021, but the price history the store holds under
+that symbol starts in March 2022: a different company. The first ten escaped only
+because their replacement listings begin after the replay window ends, so the
+looser test happened to give the right answer. `FUSE` is where that luck ran out —
+its two trades were being counted as replayable and then blamed on the app for
+"not enough history". Fixing the question moved the count from 91 / 170 / 18.15%
+to the 92 / 172 / 18.0% in the table above. The hole didn't grow; it was measured
+properly.
 
 **This hole is now permanent.** Buying the missing history was investigated and
 closed: every provider that carries it charges money, retail plans start around
@@ -156,7 +168,9 @@ the method that work best.
 ## Test 1 — Which filter throws away his trades?
 
 **658 of the 828 trades could be replayed** (the other 170 are the coverage
-hole). 80 of those are repeat entries.
+hole). 80 of those are repeat entries. Those counts are the ones this run measured;
+the stricter coverage question described above puts them at 656 and 172, which
+moves nothing in the percentages below.
 
 Each of the three filters was tested *independently* on every trade, so no single
 blended number can hide a disaster at one stage:

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -89,9 +89,9 @@ stage failure or an absent-from-field verdict.
 | Total rows (executed entries) | 828 |
 | Rows with outcomes | 827 |
 | Distinct tickers | 312 |
-| Blind-spot tickers | **91** |
-| Blind-spot trades | **170** |
-| Blind-spot share of total realised R | **18.1%** |
+| Blind-spot tickers | **92** |
+| Blind-spot trades | **172** |
+| Blind-spot share of total realised R | **18.0%** |
 
 > **The hole is larger than #114 first measured**, and the correction matters. The
 > original 81 / 141 / 11.7% asked whether the provider returns the symbol *at all today*.
@@ -105,6 +105,20 @@ stage failure or an absent-from-field verdict.
 > replay one company's trade against another company's bars. So survivorship here is not
 > only delisting; it is delisting **plus ticker recycling**, and the recycled names are
 > silent rather than absent.
+
+> **#139 re-pinned these figures: the window test now asks whether the bars cover the
+> session the trade is evaluated at**, not merely whether the symbol has bars somewhere in
+> the window. The ten recycled names above were caught only by luck — their replacement
+> listings all begin after `2022-12`, so the window build excluded them and a has-any-bars
+> test happened to give the right answer. `FUSE` is where the luck ran out: it is paired
+> with a `2021-01-04` entry, and its bars in the store run `2022-03-07..2022-12-22`. Under
+> the old test its 2 trades were counted replayable, entered the funnel denominator, and
+> failed the detector's `history` gate — charged to the detector as a stage failure when
+> they are a coverage hole. The re-pinned figures supersede **91 / 170 / 18.15%** (658
+> replayable), which every measured result in §§3–8 below was computed under; the R share
+> moves *down* because `FUSE`'s two trades carried below-average R. Both moves are
+> corrections, not improvements — the hole is the same size, measured properly — and both
+> are small enough to leave every finding below standing as measured.
 
 These counts are **computed, never hard-coded**; `REFERENCE_FIGURES` records the pinned
 figures only to detect drift, and `assert_matches_reference` stops the run with a
@@ -860,13 +874,14 @@ and the ≥3.5★ share it declined to predict has now been measured.
 
 ### Coverage, restated so this result carries its own bound
 
-Unchanged and now permanent: **91 blind-spot tickers / 170 trades / 18.1% of total realised R**
+Unchanged and now permanent: **92 blind-spot tickers / 172 trades / 18.0% of total realised R**
 (§2), and only **104 of 658** replayable trades appeared in the field at all — **41** inside the
 board under v1, **45** under v2. So this is a rubric comparison measured on a **sixth of his
 record** against a field missing a quarter of its names, and the population missing is the one a
-momentum screener surfaces. #139 is **open** and proposes correcting these figures to
-92 / 172 / 18.02% once the recycled-symbol check lands; that correction is small and would move
-nothing here, but it has not landed and the figures above are the ones this run measured.
+momentum screener surfaces. #139 has now **landed**: the coverage figures above are the
+re-pinned ones (they were 91 / 170 / 18.15% when this run was measured), and the 658-trade
+denominator is the pre-#139 one — `FUSE`'s 2 trades leave it at 656. That correction moves
+nothing here, and the per-trade figures below are the ones this run measured.
 
 **The no-percentile constraint stands, permanently.** #136 said to keep it "unless the coverage
 hole is fully closed". With #129 closed won't-do the hole cannot be closed, so the constraint is
@@ -1237,7 +1252,7 @@ kept in both places because it bounds §5b — the evidence the ADR reweight res
 
 - **Survivorship coverage.** Everything derived from the field is read against a store
   missing 29% of its tickers, skewed toward names that later died. Every field-derived
-  result carries `blind_spot_count`; the 91-ticker / 170-trade / 18.1%-of-R hole is quantified
+  result carries `blind_spot_count`; the 92-ticker / 172-trade / 18.0%-of-R hole is quantified
   in [§2](#2-coverage--the-survivorship-hole-attach-to-every-field-derived-result) and the
   ticker list is committed.
 - **Range restriction (A3).** Every trade in the sample already passed the trader's eye, so

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -97,10 +97,12 @@ stage failure or an absent-from-field verdict.
 > original 81 / 141 / 11.7% asked whether the provider returns the symbol *at all today*.
 > The study actually needs a stricter question — does the ticker have bars **in the replay
 > window** (`2019-04..2022-12`), which is the only condition under which the funnel or the
-> field can say anything about the trade. The two differ by 10 tickers / 29 trades, and
-> every one of those is a **symbol-reuse** case: APXT, BNKU, EYES, FNGU, LAC, LAZR, NRGU,
-> SI, SPWR, USLV all resolve today, but their bar history begins years *after* the entry
-> they are paired with, because the ticker was recycled onto an unrelated listing. Counting
+> field can say anything about the trade. The two differ by 11 tickers / 31 trades, and
+> every one of those is a **symbol-reuse** case: APXT, BNKU, EYES, FNGU, FUSE, LAC, LAZR,
+> NRGU, SI, SPWR, USLV all resolve today, but their bar history begins years *after* the
+> entry they are paired with, because the ticker was recycled onto an unrelated listing.
+> (Ten of the eleven were caught by the window test alone; `FUSE` needed the stricter
+> covers-the-evaluated-session test #139 landed — see the note below.) Counting
 > them replayable would not merely understate the hole — at any window overlap it would
 > replay one company's trade against another company's bars. So survivorship here is not
 > only delisting; it is delisting **plus ticker recycling**, and the recycled names are


### PR DESCRIPTION
Closes #139.

`replay.reference.classify` decided replayability with a has-any-bars test, which answers "does this symbol exist in the store?" when the study needs "can this trade be evaluated?". A **recycled symbol** — a ticker reassigned to an unrelated listing — passed it, entered the funnel denominator, and failed the detector's `history` gate: a coverage hole charged to the detector. `FUSE` (entries 2021-01-04 / 2021-01-07, bars 2022-03-07..2022-12-22) is the live case; the ten known recycled names escaped only because their replacement listings begin after the window ends.

Replayability is now **per trade**: the store's bars for the ticker must cover the session the trade is evaluated at. `evaluation_session` moved to `reference` (which needs it and cannot import `funnel`) and is read from there by all callers.

## Re-pinned figures

| Figure | Was | Now |
| --- | --- | --- |
| Blind-spot tickers | 91 | **92** |
| Blind-spot trades | 170 | **172** |
| Blind-spot share of realised R | 18.15% | **18.0%** |
| Replayable trades | 658 | **656** |

Measured against `data/replay.duckdb` — exactly the issue's table. The superseded measurements are recorded, not overwritten. Carried into `REFERENCE_FIGURES`, the regenerated `references/blind_spot_tickers.json` (one line: `FUSE`), findings §2 and §8, the plain-language companion, the backtest plan's anchors, and `CONTEXT.md`, which gains a **Recycled symbol** entry.

## Tests

TDD, red first: `test_replayable_asks_whether_bars_cover_the_evaluation_session` and `test_recycled_symbol_is_a_blind_spot_not_a_history_stage_failure` (asserts both no funnel row and `COND_HISTORY not in condition_counts` — the old `classify` fails it). Full backend suite: 491 passed.

## Note

Two cases beyond the issue's letter fall out of the same rule and are pinned by tests, both dormant on today's data: bars that *end* before the evaluation session, and a trade with no session preceding it at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZXK8zqwXvvfDf87M4jH47