### PR TITLE
Grade base tightness, and gate only far outliers (#154)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,29 +102,46 @@ Prior-move peak through today, capped at 45 bars. Always ends today — there is
 thing as a base that ended last week.
 
 **Cluster**:
-The largest trailing 3–7 bar window spanning at most 1.5 × ADR. The quiet end of the base,
-and where **base tightness** is measured — never a stop level. Whether a name *has* a cluster
-is settled entirely by its **3-bar range**: range is monotone in the window length, so the
-3-bar window is the tightest one there is. The 7 is a scoring bound, not a gate.
+The largest trailing 3–7 bar window spanning at most 1.5 × ADR, falling back to the 3-bar
+window when none does. The quiet end of the base, and where **base tightness** is measured —
+never a stop level. Since #154 the 1.5 shapes the window and does not gate: whether a name is
+a detection at all is settled by the **far-outlier guard**, and the 7 is only a reporting
+bound.
 
 **Cluster length `k`**:
-Bars in the cluster. The double-weighted **base tightness** dimension of the star score, and
-the only thing the upper bound of 7 can move.
+Bars in the cluster, and the only thing the upper bound of 7 can move. It is what the star
+score's `Tightness` dimension read *until rubric v3*, which grades the **3-bar range**
+instead; `k` is still persisted, still what the chart draws, and still what a v2 re-score
+reads.
 
 **3-bar range**:
-A name's trailing 3-bar high-to-low span, in ADR. The tightest window the cluster scan can
-find, and so the number the cluster gate actually tests. Reported as `range_3bar_adr` on a
-cluster miss, to say by how much it missed.
+A name's trailing 3-bar high-to-low span, in ADR (`range_3bar_adr`). The tightest window the
+cluster scan can find — range is monotone in the window length — and so the **ungated**
+measure of **base tightness**. Two jobs since #154: the number the far-outlier guard tests,
+and the number the rubric's ×2 `Tightness` dimension is graded on. Persisted on every
+detection, and reported on a cluster miss to say by how much it missed.
+_Avoid_: cluster_min_range_adr (the pre-#146 name).
+
+**Far-outlier guard**:
+The cluster gate as it now stands: a detection requires a **3-bar range** inside
+`OUTLIER_MULT = 3.0 × ADR`. It replaced the hard 1.5 cut in #154, and does a different job —
+it rejects a name genuinely in motion, rather than ranking how quiet a base is, which the
+rubric now grades. **Provisional**, and sited on the one feature findings §3b's outcome table
+offers: mean R is positive in every 3-bar-range bucket up to 2.0–3.0 and turns negative only
+in the 3.0+ bucket, on **n = 10**. Not a percentile of his habits (ADR 0002 / #143).
+_Avoid_: cluster gate, tightness gate, TIGHT_MULT (which no longer gates).
 
 **Base tightness**:
 How quiet the stock was *before* the break — the span of a trailing 3–7 bar window in ADR.
-Setup geometry: it is what `TIGHT_MULT` gates on and what the rubric's ×2 `Tightness`
-dimension scores. Measured two ways, and the difference matters: the **3-bar range**
-(`range_3bar_adr`) is the **ungated** measure, which is what findings §3b puts at a median of
-**1.310 ADR** over his 649 replayable entries; `cluster_range_adr` is the **gated** span of
-the window that cleared the cut, and so sits at or under `TIGHT_MULT` by construction. Never
-a stop level — **stop width** is 3.8× narrower on the same trades (see below), and reading a
-stop off this quantity is the mistake issue #127 removed.
+Setup geometry: it is what the **far-outlier guard** tests and what the rubric's ×2
+`Tightness` dimension grades. Measured two ways, and the difference matters: the **3-bar
+range** (`range_3bar_adr`) is the **ungated** measure, which is what findings §3b puts at a
+median of **1.310 ADR** over his 649 replayable entries, and it is the one both the guard and
+the rubric read; `cluster_range_adr` is the **gated** span of the window that cleared
+`TIGHT_MULT`, so a *quieter* name can report a *wider* span by earning a longer window, which
+makes it non-monotone in the thing being measured and unfit to grade on. Never a stop level —
+**stop width** is 3.8× narrower on the same trades (see below), and reading a stop off this
+quantity is the mistake issue #127 removed.
 _Avoid_: tightness or tight, unqualified, in prose (the `TIGHT_*` constants and the published
 `Tightness` rubric label keep their names); tight zone; tight stop.
 
@@ -154,8 +171,8 @@ are independently tunable and independently evidenced.
 _Avoid_: risk_adr, tight stop, cluster-low stop, risk.
 
 **Detection**:
-A name with a valid base, cluster and MA catch-up, inside the detection gate, on a session.
-A dated row.
+A name with a valid base, a cluster inside the **far-outlier guard**, and MA catch-up, inside
+the detection gate, on a session. A dated row.
 
 **Break**:
 An event, not a state: today's close above yesterday's trigger. Equivalently, today's
@@ -164,8 +181,20 @@ close is above the last `k` sessions' high.
 **Star score**:
 The rubric — 8 dimensions, 9 weighted points, halved to stars. The sort key of the only list
 in the app. Its range is 0.5–4.5, never 0–5: one dimension always fires (`Prior move`) and one
-is weighted zero (`Base length`). Derived on read everywhere except a digest, which freezes the
-value it was written with. Recalibrated to the method's revealed selection by PRD #138:
+is weighted zero (`Base length`). Seven dimensions are booleans; `Tightness` is a **graded
+dimension**. Derived on read everywhere except a digest, which freezes the
+value it was written with.
+
+**Graded dimension**:
+A score dimension that maps a real-valued quantity to points in bands, rather than awarding
+its whole weight on a boolean. `Tightness` is the only one (rubric v3, #145/#154): 2 points
+at or under 1.0 ADR of **3-bar range**, 1 through 2.0, none beyond. Its shape is what findings
+§3b licenses — a smooth monotone decline in outcome with no feature to hang a threshold on,
+the opposite of the cliff #143 found in entry-to-MA distance. Two rules keep it replayable:
+the points stay **integral**, so the nine-point ceiling and the `÷ 2` arithmetic do not move;
+and the stored breakdown row carries the **value**, never one version's verdict about it, so
+any **rubric version** can re-score a stored row exactly.
+_Avoid_: continuous dimension, fractional score. Recalibrated to the method's revealed selection by PRD #138:
 `Tightness` and `ADR` weigh ×2 (the two sharpest §5b selectors), `Base length` ×0 (its largest
 wrong-way gap), everything else ×1. Weights come from the *ordering* of the measured selection
 gaps, never their magnitude. The three-weight ordinal swap inside that recalibration — `ADR`
@@ -188,9 +217,12 @@ and can never move the sort. `Prior move` is one, and is kept for what it docume
 what it discriminates.
 
 **Rubric version**:
-The stamp identifying which weights and thresholds produced a star score (`score.RUBRIC_VERSION`,
-currently 2 — the PRD #138 nine-point rubric; v1 was the ten-point one). Rides the API candidates
-payload and the digest header. A star figure quoted without one cannot be compared to another.
+The stamp identifying which weights and mappings produced a star score (`score.RUBRIC_VERSION`,
+currently 3 — v2's nine weights with `Tightness` graded, #154; v2 was the PRD #138 nine-point
+boolean rubric, v1 the ten-point one). Rides the API candidates payload and the digest header.
+A star figure quoted without one cannot be compared to another. Every superseded version stays
+live in `score.RUBRICS` so the paired A2 re-run can hold a field fixed and swap only the
+rubric; adding a version never edits an older one.
 
 **Regime**:
 `FRIENDLY`, `CHOPPY` or `HOSTILE` per market, from one index each. Advisory only — never

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -123,13 +123,16 @@ detection, and reported on a cluster miss to say by how much it missed.
 _Avoid_: cluster_min_range_adr (the pre-#146 name).
 
 **Far-outlier guard**:
-The cluster gate as it now stands: a detection requires a **3-bar range** inside
-`OUTLIER_MULT = 3.0 × ADR`. It replaced the hard 1.5 cut in #154, and does a different job —
-it rejects a name genuinely in motion, rather than ranking how quiet a base is, which the
-rubric now grades. **Provisional**, and sited on the one feature findings §3b's outcome table
-offers: mean R is positive in every 3-bar-range bucket up to 2.0–3.0 and turns negative only
-in the 3.0+ bucket, on **n = 10**. Not a percentile of his habits (ADR 0002 / #143).
-_Avoid_: cluster gate, tightness gate, TIGHT_MULT (which no longer gates).
+What the detector's `cluster` condition tests since #154: a detection requires a **3-bar
+range** inside `OUTLIER_MULT = 3.0 × ADR`. It replaced the hard 1.5 cut, and does a different
+job — it rejects a name genuinely in motion, rather than ranking how quiet a base is, which
+the rubric now grades. **Provisional**, and sited on the one feature findings §3b's outcome
+table offers: mean R is positive in every 3-bar-range bucket up to 2.0–3.0 and turns negative
+only in the 3.0+ bucket, on **n = 10**. Not a percentile of his habits (#143). The evidence
+that licenses it, and the sense in which ADR 0002 does not, is
+`docs/adr/0004-replacing-a-threshold-with-a-graded-input.md`.
+_Avoid_: tightness gate; `TIGHT_MULT`, which no longer gates. (`cluster` stays the name of the
+detector's condition and of the funnel's `failed_condition` value — it is persisted.)
 
 **Base tightness**:
 How quiet the stock was *before* the break — the span of a trailing 3–7 bar window in ADR.
@@ -183,7 +186,11 @@ The rubric — 8 dimensions, 9 weighted points, halved to stars. The sort key of
 in the app. Its range is 0.5–4.5, never 0–5: one dimension always fires (`Prior move`) and one
 is weighted zero (`Base length`). Seven dimensions are booleans; `Tightness` is a **graded
 dimension**. Derived on read everywhere except a digest, which freezes the
-value it was written with.
+value it was written with. Recalibrated to the method's revealed selection by PRD #138:
+`Tightness` and `ADR` weigh ×2 (the two sharpest §5b selectors), `Base length` ×0 (its largest
+wrong-way gap), everything else ×1. Weights come from the *ordering* of the measured selection
+gaps, never their magnitude. The three-weight ordinal swap inside that recalibration — `ADR`
+×1→×2, `Orderliness` ×2→×1, `Base length` ×1→×0 — is ticketed as #135.
 
 **Graded dimension**:
 A score dimension that maps a real-valued quantity to points in bands, rather than awarding
@@ -194,11 +201,7 @@ the opposite of the cliff #143 found in entry-to-MA distance. Two rules keep it 
 the points stay **integral**, so the nine-point ceiling and the `÷ 2` arithmetic do not move;
 and the stored breakdown row carries the **value**, never one version's verdict about it, so
 any **rubric version** can re-score a stored row exactly.
-_Avoid_: continuous dimension, fractional score. Recalibrated to the method's revealed selection by PRD #138:
-`Tightness` and `ADR` weigh ×2 (the two sharpest §5b selectors), `Base length` ×0 (its largest
-wrong-way gap), everything else ×1. Weights come from the *ordering* of the measured selection
-gaps, never their magnitude. The three-weight ordinal swap inside that recalibration — `ADR`
-×1→×2, `Orderliness` ×2→×1, `Base length` ×1→×0 — is ticketed as #135.
+_Avoid_: continuous dimension, fractional score.
 
 **Calibration target**:
 What the rubric is fitted to encode — the method's revealed selection, evidenced by the

--- a/backend/replay/funnel.py
+++ b/backend/replay/funnel.py
@@ -106,13 +106,16 @@ COND_ADR = "adr"                  # non-positive ADR
 COND_PRIOR_MOVE = "prior_move"    # no qualifying low->high prior move
 COND_BASE_LENGTH = "base_length"  # base shorter than MIN_BASE_LEN
 COND_CATCH_UP = "catch_up"        # price not back at the 10/20 MA
-COND_CLUSTER = "cluster"          # no tight 3-7 bar cluster (size or tightness)
+COND_CLUSTER = "cluster"          # 3-bar range past the far-outlier guard
 
-# A `cluster` miss whose trailing 3-bar range sits within this multiple of ADR
-# is *marginal* — a modest widening of the detector's TIGHT_MULT (1.5) would recover
-# it; beyond it the name is genuinely in motion and no plausible widening reaches a
-# base. This is the boundary the #132 characterisation reads the misses against; it
-# is *reported*, never applied, and no detection constant is changed by it.
+# A `cluster` miss whose trailing 3-bar range sits within this multiple of ADR is
+# *marginal*. It was written when the detector gated at TIGHT_MULT = 1.5, to ask how
+# many misses a modest widening would recover; #145/#154 answered that question by
+# making the widening, so the partition it drives is now **history rather than a
+# live lead** — under the far-outlier guard every surviving `cluster` miss sits past
+# OUTLIER_MULT = 3.0 and the marginal count is zero by construction. It is kept, at
+# its original value, so the #132 characterisation in findings §3a still reproduces
+# against the numbers that section quotes. Reported, never applied.
 MARGINAL_TIGHT_MULT = 2.0
 
 
@@ -264,9 +267,10 @@ class ClusterDecomposition:
       distance to the nearest prior entry across the continuation misses.
     - **how they distribute against the condition's window** — ``marginal`` counts
       the misses whose trailing 3-bar range sits within
-      :data:`MARGINAL_TIGHT_MULT` × ADR (a modest widening of the detector's
-      ``TIGHT_MULT`` would recover them), ``far`` the ones beyond it (a name
-      genuinely in motion no plausible widening reaches).
+      :data:`MARGINAL_TIGHT_MULT` × ADR, ``far`` the ones beyond it. Since
+      #145/#154 made the widening this partition was measuring, ``marginal`` is
+      zero on a current run: every surviving miss is past ``OUTLIER_MULT``. The
+      split is kept so §3a's committed figures still reproduce.
       ``range_distribution`` summarises the 3-bar range in ADR across all the
       misses.
 
@@ -557,7 +561,7 @@ def _funnel_row(
     detection_pass = detection is not None
     failed_condition = None if detection_pass else diagnose_detection(bars, eval_session)
     # The margin of a `cluster` miss (#132): how far the trailing 3-bar range —
-    # the tightest window there is — sat over the condition's TIGHT_MULT window.
+    # the tightest window there is — sat over the far-outlier guard.
     # Set only on a cluster miss — the other conditions have their own margins and
     # a pass has no miss to characterise.
     range_3bar = (

--- a/backend/replay/placement.py
+++ b/backend/replay/placement.py
@@ -41,7 +41,7 @@ from datetime import date
 from typing import Iterable, Mapping
 
 from screener.boards import BOARD_SIZE
-from screener.score import RUBRIC_VERSION, RUBRIC_WEIGHTS, Dimension, stars_under
+from screener.score import RUBRIC_VERSION, RUBRICS, Dimension, stars_under
 from screener.store import Store
 
 from .chain import BURN_IN_SESSIONS, REPLAY_MARKET
@@ -225,13 +225,13 @@ def _top_thirty_under(
     and the live version reproduces ``PlacementReport.top_thirty_count`` by
     construction.
     """
-    weights = RUBRIC_WEIGHTS[version]
+    rubric = RUBRICS[version]
     boards: dict[date, set[str]] = {}
     for session in {pick.session for pick in picks_in_field}:
         ranked = sorted(
             by_session[session].detections,
             key=lambda d: star_order_key(
-                stars_under(d.score.breakdown, weights), d.detection
+                stars_under(d.score.breakdown, rubric), d.detection
             ),
         )
         boards[session] = {d.symbol for d in ranked[:BOARD_SIZE]}
@@ -289,16 +289,16 @@ def build_placement_report(
     # The live version reproduces the detections' own stars exactly (they were
     # scored under it), so the live pair *is* the headline picks/field below.
     versions = [RUBRIC_VERSION] + sorted(
-        (v for v in RUBRIC_WEIGHTS if v != RUBRIC_VERSION), reverse=True
+        (v for v in RUBRICS if v != RUBRIC_VERSION), reverse=True
     )
     by_rubric = [
         RubricStarDistributions(
             rubric_version=version,
             picks=StarDistribution.from_stars(
-                stars_under(b, RUBRIC_WEIGHTS[version]) for b in pick_breakdowns
+                stars_under(b, RUBRICS[version]) for b in pick_breakdowns
             ),
             field=StarDistribution.from_stars(
-                stars_under(b, RUBRIC_WEIGHTS[version]) for b in field_breakdowns
+                stars_under(b, RUBRICS[version]) for b in field_breakdowns
             ),
             top_thirty=_top_thirty_under(picks_in_field, by_session, version),
         )

--- a/backend/screener/acceptance.py
+++ b/backend/screener/acceptance.py
@@ -54,7 +54,7 @@ ADR_SPOT_CHECK: tuple[str, ...] = (
 # detections-per-night level). Shares are fractions of the universe/list; counts are
 # absolute. These are the numbers ticket 45 replaces once measured on a real run.
 # **Two of these are expected to deviate after #154, and are deliberately not
-# retuned here.** The tightness restructure replaced the hard 1.5×ADR cluster cut
+# retuned here.** The base-tightness restructure replaced the hard 1.5×ADR cut
 # with a far-outlier guard, which more than doubles the field (measured +123%, 90.3
 # → 201.6 detections per session over 505 replayed sessions) and makes the 3-bar
 # window the reported cluster whenever nothing tighter clears — so **B4**

--- a/backend/screener/acceptance.py
+++ b/backend/screener/acceptance.py
@@ -53,6 +53,15 @@ ADR_SPOT_CHECK: tuple[str, ...] = (
 # for that market (B4/B9 were measured on the US sample only; IDX has no published
 # detections-per-night level). Shares are fractions of the universe/list; counts are
 # absolute. These are the numbers ticket 45 replaces once measured on a real run.
+# **Two of these are expected to deviate after #154, and are deliberately not
+# retuned here.** The tightness restructure replaced the hard 1.5×ADR cluster cut
+# with a far-outlier guard, which more than doubles the field (measured +123%, 90.3
+# → 201.6 detections per session over 505 replayed sessions) and makes the 3-bar
+# window the reported cluster whenever nothing tighter clears — so **B4**
+# (detections per night) and **B8** (share of clusters at k=3) both move by
+# construction. Editing the expectation to match would turn the regression test
+# into a rubber stamp: the deviation flag firing is the pass working. Ticket 45
+# owns replacing these with figures measured on a real run.
 _EXPECTED: dict[str, dict[str, float | None]] = {
     "US": {
         "B1": 1966, "B2": 0.285, "B3": 112, "B4": 30, "B5": 9.6,

--- a/backend/screener/candidates.py
+++ b/backend/screener/candidates.py
@@ -41,7 +41,7 @@ from __future__ import annotations
 from .detection import Detection, detection_gate
 from .models import Candidate, ScoreRow
 from .ranks import Rank, breadth_counts
-from .score import star_score
+from .score import live_points, star_score
 from .sectors import leave_one_out_sector_shares
 
 # §7's 1×ADR affordability cap: a row at or below it is the highlighted minority.
@@ -106,7 +106,10 @@ def build_candidates(
                 Candidate(
                     symbol=det.symbol,
                     score=stars,
-                    breakdown=[ScoreRow(**vars(d)) for d in breakdown],
+                    breakdown=[
+                        ScoreRow(**vars(d), points=live_points(d))
+                        for d in breakdown
+                    ],
                     dist_adr=det.dist_adr,
                     stopw_adr=det.stopw_adr,
                     affordable=det.stopw_adr <= AFFORDABLE_ADR,

--- a/backend/screener/chart.py
+++ b/backend/screener/chart.py
@@ -31,7 +31,7 @@ from .detection import Detection
 from .indicators import ema_series, median_dollar_volume, sma_series
 from .models import Candle, ChartFacts, ChartResponse, MaPoint, ScoreRow, SetupOverlay
 from .ranks import Rank
-from .score import star_score
+from .score import live_points, star_score
 
 # The 65 EMA is the daily chart's one exponential (spec §2 / §4.2).
 EMA_WINDOW = 65
@@ -100,7 +100,7 @@ def _setup(
         stop=detection.stop_price,     # the proposed convention stop line (issue #127)
         envelope=envelope,
         score=stars,
-        breakdown=[ScoreRow(**vars(d)) for d in breakdown],
+        breakdown=[ScoreRow(**vars(d), points=live_points(d)) for d in breakdown],
     )
 
 

--- a/backend/screener/detection.py
+++ b/backend/screener/detection.py
@@ -28,9 +28,9 @@ reaches the trigger**: it gates ``line_ok`` and it draws the chart, nothing else
 Gates (a name is a detection iff all hold):
 
 - **Cluster** — the trailing 3-bar range sits inside ``OUTLIER_MULT × ADR`` (step
-  3). A **far-outlier guard**, not a tightness cut: since #145/#154 how quiet the
-  base is is *graded* by the rubric, and only a name genuinely in motion is
-  rejected here.
+  3). A **far-outlier guard**, not a cut on how quiet the base is: since #145/#154
+  that is *graded* by the rubric, and only a name genuinely in motion is rejected
+  here (ADR 0004).
 - **Catch-up** — price is back at the 10/20 MA (step 2).
 - **Decile** — top decile in **any of 1m/3m/6m**, off the rank table
   (:func:`detection_gate`). 1w is a momentum burst, not §3.1's big prior move;
@@ -69,14 +69,14 @@ MAX_BASE_LEN = 45  # re-anchor to the highest high within 45 bars past this
 MIN_BASE_LEN = 3   # §3.1's minimum; the base always ends today
 
 # The cluster: the largest trailing k in [K_MIN, K_MAX] spanning ≤ TIGHT_MULT×ADR.
-# The two bounds do unrelated jobs, and only one of them gates. Trailing range is
+# The two bounds do unrelated jobs, and neither of them gates. Trailing range is
 # monotone in k (a longer window can only add high and add low, never less), so
-# the K_MIN window is the tightest one the scan can see: a name clears the cluster
-# gate iff its K_MIN window clears it.
-K_MIN = 3   # the gate: pass/fail is decided by this window, and nowhere else
-# K_MAX is a score input only: it sets the *reported* cluster_k, which the rubric's
-# ×2 Tightness dimension then scores. Widening or narrowing it cannot admit or
-# reject a single name.
+# the K_MIN window is the tightest one the scan can see — which is why it, and
+# nothing else, is what the far-outlier guard measures.
+K_MIN = 3   # the guard's window, and the cluster's fallback shape
+# K_MAX sets only the *reported* cluster_k. It could never admit or reject a name,
+# and since #154 it no longer feeds the score either: the rubric grades the 3-bar
+# range, not k.
 K_MAX = 7
 # TIGHT_MULT is the cut those windows are measured against. Since #145/#154 it
 # **shapes the cluster and no longer gates**: it decides which trailing window is
@@ -93,13 +93,15 @@ TIGHT_MULT = 1.5
 # 3.0+ bucket (−0.36).
 #
 # **Provisional, and on n = 10.** That last bucket holds ten of his 649 replayable
-# entries; it is the only feature available and far too thin to carry a threshold on
-# its own. §3b's complementary figure is the reason it is nonetheless the right
-# order of magnitude: widening to ~3.0 keeps 98.5% of his trades and 100.4% of his
-# summed R — over 100% because the tail this guard cuts is net negative. What would
-# firm it up is the same denominator the out-of-sample backtest builds
-# (`docs/out-of-sample-backtest-plan.md`); until that lands, treat the value as
-# provisional and do not tune it on a swept in-sample number.
+# entries; it is the only feature available and far too thin to carry a bound on its
+# own. §3b's complementary figure is why it is nonetheless the right order of
+# magnitude: widening to ~3.0 keeps 98.5% of his trades and 100.4% of his summed R —
+# over 100% because the tail this guard cuts is net negative. It is also a
+# *magnitude*, which ADR 0001 says the replay does not license; it is adopted anyway
+# under the provisional-with-an-n condition in
+# `docs/adr/0004-replacing-a-threshold-with-a-graded-input.md`. Do not tune it on a
+# swept in-sample number — the out-of-sample backtest re-derives it
+# (`docs/out-of-sample-backtest-plan.md`).
 OUTLIER_MULT = 3.0
 
 # Catch-up: price back at the 10/20 MA, in ADR units (spec §4.5 step 2).
@@ -265,10 +267,29 @@ def _prior_move(high: list[float], low: list[float], as_of: int):
     return best
 
 
-def _find_cluster(high: list[float], low: list[float], as_of: int, adr_abs: float):
-    """The cluster window, or ``None`` if the far-outlier guard rejects the name.
+@dataclass(frozen=True)
+class ClusterWindow:
+    """The trailing window :func:`_find_cluster` settled on, and the guard's ruler.
 
-    Returns ``(k, cluster_high, cluster_low, range_adr, range_3bar)``.
+    ``k``, ``high``, ``low`` and ``range_adr`` describe the window that was chosen —
+    its high is the trigger by identity, its low is base geometry for the chart and
+    never a stop. ``range_3bar`` is the *ungated* trailing 3-bar range: the number
+    the far-outlier guard tested to admit the name at all, and the one the rubric
+    grades. It rides on the window rather than being recomputed downstream because
+    the two are decided together and must agree.
+    """
+
+    k: int
+    high: float
+    low: float
+    range_adr: float
+    range_3bar: float
+
+
+def _find_cluster(
+    high: list[float], low: list[float], as_of: int, adr_abs: float
+) -> ClusterWindow | None:
+    """The cluster window, or ``None`` if the far-outlier guard rejects the name.
 
     **The guard and the window are two jobs, and since #145/#154 two constants.**
     Pass/fail is settled entirely by the trailing 3-bar range against
@@ -301,9 +322,9 @@ def _find_cluster(high: list[float], low: list[float], as_of: int, adr_abs: floa
         cl = min(low[lo:as_of + 1])
         range_adr = (ch - cl) / adr_abs
         if range_adr <= TIGHT_MULT:
-            return k, ch, cl, range_adr, range_3bar
+            return ClusterWindow(k, ch, cl, range_adr, range_3bar)
     lo = as_of - K_MIN + 1
-    return (
+    return ClusterWindow(
         K_MIN,
         max(high[lo:as_of + 1]),
         min(low[lo:as_of + 1]),
@@ -462,7 +483,7 @@ def detect(symbol: str, bars: list[Bar], as_of: date) -> Detection | None:
     Returns ``None`` when the per-name gates fail: too little history (< 80 bars)
     or non-positive ADR, no prior move, a base shorter than 3 bars, price not yet
     caught up to the 10/20, or a trailing 3-bar range past ``OUTLIER_MULT × ADR``
-    — the far-outlier guard, which is the only tightness rejection left. The
+    — the far-outlier guard, the only base-tightness rejection left. The
     **decile** gate is not applied here — it is cross-sectional and lives in the
     pipeline; a caller detecting a single name in isolation has already decided it
     is eligible.
@@ -505,17 +526,16 @@ def detect(symbol: str, bars: list[Bar], as_of: date) -> Detection | None:
     cluster = _find_cluster(high, low, idx, adr_abs)
     if cluster is None:
         return None
-    k, cluster_high, cluster_low, range_adr, range_3bar = cluster
 
-    anchor = _argmax(high, idx - k + 1, idx)
+    anchor = _argmax(high, idx - cluster.k + 1, idx)
     slope, line_ok, zones, over_max, line_end = _fit_envelope(
-        high, adr_abs, anchor, base_start, idx, k
+        high, adr_abs, anchor, base_start, idx, cluster.k
     )
 
-    trigger = cluster_high  # by identity — never max(line, high); the clamp is dead
+    trigger = cluster.high  # by identity — never max(line, high); the clamp is dead
     # The proposed stop is the trader's convention (issue #127): a fixed
     # STOP_CONVENTION_ADR multiple of the night's ADR below the trigger, in price
-    # units. Note what is *not* read here — ``cluster_low``, ``range_adr``, nor any
+    # units. Note what is *not* read here — the cluster's low, its span, nor any
     # other base-tightness quantity. By construction ``stopw_adr`` equals the
     # convention — the a·trigger in ``stop`` cancels — so every proposed stop sits
     # at 0.345 ADR, not the ~1.28 ADR the cluster-low distance used to yield.
@@ -539,11 +559,11 @@ def detect(symbol: str, bars: list[Bar], as_of: date) -> Detection | None:
         move_gain=move_gain,
         adr=a,
         close=close[idx],
-        cluster_k=k,
-        cluster_high=cluster_high,
-        cluster_low=cluster_low,
-        cluster_range_adr=range_adr,
-        range_3bar_adr=range_3bar,
+        cluster_k=cluster.k,
+        cluster_high=cluster.high,
+        cluster_low=cluster.low,
+        cluster_range_adr=cluster.range_adr,
+        range_3bar_adr=cluster.range_3bar,
         line_ok=line_ok,
         touch_zones=zones,
         overshoot_adr=over_max,

--- a/backend/screener/detection.py
+++ b/backend/screener/detection.py
@@ -13,12 +13,12 @@ The structure is two levels, ported from the wayfinding prototype
   the envelope does not invalidate it (the boundaries are fits, not monotonic
   tests).
 - **The cluster** is the largest 3–7 bar trailing window whose span sits under
-  ``TIGHT_MULT × ADR``. Its max high *is* the trigger, by identity. Its span is
-  **base tightness** as this module gates it — setup geometry, and what the
-  rubric scores ×2 through ``cluster_k``. (The *ungated* form of the same
-  quantity is :func:`range_3bar_adr`, which is what findings §3b puts at
-  a median of 1.310 ADR.) A span is never a stop level; **stop width** is a
-  separate quantity, measured 3.8× narrower on the same trades (issue #147).
+  ``TIGHT_MULT × ADR``, falling back to the 3-bar window when none does. Its max
+  high *is* the trigger, by identity. Its span is **base tightness** — setup
+  geometry, which the rubric grades ×2 off the ungated form of the same quantity,
+  :func:`range_3bar_adr` (findings §3b puts its median at 1.310 ADR across his
+  entries). A span is never a stop level; **stop width** is a separate quantity,
+  measured 3.8× narrower on the same trades (issue #147).
 
 The envelope is anchored at the cluster's max-high bar and searched over
 **non-positive slopes only**, so the fitted line can never exceed the anchor —
@@ -27,7 +27,10 @@ reaches the trigger**: it gates ``line_ok`` and it draws the chart, nothing else
 
 Gates (a name is a detection iff all hold):
 
-- **Cluster** — a 3–7 bar cluster inside ``TIGHT_MULT × ADR`` exists (step 3).
+- **Cluster** — the trailing 3-bar range sits inside ``OUTLIER_MULT × ADR`` (step
+  3). A **far-outlier guard**, not a tightness cut: since #145/#154 how quiet the
+  base is is *graded* by the rubric, and only a name genuinely in motion is
+  rejected here.
 - **Catch-up** — price is back at the 10/20 MA (step 2).
 - **Decile** — top decile in **any of 1m/3m/6m**, off the rank table
   (:func:`detection_gate`). 1w is a momentum burst, not §3.1's big prior move;
@@ -75,10 +78,29 @@ K_MIN = 3   # the gate: pass/fail is decided by this window, and nowhere else
 # ×2 Tightness dimension then scores. Widening or narrowing it cannot admit or
 # reject a single name.
 K_MAX = 7
-# TIGHT_MULT is the cut those windows are measured against. It gates **base
-# tightness** — how quiet the stock was before the break — and nothing else. It has
-# never bounded a stop; see STOP_CONVENTION_ADR below.
+# TIGHT_MULT is the cut those windows are measured against. Since #145/#154 it
+# **shapes the cluster and no longer gates**: it decides which trailing window is
+# reported as the cluster (and so where the trigger sits), not whether the name is
+# a detection. A name whose 3-bar window is over it still detects — with the 3-bar
+# window as its cluster — and the rubric grades how far over it sat. It has never
+# bounded a stop; see STOP_CONVENTION_ADR below.
 TIGHT_MULT = 1.5
+# OUTLIER_MULT is the **far-outlier guard** that replaced the hard cut (#145/#154):
+# past this the trailing 3-bar range is not a quiet base at all but a name in
+# motion, and no rubric grade should be asked to express that. Sited on the only
+# feature findings §3b's outcome table offers — mean R by three-bar range is
+# positive in every bucket up to 2.0–3.0 (+0.35) and turns negative only in the
+# 3.0+ bucket (−0.36).
+#
+# **Provisional, and on n = 10.** That last bucket holds ten of his 649 replayable
+# entries; it is the only feature available and far too thin to carry a threshold on
+# its own. §3b's complementary figure is the reason it is nonetheless the right
+# order of magnitude: widening to ~3.0 keeps 98.5% of his trades and 100.4% of his
+# summed R — over 100% because the tail this guard cuts is net negative. What would
+# firm it up is the same denominator the out-of-sample backtest builds
+# (`docs/out-of-sample-backtest-plan.md`); until that lands, treat the value as
+# provisional and do not tune it on a swept in-sample number.
+OUTLIER_MULT = 3.0
 
 # Catch-up: price back at the 10/20 MA, in ADR units (spec §4.5 step 2).
 CATCHUP_10, CATCHUP_20 = 1.0, 2.0
@@ -135,7 +157,12 @@ DETECTION_LOOKBACKS = ("1m", "3m", "6m")
 
 # Stamped on every detection row; bump when the detector's output changes so
 # rows from different logic are never silently compared (spec §7.2 / A1).
-DETECTOR_VERSION = 1
+# v2 (#145/#154): the hard 1.5×ADR cluster cut became the OUTLIER_MULT far-outlier
+# guard, so a v2 session's rows are drawn from a **different population** than a
+# v1 session's — the funnel's denominators, the detected-count anchor and every
+# field-derived share move with it. That is exactly the comparison this stamp
+# exists to stop happening silently.
+DETECTOR_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -161,7 +188,16 @@ class Detection:
     cluster_k: int
     cluster_high: float
     cluster_low: float
-    cluster_range_adr: float
+    cluster_range_adr: float  # the reported window's span — gated by TIGHT_MULT's shape
+    # **Base tightness, ungated** — the trailing 3-bar range in ADR, the tightest
+    # window there is and the quantity the far-outlier guard tests. Persisted (not
+    # merely derived) because the rubric *grades* it: a breakdown has to carry the
+    # value so any rubric version can map it to points (#154, score.Dimension).
+    # Equal to cluster_range_adr exactly when no window cleared TIGHT_MULT.
+    # ``None`` only on a row read back from a store written before the column
+    # existed (schema v10): the night had no value for it and inventing one would
+    # fabricate a signal. :func:`detect` always sets a float.
+    range_3bar_adr: float | None
     line_ok: bool           # a verdict on the fit's quality, NOT a gate
     touch_zones: int
     overshoot_adr: float
@@ -230,17 +266,32 @@ def _prior_move(high: list[float], low: list[float], as_of: int):
 
 
 def _find_cluster(high: list[float], low: list[float], as_of: int, adr_abs: float):
-    """Largest trailing 3–7 bar window spanning ≤ ``TIGHT_MULT × ADR``.
+    """The cluster window, or ``None`` if the far-outlier guard rejects the name.
 
-    Returns ``(k, cluster_high, cluster_low, range_adr)`` for the first (largest)
-    k whose **base tightness** clears the gate, or ``None`` (``no_cluster``, a
-    rejection). ``cluster_low`` is base geometry for the chart, never a stop.
+    Returns ``(k, cluster_high, cluster_low, range_adr, range_3bar)``.
 
-    The scan runs down from ``K_MAX``, but pass/fail is settled at ``K_MIN`` —
-    ``K_MAX`` moves only the reported ``k``. :func:`range_3bar_adr` carries the
-    argument.
+    **The guard and the window are two jobs, and since #145/#154 two constants.**
+    Pass/fail is settled entirely by the trailing 3-bar range against
+    ``OUTLIER_MULT``: over it, the name is in motion and there is no base
+    (``no_cluster``, the only rejection this function makes). Inside it, the name
+    detects, and the scan then runs down from ``K_MAX`` for the largest window
+    under ``TIGHT_MULT`` — how quiet it was is graded by the rubric, not gated
+    here.
+
+    When no window clears ``TIGHT_MULT`` the **3-bar window is the cluster**: it is
+    the tightest one there is (range is monotone in ``k``, see
+    :func:`range_3bar_adr`), so it is the honest choice of anchor for a name that
+    is inside the guard but past 1.5. Its ``range_adr`` is then exactly
+    ``range_3bar``. A name that cleared the old 1.5 gate is unaffected in every
+    output — same ``k``, same trigger, same span — so this loosening adds names
+    and moves none.
+
+    ``cluster_low`` is base geometry for the chart, never a stop.
     """
     if adr_abs <= 0:
+        return None
+    range_3bar = range_3bar_adr(high, low, as_of, adr_abs)
+    if range_3bar is None or range_3bar > OUTLIER_MULT:
         return None
     for k in range(K_MAX, K_MIN - 1, -1):
         lo = as_of - k + 1
@@ -250,8 +301,15 @@ def _find_cluster(high: list[float], low: list[float], as_of: int, adr_abs: floa
         cl = min(low[lo:as_of + 1])
         range_adr = (ch - cl) / adr_abs
         if range_adr <= TIGHT_MULT:
-            return k, ch, cl, range_adr
-    return None
+            return k, ch, cl, range_adr, range_3bar
+    lo = as_of - K_MIN + 1
+    return (
+        K_MIN,
+        max(high[lo:as_of + 1]),
+        min(low[lo:as_of + 1]),
+        range_3bar,
+        range_3bar,
+    )
 
 
 def range_3bar_adr(
@@ -273,16 +331,22 @@ def range_3bar_adr(
     a measurement (it was also confirmed empirically over all 649 replayable
     entries in findings §3b, identical to the last decimal).
 
-    Two things follow. A ``no_cluster`` rejection (``_find_cluster`` returned
-    ``None``) can be quantified *against* the condition's window — a value just
-    over ``TIGHT_MULT`` is a marginal miss, a large one a name genuinely in
-    motion. And a name clears the cluster gate iff this number clears
-    ``TIGHT_MULT``; ``K_MAX`` decides only which ``cluster_k`` gets reported.
+    That identity is why this number, and not ``cluster_range_adr``, is the one the
+    guard tests and the rubric grades. ``cluster_range_adr`` is *gated* — it is the
+    span of whichever window cleared ``TIGHT_MULT``, so a very quiet name earns a
+    longer window and reports a *wider* span than a less quiet one, which makes it
+    non-monotone in the thing being measured. This number is the ungated ruler, and
+    it is what findings §3b's outcome table is denominated in.
+
+    So a name is a detection iff this number sits inside ``OUTLIER_MULT``, and how
+    far inside is what the rubric's ×2 dimension grades (#154). ``K_MAX`` decides
+    only which ``cluster_k`` gets reported, and ``cluster_k`` no longer scores.
 
     Returns ``None`` only when ``adr_abs`` is non-positive or the window runs off
     the front of the series (``as_of`` is under ``K_MIN - 1``, so there are not
-    ``K_MIN`` bars ending at it); it changes no detection verdict. Used by the A1
-    study to characterise the ``cluster`` misses (issue #132), not by the detector.
+    ``K_MIN`` bars ending at it). Read by :func:`_find_cluster`, persisted on every
+    detection, and used by the A1 study to characterise the ``cluster`` misses
+    (issue #132).
     """
     if adr_abs <= 0:
         return None
@@ -397,7 +461,8 @@ def detect(symbol: str, bars: list[Bar], as_of: date) -> Detection | None:
 
     Returns ``None`` when the per-name gates fail: too little history (< 80 bars)
     or non-positive ADR, no prior move, a base shorter than 3 bars, price not yet
-    caught up to the 10/20, or no cluster inside ``TIGHT_MULT × ADR``. The
+    caught up to the 10/20, or a trailing 3-bar range past ``OUTLIER_MULT × ADR``
+    — the far-outlier guard, which is the only tightness rejection left. The
     **decile** gate is not applied here — it is cross-sectional and lives in the
     pipeline; a caller detecting a single name in isolation has already decided it
     is eligible.
@@ -440,7 +505,7 @@ def detect(symbol: str, bars: list[Bar], as_of: date) -> Detection | None:
     cluster = _find_cluster(high, low, idx, adr_abs)
     if cluster is None:
         return None
-    k, cluster_high, cluster_low, range_adr = cluster
+    k, cluster_high, cluster_low, range_adr, range_3bar = cluster
 
     anchor = _argmax(high, idx - k + 1, idx)
     slope, line_ok, zones, over_max, line_end = _fit_envelope(
@@ -478,6 +543,7 @@ def detect(symbol: str, bars: list[Bar], as_of: date) -> Detection | None:
         cluster_high=cluster_high,
         cluster_low=cluster_low,
         cluster_range_adr=range_adr,
+        range_3bar_adr=range_3bar,
         line_ok=line_ok,
         touch_zones=zones,
         overshoot_adr=over_max,

--- a/backend/screener/models.py
+++ b/backend/screener/models.py
@@ -309,13 +309,28 @@ class ScoreRow(BaseModel):
     the rest — recalibrated by PRD #138) and whether it hit. ``Tightness`` is **base
     tightness** — the setup's geometry, not the stop width the row also carries
     (issue #147); the label is published, so it is qualified here rather than
-    renamed. ``n/9 → stars`` is ``sum(weight where hit) ÷ 2``; the ceiling is nine
-    points, not ten.
+    renamed. The ceiling is nine points, not ten, and stars are ``points ÷ 2``.
+
+    ``value`` is the graded quantity, present only on a **graded** dimension — since
+    rubric v3 that is ``Tightness`` alone, carrying its three-bar range in ADR
+    (#154). On a graded row ``hit`` is *not* what scored: it is the boolean the
+    setup satisfies (Tightness keeps v1/v2's ``cluster_k >= 5``), kept so a stored
+    breakdown re-scores exactly under an older rubric.
+
+    ``points`` is what the row **actually earned**, under the rubric the payload's
+    ``rubric_version`` names. It is published because ``weight where hit`` no longer
+    totals a graded breakdown, and the client must not carry a second copy of the
+    band table: a breakdown that does not add up to the star it sits beside is
+    exactly the un-auditable sort key the rubric exists to avoid. ``points`` is a
+    property of a *rubric applied to* the row, which is why it rides the API model
+    and never the stored :class:`~screener.score.Dimension`.
     """
 
     dimension: str
     weight: int
     hit: bool
+    value: float | None = None
+    points: int
 
 
 class Candidate(BaseModel):

--- a/backend/screener/score.py
+++ b/backend/screener/score.py
@@ -1,14 +1,16 @@
-"""The star score: eight boolean dimensions, nine weighted points (spec §4.7,
-recalibrated by PRD #138).
+"""The star score: eight dimensions — seven boolean, one banded — nine weighted
+points (spec §4.7, recalibrated by PRD #138, Tightness graded by #145/#154).
 
 The sort key of the only list in the app. `points ÷ 2` = stars, with a **real
 range of 0.5–4.5, never 0–5**: ``Prior move`` fires for every detection by
 construction (a permanent half-star floor) and ``Base length`` is weighted zero
 (the ninth point can never be earned). The scale was never truly 0–5; the ×0
-makes that visible rather than nominal. **Booleans, not continuous** (+0.255 vs
-+0.191 in the round that tested it): the score is the default sort of the only
-list in the app, and a sort key you cannot audit is one you will not trust
-(ticket 15 R4).
+makes that visible rather than nominal. **Auditable, not continuous** (+0.255 vs
++0.191 in the round that tested a fully continuous score): the score is the default
+sort of the only list in the app, and a sort key you cannot audit is one you will
+not trust (ticket 15 R4). v3's one graded dimension is banded to integral points for
+that reason — a breakdown still reconstructs the star by addition, and the
+nine-point ceiling and the ``÷ 2`` are untouched.
 
 **What the weights encode** (ADR 0001): the method's *revealed selection*,
 evidenced by Kullamägi's executed trades — the §5b selection contrast of 69 taken
@@ -34,7 +36,7 @@ travelling to IDX):
 
 | Dimension   | Weight | Rule                                    |
 |-------------|--------|-----------------------------------------|
-| Tightness   | ×2     | ``cluster_k >= 5``                      |
+| Tightness   | ×2     | graded on ``range_3bar_adr``: 2 ≤ 1.0, 1 ≤ 2.0, else 0 |
 | Orderliness | ×1     | ``0.30 <= churn/L <= 0.60`` over the base |
 | Prior move  | ×1     | decile percentile ``>= 0.90`` (constant) |
 | Base length | ×0     | ``base_len <= 14`` (measured, worth nothing) |
@@ -47,6 +49,18 @@ travelling to IDX):
 read off the cluster's geometry. It is not stop width, and the two are 3.8× apart on
 his own trades (findings §3b, issue #147); the dimension label is kept as published
 because it rides the API payload and the digest.
+
+**Tightness is the one dimension that is not a boolean (v3, #145/#154).** Findings
+§3b measured mean R by three-bar range across his executed trades and found a
+*smooth monotone decline with no feature anywhere* — +2.02 / +1.35 / +0.84 / +0.35 /
+−0.36 R across the range — so a threshold is the wrong shape for it, in the same
+sense that #143's entry-to-MA cliff made a threshold the right shape there. v3 grades
+it in bands off :data:`Detection.range_3bar_adr` (see :data:`TIGHTNESS_BANDS`), and
+:class:`Rubric` — not the stored row — owns the mapping, so v2 still re-scores a v3
+row exactly. Note what this is *not*: the ADR 0002 score-dimension limb governs
+*loosening a dimension away on a null*, and Tightness is the study's best-evidenced
+dimension (§5b selection +20.8pp, §3b outcome). The dimension is not loosened here —
+its shape changes and its weight does not.
 
 Three of the eight are read off the detection's own signal vector (base tightness,
 base length, ADR); orderliness, MA support and volume are the detector's derived
@@ -70,18 +84,20 @@ Pure and numpy-free, so it is unit-tested without the network.
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from .detection import Detection
 
 # The rubric version stamp (PRD #138). Version 1 was the ten-point rubric
-# (Tightness/Orderliness ×2, all else ×1); version 2 is the nine-point
-# selection-recalibrated rubric below. Stars are derived on read *except in a
+# (Tightness/Orderliness ×2, all else ×1); version 2 was the nine-point
+# selection-recalibrated one, boolean throughout; version 3 keeps v2's weights and
+# grades ``Tightness`` off the row's own three-bar range (#145/#154). Stars are
+# derived on read *except in a
 # digest*, which freezes them — so without a stamp a changed rubric leaves last
 # week's digest and today's app disagreeing about the same session with nothing
 # recording why. It is also what lets a paired re-run (#136) compare like with
 # like instead of comparing two rubrics while believing it compares two fields.
-RUBRIC_VERSION = 2
+RUBRIC_VERSION = 3
 
 # The published thresholds (spec §4.7). One set, both markets. An earlier
 # wayfinding table carried different values under an objective later shown blind —
@@ -90,7 +106,24 @@ RUBRIC_VERSION = 2
 # not scored from the detection but passed in as a boolean by the caller, decided
 # upstream by the decile gate. The rubric's ceiling — nine weighted points, ÷2 for
 # 0.5–4.5 stars — is likewise not a tunable but the sum of the weights below.
-TIGHT_K = 5              # cluster_k >= 5 — base tightness, never a stop width
+TIGHT_K = 5              # cluster_k >= 5 — v1/v2's Tightness rule, still recorded
+# v3's Tightness bands: ``(upper bound in ADR, points)``, ascending, first match
+# wins, nothing beyond the last. Read off :data:`Detection.range_3bar_adr` — the
+# *ungated* base tightness, which is the quantity findings §3b's outcome table is
+# denominated in and the one the far-outlier guard tests.
+#
+# **The edges are §3b's own bucket boundaries, not new numbers.** That table
+# reports mean R by three-bar range at 0.0–1.0 (+2.02), 1.0–1.5 (+1.35), 1.5–2.0
+# (+0.84), 2.0–3.0 (+0.35) and 3.0+ (−0.36); the bands collapse it to the two
+# places expectancy roughly halves. ADR 0001's constraint holds — the *ordering*
+# of the buckets licenses the direction, and no band edge reads a gap's magnitude.
+#
+# **Bands, not a fraction.** Integral points keep the nine-point ceiling and the
+# ``points ÷ 2 → stars`` arithmetic exactly as they were, so no star display,
+# frozen digest or acceptance metric changes shape. A fractional grade would move
+# every one of those for a resolution the evidence (five buckets, the thinnest
+# n = 10) cannot support.
+TIGHTNESS_BANDS: tuple[tuple[float, int], ...] = ((1.0, 2), (2.0, 1))
 CHURN_LO, CHURN_HI = 0.30, 0.60   # 0.30 <= churn/L <= 0.60, a band on both edges
 BASE_LEN_MAX = 14        # base_len <= 14
 DRYUP_MAX = 0.95         # dry-up <= 0.95
@@ -100,13 +133,28 @@ ADR_MIN = 0.05           # ADR >= 0.05
 
 @dataclass(frozen=True)
 class Dimension:
-    """One row of the score breakdown: a named boolean and its weight. Eight of
-    these reconstruct the star score arithmetically — weights, hits, ``n/9 →
-    stars`` (spec §4.7 acceptance C4; nine-point ceiling, PRD #138)."""
+    """One row of the score breakdown: a named boolean, its weight, and — for a
+    graded dimension — the value that was graded. Eight of these reconstruct the
+    star score arithmetically (spec §4.7 acceptance C4; nine-point ceiling, PRD
+    #138).
+
+    **The row carries the value, never the verdict of a particular rubric** (#154).
+    ``hit`` is the boolean the *setup* has — for ``Tightness`` that is still v1/v2's
+    ``cluster_k >= TIGHT_K``, which no value can reconstruct — and ``value`` is the
+    quantity a graded rubric maps to points. Both are properties of the setup, so
+    the invariant :func:`stars_under` rests on survives grading: only the mapping
+    moves between versions, and a v2 re-score of a v3 row is exact rather than
+    approximate. Bake a v3 grade into ``hit`` instead and the paired A2 re-run
+    (#136) would be comparing two rubrics while believing it compares two fields.
+
+    ``value`` is ``None`` on the seven ungraded dimensions, and on any breakdown
+    written before the field existed.
+    """
 
     dimension: str
     weight: int
     hit: bool
+    value: float | None = None
 
 
 # The eight dimension labels and weights, in the spec's published order. The rule
@@ -123,15 +171,51 @@ DIMENSIONS: tuple[tuple[str, int], ...] = (
 )
 
 
-# The weight of every rubric version, keyed by its :data:`RUBRIC_VERSION` stamp,
-# so a set of *hit booleans* can be re-scored under any version without
-# re-detecting. Version 1 is the superseded ten-point rubric (Tightness and
-# Orderliness ×2, everything else ×1); version 2 is the live nine-point table
-# above. Kept beside the live one specifically for the paired A2 re-run (#136),
-# which scores one field under both rubrics so a *rubric* change is separated from
-# a *field* change instead of the two moving at once.
-RUBRIC_WEIGHTS: Mapping[int, Mapping[str, int]] = {
-    1: {
+@dataclass(frozen=True)
+class Rubric:
+    """One version's mapping from a breakdown row to points.
+
+    ``weights`` is the per-dimension weight — for a graded dimension, the points a
+    row can earn at most. ``bands`` names the dimensions this version *grades*,
+    each with its ascending ``(upper bound, points)`` table; every other dimension
+    scores ``weight`` when it hits and nothing when it does not.
+
+    A rubric owns its own value → points mapping, which is what lets a graded
+    dimension coexist with a stored breakdown replayable under any version: the row
+    carries the value, the rubric decides what it is worth (#154).
+    """
+
+    weights: Mapping[str, int]
+    bands: Mapping[str, tuple[tuple[float, int], ...]] = field(default_factory=dict)
+
+    def points(self, row: Dimension) -> int:
+        """What ``row`` is worth under this rubric.
+
+        A graded dimension whose row carries no ``value`` falls back to the
+        boolean — a breakdown written before the value existed, or one the replay
+        struck a dimension from, still re-totals rather than silently scoring zero.
+        """
+        bands = self.bands.get(row.dimension)
+        if bands is None or row.value is None:
+            return self.weights.get(row.dimension, 0) if row.hit else 0
+        for upper, points in bands:
+            if row.value <= upper:
+                return points
+        return 0
+
+
+# Every rubric version, keyed by its :data:`RUBRIC_VERSION` stamp, so a stored
+# breakdown can be re-scored under any version without re-detecting. Version 1 is
+# the superseded ten-point rubric (Tightness and Orderliness ×2, everything else
+# ×1); version 2 the nine-point selection-recalibrated one, boolean throughout;
+# version 3 the live one — v2's weights exactly, with ``Tightness`` graded off the
+# row's three-bar range. The superseded versions are kept beside the live one
+# specifically for the paired A2 re-run (#136), which scores one field under every
+# rubric so a *rubric* change is separated from a *field* change instead of the two
+# moving at once. **Adding a version must never edit an older one**: v2 below is
+# what shipped, and a re-score under it has to reproduce what shipped.
+RUBRICS: Mapping[int, Rubric] = {
+    1: Rubric({
         "Tightness": 2,
         "Orderliness": 2,
         "Prior move": 1,
@@ -140,25 +224,41 @@ RUBRIC_WEIGHTS: Mapping[int, Mapping[str, int]] = {
         "Volume": 1,
         "Sector": 1,
         "ADR": 1,
-    },
-    RUBRIC_VERSION: {name: weight for name, weight in DIMENSIONS},
+    }),
+    2: Rubric({name: weight for name, weight in DIMENSIONS}),
+    RUBRIC_VERSION: Rubric(
+        {name: weight for name, weight in DIMENSIONS},
+        bands={"Tightness": TIGHTNESS_BANDS},
+    ),
 }
 
 
-def stars_under(breakdown: Iterable[Dimension], weights: Mapping[str, int]) -> float:
-    """Re-total a breakdown's hit booleans under an arbitrary weight map → stars.
+def stars_under(breakdown: Iterable[Dimension], rubric: Rubric) -> float:
+    """Re-total a stored breakdown under an arbitrary rubric → stars.
 
-    The hits are a property of the *setup*, not the rubric — only the weights move
-    between versions. So one field's detections can be scored under either rubric
-    (:data:`RUBRIC_WEIGHTS`) from the same breakdown, which is what lets the paired
-    A2 re-run (#136) hold the field fixed while swapping only the weights. Under the
-    live weights it reproduces :func:`star_score` exactly (``points ÷ 2``); a
-    dimension absent from ``weights`` scores nothing. Sector-struck breakdowns from
-    the replay (:mod:`replay.field`) re-total correctly because the sum ranges over
-    the rows that are present.
+    A breakdown row records what the *setup* is — the boolean it satisfies and, on
+    a graded dimension, the value it carries — never what a particular rubric made
+    of it. Only the mapping moves between versions. So one field's detections can
+    be scored under any rubric (:data:`RUBRICS`) from the same breakdown, which is
+    what lets the paired A2 re-run (#136) hold the field fixed while swapping only
+    the rubric. Under the live rubric it reproduces :func:`star_score` exactly
+    (``points ÷ 2``); a dimension the rubric does not weigh scores nothing.
+    Sector-struck breakdowns from the replay (:mod:`replay.field`) re-total
+    correctly because the sum ranges over the rows that are present.
     """
-    points = sum(weights.get(d.dimension, 0) for d in breakdown if d.hit)
-    return points / 2
+    return sum(rubric.points(d) for d in breakdown) / 2
+
+
+def live_points(row: Dimension) -> int:
+    """What one breakdown row earns under the **live** rubric.
+
+    The one thing a stored row deliberately does not carry (#154), published on the
+    API payload beside its ``rubric_version`` so a client can reconstruct the star
+    by addition without owning a copy of the band table. Since v3 the old
+    arithmetic — ``weight where hit`` — no longer totals a graded breakdown, and a
+    sort key you cannot audit is one you will not trust.
+    """
+    return RUBRICS[RUBRIC_VERSION].points(row)
 
 
 def star_score(
@@ -178,6 +278,10 @@ def star_score(
     totalling is :func:`stars_under` under the live weights — one site owns the
     ``÷ 2``, so the live rubric cannot drift from the version table it is keyed in.
     """
+    # ``Tightness`` is the one graded dimension (#154): its row carries the
+    # *value* — the ungated three-bar range — and the live rubric bands it, while
+    # ``hit`` keeps v1/v2's ``cluster_k >= TIGHT_K`` so those versions still
+    # re-score the same row exactly.
     hits = {
         "Tightness": det.cluster_k >= TIGHT_K,
         "Orderliness": CHURN_LO <= det.churn_l <= CHURN_HI,
@@ -188,5 +292,9 @@ def star_score(
         "Sector": sector_share >= SECTOR_SHARE_MIN,
         "ADR": det.adr >= ADR_MIN,
     }
-    breakdown = [Dimension(name, weight, hits[name]) for name, weight in DIMENSIONS]
-    return stars_under(breakdown, RUBRIC_WEIGHTS[RUBRIC_VERSION]), breakdown
+    values = {"Tightness": det.range_3bar_adr}
+    breakdown = [
+        Dimension(name, weight, hits[name], values.get(name))
+        for name, weight in DIMENSIONS
+    ]
+    return stars_under(breakdown, RUBRICS[RUBRIC_VERSION]), breakdown

--- a/backend/screener/score.py
+++ b/backend/screener/score.py
@@ -57,10 +57,10 @@ because it rides the API payload and the digest.
 sense that #143's entry-to-MA cliff made a threshold the right shape there. v3 grades
 it in bands off :data:`Detection.range_3bar_adr` (see :data:`TIGHTNESS_BANDS`), and
 :class:`Rubric` — not the stored row — owns the mapping, so v2 still re-scores a v3
-row exactly. Note what this is *not*: the ADR 0002 score-dimension limb governs
-*loosening a dimension away on a null*, and Tightness is the study's best-evidenced
-dimension (§5b selection +20.8pp, §3b outcome). The dimension is not loosened here —
-its shape changes and its weight does not.
+row exactly. What licenses replacing a threshold with a grade, and why that is not
+the loosening ADR 0002 forbids, is
+``docs/adr/0004-replacing-a-threshold-with-a-graded-input.md`` — the argument is
+recorded there rather than made here.
 
 Three of the eight are read off the detection's own signal vector (base tightness,
 base length, ADR); orderliness, MA support and volume are the detector's derived
@@ -225,7 +225,22 @@ RUBRICS: Mapping[int, Rubric] = {
         "Sector": 1,
         "ADR": 1,
     }),
-    2: Rubric({name: weight for name, weight in DIMENSIONS}),
+    # Spelled out, not derived from DIMENSIONS. A superseded version must record
+    # what *shipped*, and a table computed from the live one silently follows any
+    # future weight edit — which would corrupt the paired re-run in the one way it
+    # cannot detect, by moving the "before" as well as the "after".
+    2: Rubric({
+        "Tightness": 2,
+        "Orderliness": 1,
+        "Prior move": 1,
+        "Base length": 0,
+        "MA support": 1,
+        "Volume": 1,
+        "Sector": 1,
+        "ADR": 2,
+    }),
+    # The live one *is* derived from DIMENSIONS: there is one live weight table and
+    # this must not be a second copy of it.
     RUBRIC_VERSION: Rubric(
         {name: weight for name, weight in DIMENSIONS},
         bands={"Tightness": TIGHTNESS_BANDS},

--- a/backend/screener/store.py
+++ b/backend/screener/store.py
@@ -33,10 +33,12 @@ from .regime import FollowThrough
 # v7 the run_failures table — the per-symbol record of why a pull fell short (#91);
 # v8 the refusals table — the persisted per-symbol refusal verdict (spec §3.6, #100);
 # v9 the label_history table — the forward sector/industry record so the rubric's
-# eighth dimension is replayable going forward (issue #130, PRD #114).
+# eighth dimension is replayable going forward (issue #130, PRD #114); v10 extends
+# detections with range_3bar_adr, the ungated base tightness the graded Tightness
+# dimension reads (#154).
 # Recorded in the database on open (``schema_meta``) and reconciled against it by
 # :meth:`Store._migrate`, so an older file is upgraded rather than crashed into.
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 _SCHEMA = """
 -- The schema this database has been reconciled to. Written on every open, so
@@ -167,6 +169,10 @@ CREATE TABLE IF NOT EXISTS detections (
     cluster_high       DOUBLE  NOT NULL,
     cluster_low        DOUBLE  NOT NULL,
     cluster_range_adr  DOUBLE  NOT NULL,
+    -- Base tightness, ungated: the trailing 3-bar range in ADR. Persisted because
+    -- the rubric grades it (#154) — a breakdown must carry the value, not one
+    -- version's verdict about it. NULL on rows written before v10.
+    range_3bar_adr     DOUBLE  NOT NULL,
     line_ok            BOOLEAN NOT NULL,
     touch_zones        INTEGER NOT NULL,
     overshoot_adr      DOUBLE  NOT NULL,
@@ -680,11 +686,12 @@ class Store:
             return 0
         self._cursor().executemany(
             "INSERT INTO detections VALUES "
-            "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             [
                 [market, session, d.symbol, d.detector_version, d.trigger, d.stop,
                  d.stopw_adr, d.base_len, d.move_gain, d.adr, d.close, d.cluster_k,
-                 d.cluster_high, d.cluster_low, d.cluster_range_adr, d.line_ok,
+                 d.cluster_high, d.cluster_low, d.cluster_range_adr,
+                 d.range_3bar_adr, d.line_ok,
                  d.touch_zones, d.overshoot_adr, d.slope, d.line_end, d.base_low,
                  d.churn_l, d.sma20_rising, d.dryup]
                 for d in rows
@@ -791,7 +798,8 @@ class Store:
         rows = self._cursor().execute(
             "SELECT symbol, detector_version, trigger, stop, stopw_adr, base_len, "
             "move_gain, adr, close, cluster_k, cluster_high, cluster_low, "
-            "cluster_range_adr, line_ok, touch_zones, overshoot_adr, slope, "
+            "cluster_range_adr, range_3bar_adr, line_ok, touch_zones, "
+            "overshoot_adr, slope, "
             "line_end, base_low, churn_l, sma20_rising, dryup FROM detections "
             "WHERE market = ? AND session = ? ORDER BY symbol",
             [market, session],
@@ -801,9 +809,10 @@ class Store:
                 symbol=r[0], session=session, detector_version=r[1], trigger=r[2],
                 stop=r[3], stopw_adr=r[4], base_len=r[5], move_gain=r[6], adr=r[7],
                 close=r[8], cluster_k=r[9], cluster_high=r[10], cluster_low=r[11],
-                cluster_range_adr=r[12], line_ok=r[13], touch_zones=r[14],
-                overshoot_adr=r[15], slope=r[16], line_end=r[17], base_low=r[18],
-                churn_l=r[19], sma20_rising=r[20], dryup=r[21],
+                cluster_range_adr=r[12], range_3bar_adr=r[13], line_ok=r[14],
+                touch_zones=r[15],
+                overshoot_adr=r[16], slope=r[17], line_end=r[18], base_low=r[19],
+                churn_l=r[20], sma20_rising=r[21], dryup=r[22],
             )
             for r in rows
         ]

--- a/backend/screener/store.py
+++ b/backend/screener/store.py
@@ -171,7 +171,9 @@ CREATE TABLE IF NOT EXISTS detections (
     cluster_range_adr  DOUBLE  NOT NULL,
     -- Base tightness, ungated: the trailing 3-bar range in ADR. Persisted because
     -- the rubric grades it (#154) — a breakdown must carry the value, not one
-    -- version's verdict about it. NULL on rows written before v10.
+    -- version's verdict about it. Declared NOT NULL for a database created from
+    -- this schema; on one migrated up to v10 the column arrives nullable, as
+    -- Store._migrate documents for every column it adds.
     range_3bar_adr     DOUBLE  NOT NULL,
     line_ok            BOOLEAN NOT NULL,
     touch_zones        INTEGER NOT NULL,

--- a/backend/tests/test_acceptance.py
+++ b/backend/tests/test_acceptance.py
@@ -32,7 +32,7 @@ def _det(symbol, *, stopw_adr=1.28, cluster_k=5, adr=0.06, base_len=10):
         trigger=100.0, stop=stopw_adr * adr * 98.0, stopw_adr=stopw_adr,
         base_len=base_len, move_gain=103.0, adr=adr, close=98.0,
         cluster_k=cluster_k, cluster_high=100.0, cluster_low=97.0,
-        cluster_range_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
+        cluster_range_adr=0.99, range_3bar_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
         slope=-0.001, line_end=99.9, base_low=97.0,
         churn_l=0.45, sma20_rising=True, dryup=0.90,
     )

--- a/backend/tests/test_api_seam.py
+++ b/backend/tests/test_api_seam.py
@@ -162,7 +162,7 @@ def _candidates_store() -> Store:
             trigger=100.0, stop=stop, stopw_adr=stop / adr_abs,
             base_len=30, move_gain=103.0, adr=adr, close=98.0,
             cluster_k=5, cluster_high=100.0, cluster_low=cluster_low,
-            cluster_range_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
+            cluster_range_adr=0.99, range_3bar_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
             slope=-0.001, line_end=99.9, base_low=cluster_low,
             churn_l=0.45, sma20_rising=True, dryup=0.90,
         )
@@ -245,7 +245,7 @@ def test_candidates_endpoint_folds_the_chart_facts_onto_the_row():
             symbol=symbol, session=sess, detector_version=DETECTOR_VERSION,
             trigger=100.0, stop=3.0, stopw_adr=3.0 / adr_abs,
             base_len=30, move_gain=103.0, adr=0.02, close=98.0,
-            cluster_k=5, cluster_high=100.0, cluster_low=97.0, cluster_range_adr=0.99,
+            cluster_k=5, cluster_high=100.0, cluster_low=97.0, cluster_range_adr=0.99, range_3bar_adr=0.99,
             line_ok=True, touch_zones=2, overshoot_adr=0.0, slope=-0.001,
             line_end=99.9, base_low=97.0, churn_l=0.45, sma20_rising=True, dryup=0.90,
         )
@@ -332,7 +332,7 @@ def _chart_store() -> Store:
         symbol="AAA", session=session, detector_version=DETECTOR_VERSION,
         trigger=100.0, stop=stop, stopw_adr=stop / (adr_val * 98.0),
         base_len=30, move_gain=103.0, adr=adr_val, close=98.0,
-        cluster_k=5, cluster_high=100.0, cluster_low=97.0, cluster_range_adr=0.99,
+        cluster_k=5, cluster_high=100.0, cluster_low=97.0, cluster_range_adr=0.99, range_3bar_adr=0.99,
         line_ok=True, touch_zones=2, overshoot_adr=0.0, slope=-0.001,
         line_end=99.9, base_low=97.0,
         churn_l=0.45, sma20_rising=True, dryup=0.90,

--- a/backend/tests/test_candidates.py
+++ b/backend/tests/test_candidates.py
@@ -20,6 +20,7 @@ def _det(
     trigger=100.0,
     close=98.0,
     cluster_low=97.0,
+    range_3bar_adr=0.99,
     adr=0.06,
     cluster_k=5,
     base_len=10,
@@ -38,7 +39,7 @@ def _det(
         trigger=trigger, stop=stop, stopw_adr=stop / adr_abs,
         base_len=base_len, move_gain=103.0, adr=adr, close=close,
         cluster_k=cluster_k, cluster_high=trigger, cluster_low=cluster_low,
-        cluster_range_adr=0.99, line_ok=line_ok, touch_zones=2, overshoot_adr=0.0,
+        cluster_range_adr=0.99, range_3bar_adr=range_3bar_adr, line_ok=line_ok, touch_zones=2, overshoot_adr=0.0,
         slope=-0.001, line_end=trigger - 0.1, base_low=cluster_low,
         churn_l=churn_l, sma20_rising=sma20_rising, dryup=dryup,
     )
@@ -71,12 +72,12 @@ def test_the_score_is_the_star_rubric_and_its_eight_row_breakdown():
     assert c.score == 4.5
     assert len(c.breakdown) == 8
     assert all(row.hit for row in c.breakdown)
-    assert sum(row.weight for row in c.breakdown if row.hit) == 9
+    assert sum(row.points for row in c.breakdown) == 9
 
 
 def test_the_list_sorts_by_star_score_descending():
     strong = _det("LOW", adr=0.06)                       # 4.5★ ceiling
-    weak = _det("HIGH", adr=0.04, cluster_k=4)  # loses tightness (×2) and ADR (×2)
+    weak = _det("HIGH", adr=0.04, range_3bar_adr=2.5)  # loses tightness (×2) and ADR (×2)
     rows = build_candidates([weak, strong], _decile("LOW") + _decile("HIGH"), {}, {})
     # Sorted by score, not by ticker — the strong name leads the weaker one.
     assert [c.symbol for c in rows] == ["LOW", "HIGH"]
@@ -231,3 +232,23 @@ def test_dollar_volume_and_sector_degrade_to_none():
     assert c.sector is None
     assert c.decile_ranks == {}
     assert c.new_tonight is True  # empty prev set → every name is new
+
+
+def test_the_row_publishes_what_each_dimension_earned_and_what_it_was_graded_on():
+    # Since rubric v3 the Tightness dimension is graded (#154), so `hit × weight`
+    # no longer totals the breakdown. The payload carries the points each row
+    # earned and the value the graded one was read off, or a client reconstructing
+    # the star from the table would disagree with the star it sorted by.
+    ranks = _decile("AAA")
+    [c] = build_candidates([_det("AAA", range_3bar_adr=1.60)], ranks, {}, {})
+    tight = next(row for row in c.breakdown if row.dimension == "Tightness")
+    assert tight.value == 1.60
+    assert tight.weight == 2 and tight.points == 1     # graded, part of its weight
+    assert tight.hit is True                            # v2's cluster_k >= 5 verdict
+    # Every other row is boolean: points is weight when it hits, nothing when not.
+    for row in c.breakdown:
+        if row.dimension != "Tightness":
+            assert row.value is None
+            assert row.points == (row.weight if row.hit else 0)
+    # And the table still adds up to the star the row is sorted by.
+    assert sum(row.points for row in c.breakdown) / 2 == c.score

--- a/backend/tests/test_chart.py
+++ b/backend/tests/test_chart.py
@@ -31,7 +31,7 @@ def _det(symbol, session, *, trigger=100.0, close=98.0, cluster_low=97.0, adr=0.
         trigger=trigger, stop=stop, stopw_adr=stop / adr_abs,
         base_len=30, move_gain=103.0, adr=adr, close=close,
         cluster_k=5, cluster_high=trigger, cluster_low=cluster_low,
-        cluster_range_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
+        cluster_range_adr=0.99, range_3bar_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
         slope=-0.001, line_end=trigger - 0.1, base_low=cluster_low,
         churn_l=0.45, sma20_rising=True, dryup=0.90,
     )

--- a/backend/tests/test_detection.py
+++ b/backend/tests/test_detection.py
@@ -22,7 +22,9 @@ from screener.detection import (
     DETECTOR_VERSION,
     K_MAX,
     K_MIN,
+    OUTLIER_MULT,
     STOP_CONVENTION_ADR,
+    TIGHT_MULT,
     TOP_DECILE,
     Rank,
     _churn_l,
@@ -112,8 +114,8 @@ def test_proposed_stop_is_the_traders_convention_not_the_cluster_low():
 
 def test_stop_width_does_not_move_with_base_tightness():
     # The two quantities the domain model keeps apart (issue #147). Base tightness
-    # is setup geometry — the trailing window's span in ADR, what TIGHT_MULT gates
-    # and the rubric's ×2 dimension scores. Stop width is his risk — the trigger-to-
+    # is setup geometry — the trailing window's span in ADR, which the rubric's ×2
+    # dimension grades. Stop width is his risk — the trigger-to-
     # stop distance, fixed at the convention. Findings §3b measured them 3.8× apart
     # on the same 649 entries; here they are wired apart, so a future edit deriving
     # the stop from the base geometry again fails this test.
@@ -165,12 +167,68 @@ def test_a_name_not_caught_up_to_the_ma_is_not_a_detection():
     assert detect("AAA", _bars(hlc), CAL[102]) is None
 
 
-def test_a_name_with_no_tight_cluster_is_not_a_detection():
-    # A wide, ragged top: no trailing 3-7 bar window is tight enough.
+def test_a_name_genuinely_in_motion_is_not_a_detection():
+    # A wide, ragged top: the trailing 3-bar range is far past OUTLIER_MULT, so the
+    # far-outlier guard rejects it. This is the only tightness rejection left.
     hlc = [(50.5, 49.5, 50.0)] * 90
     for h in (60, 55, 62, 54, 63, 56, 61):  # last bars swing ~15% of price
         hlc.append((h + 0.5, h - 0.5, h))
     assert detect("AAA", _bars(hlc), CAL[96]) is None
+
+
+# -- the cluster gate is a far-outlier guard, not a tightness cut (#145/#154) --
+
+
+def test_a_base_past_the_old_hard_cut_now_detects():
+    # The 1.5×ADR hard rejection is gone. A top wandering wide enough that no 3-7
+    # bar window sits under TIGHT_MULT is still a detection, because how quiet the
+    # base is became a graded rubric input rather than a gate.
+    d = detect("AAA", _bars(_wandering_top_series(0.5)), CAL[104])
+    assert d is not None
+    assert d.range_3bar_adr > TIGHT_MULT       # the old gate would have rejected it
+    assert d.range_3bar_adr < OUTLIER_MULT     # and the guard admits it
+    # With no window under TIGHT_MULT the 3-bar window *is* the cluster — the
+    # tightest one there is — so k is K_MIN and the span is the 3-bar range itself.
+    assert d.cluster_k == K_MIN
+    assert d.cluster_range_adr == d.range_3bar_adr
+    assert d.trigger == d.cluster_high         # the identity is untouched
+
+
+def test_a_base_past_the_far_outlier_guard_is_still_rejected():
+    # Names with no base at all still fail. The guard is sited where findings §3b's
+    # outcome table turns negative (the 3.0+ bucket), not at a percentile of his
+    # habits (#143's rule).
+    d = detect("AAA", _bars(_wandering_top_series(1.6)), CAL[104])
+    assert d is None
+    # ... and it is the 3-bar range the guard tested, past OUTLIER_MULT.
+    bars = _bars(_wandering_top_series(1.6))
+    high = [b.high for b in bars]
+    low = [b.low for b in bars]
+    d_ok = detect("AAA", _bars(_wandering_top_series(0.5)), CAL[104])
+    adr_abs = d_ok.adr * bars[104].close
+    assert range_3bar_adr(high, low, 104, adr_abs) > OUTLIER_MULT
+
+
+def test_a_name_that_cleared_the_old_cut_is_unchanged_by_the_guard():
+    # The loosening adds names and moves none: a name already inside TIGHT_MULT
+    # reports the same window, the same span and the same trigger as before.
+    d = detect("AAA", _bars(_base_series()), CAL[104])
+    assert d.cluster_k == K_MAX                # still the largest tight window
+    assert d.cluster_range_adr <= TIGHT_MULT
+    assert d.trigger == 100.5
+    # Its ungated 3-bar range is the tighter, separate number the rubric grades.
+    assert d.range_3bar_adr <= d.cluster_range_adr
+
+
+def test_every_detection_persists_its_ungated_three_bar_range():
+    # The rubric grades the value, so the row has to carry it (#154) — and it must
+    # be the *ungated* measure, recomputable from the bars by the detector's own
+    # diagnostic.
+    bars = _bars(_base_series())
+    d = detect("AAA", bars, CAL[104])
+    high = [b.high for b in bars]
+    low = [b.low for b in bars]
+    assert d.range_3bar_adr == range_3bar_adr(high, low, 104, d.adr * d.close)
 
 
 def test_range_3bar_adr_reports_the_trailing_3_bar_range():

--- a/backend/tests/test_detection.py
+++ b/backend/tests/test_detection.py
@@ -169,14 +169,14 @@ def test_a_name_not_caught_up_to_the_ma_is_not_a_detection():
 
 def test_a_name_genuinely_in_motion_is_not_a_detection():
     # A wide, ragged top: the trailing 3-bar range is far past OUTLIER_MULT, so the
-    # far-outlier guard rejects it. This is the only tightness rejection left.
+    # far-outlier guard rejects it. The only base-tightness rejection left.
     hlc = [(50.5, 49.5, 50.0)] * 90
     for h in (60, 55, 62, 54, 63, 56, 61):  # last bars swing ~15% of price
         hlc.append((h + 0.5, h - 0.5, h))
     assert detect("AAA", _bars(hlc), CAL[96]) is None
 
 
-# -- the cluster gate is a far-outlier guard, not a tightness cut (#145/#154) --
+# -- the cluster condition is a far-outlier guard, not a base-tightness cut ----
 
 
 def test_a_base_past_the_old_hard_cut_now_detects():

--- a/backend/tests/test_detection_store.py
+++ b/backend/tests/test_detection_store.py
@@ -27,7 +27,7 @@ def _det(symbol, *, trigger=100.5, cluster_low=99.5, line_ok=True):
         stopw_adr=(trigger - cluster_low) / trigger / 0.01,
         base_len=30, move_gain=103.0, adr=0.01, close=100.0,
         cluster_k=7, cluster_high=trigger, cluster_low=cluster_low,
-        cluster_range_adr=0.99, line_ok=line_ok, touch_zones=2, overshoot_adr=0.0,
+        cluster_range_adr=0.99, range_3bar_adr=0.99, line_ok=line_ok, touch_zones=2, overshoot_adr=0.0,
         slope=-0.001, line_end=100.4, base_low=99.5,
         churn_l=0.45, sma20_rising=True, dryup=0.90,
     )

--- a/backend/tests/test_digest.py
+++ b/backend/tests/test_digest.py
@@ -21,8 +21,8 @@ TODAY = date(2026, 8, 5)
 
 
 def _det(symbol, *, trigger=100.0, adr=0.06, close=98.0, cluster_low=97.0,
-         cluster_k=5, base_len=10, churn_l=0.45, sma20_rising=True, dryup=0.90,
-         line_ok=True):
+         cluster_k=5, range_3bar_adr=0.99, base_len=10, churn_l=0.45,
+         sma20_rising=True, dryup=0.90, line_ok=True):
     """Yesterday's detection: the setup whose trigger the break tests against."""
     stop = trigger - cluster_low
     return Detection(
@@ -30,7 +30,7 @@ def _det(symbol, *, trigger=100.0, adr=0.06, close=98.0, cluster_low=97.0,
         trigger=trigger, stop=stop, stopw_adr=stop / trigger / adr,
         base_len=base_len, move_gain=103.0, adr=adr, close=close,
         cluster_k=cluster_k, cluster_high=trigger, cluster_low=cluster_low,
-        cluster_range_adr=0.99, line_ok=line_ok, touch_zones=2, overshoot_adr=0.0,
+        cluster_range_adr=0.99, range_3bar_adr=range_3bar_adr, line_ok=line_ok, touch_zones=2, overshoot_adr=0.0,
         slope=-0.001, line_end=trigger - 0.1, base_low=cluster_low,
         churn_l=churn_l, sma20_rising=sma20_rising, dryup=dryup,
     )

--- a/backend/tests/test_digest_pipeline.py
+++ b/backend/tests/test_digest_pipeline.py
@@ -31,7 +31,7 @@ def _det(symbol, *, session=YESTERDAY, trigger=100.0):
         symbol=symbol, session=session, detector_version=DETECTOR_VERSION,
         trigger=trigger, stop=3.0, stopw_adr=0.5, base_len=10, move_gain=103.0,
         adr=0.06, close=98.0, cluster_k=5, cluster_high=trigger, cluster_low=97.0,
-        cluster_range_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
+        cluster_range_adr=0.99, range_3bar_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
         slope=-0.001, line_end=trigger - 0.1, base_low=97.0,
         churn_l=0.45, sma20_rising=True, dryup=0.90,
     )

--- a/backend/tests/test_digest_store.py
+++ b/backend/tests/test_digest_store.py
@@ -27,7 +27,7 @@ def _det(symbol, *, trigger=100.0):
         symbol=symbol, session=date(2026, 8, 4), detector_version=DETECTOR_VERSION,
         trigger=trigger, stop=3.0, stopw_adr=0.5, base_len=10, move_gain=103.0,
         adr=0.06, close=98.0, cluster_k=5, cluster_high=trigger, cluster_low=97.0,
-        cluster_range_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
+        cluster_range_adr=0.99, range_3bar_adr=0.99, line_ok=True, touch_zones=2, overshoot_adr=0.0,
         slope=-0.001, line_end=trigger - 0.1, base_low=97.0,
         churn_l=0.45, sma20_rising=True, dryup=0.90,
     )

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -1325,6 +1325,7 @@ def _det(symbol: str, cluster_k: int) -> Detection:
         cluster_high=100.0,
         cluster_low=95.0,
         cluster_range_adr=0.5,
+        range_3bar_adr=0.5,
         line_ok=True,
         touch_zones=2,
         overshoot_adr=0.0,
@@ -1593,7 +1594,7 @@ def test_placement_scores_one_field_under_both_rubrics_stamped_by_version():
     version stamp; the live pair equals the report's headline picks/field; and with
     the field fixed, only the weights move — Base length ×0→×1 lifts his pick by
     exactly half a star under the old rubric."""
-    from screener.score import RUBRIC_VERSION, RUBRIC_WEIGHTS, stars_under
+    from screener.score import RUBRICS, RUBRIC_VERSION, stars_under
 
     session = date(2020, 6, 1)
     det = _det("BASE", cluster_k=6)  # Base length, ADR, Orderliness all hit
@@ -1614,19 +1615,19 @@ def test_placement_scores_one_field_under_both_rubrics_stamped_by_version():
     report = build_placement_report([trade], calendar, [field], blind_spot_count=0)
 
     # Both rubric versions are reported over the SAME field, each stamped.
-    assert {r.rubric_version for r in report.by_rubric} == {1, RUBRIC_VERSION}
+    assert {r.rubric_version for r in report.by_rubric} == set(RUBRICS)
     live = next(r for r in report.by_rubric if r.rubric_version == RUBRIC_VERSION)
     old = next(r for r in report.by_rubric if r.rubric_version == 1)
     # The live-rubric pair *is* the report's headline picks/field — one source.
     assert live.picks.counts == report.picks.counts
     assert live.field.counts == report.field.counts
     # Field held fixed, only weights move: Base length ×0→×1 is +0.5 star under v1.
-    v2_star = stars_under(scored.score.breakdown, RUBRIC_WEIGHTS[RUBRIC_VERSION])
-    v1_star = stars_under(scored.score.breakdown, RUBRIC_WEIGHTS[1])
-    assert v1_star == v2_star + 0.5
-    assert live.picks.counts[v2_star] == 1
+    live_star = stars_under(scored.score.breakdown, RUBRICS[RUBRIC_VERSION])
+    v1_star = stars_under(scored.score.breakdown, RUBRICS[1])
+    assert v1_star == live_star + 0.5
+    assert live.picks.counts[live_star] == 1
     assert old.picks.counts[v1_star] == 1
-    assert live.field.counts[v2_star] == 1
+    assert live.field.counts[live_star] == 1
     assert old.field.counts[v1_star] == 1
 
 
@@ -2077,9 +2078,11 @@ def test_run_study_writes_human_and_machine_readable_outputs(tmp_path, store: St
     # change and no star figure is quoted without its stamp (#138).
     from screener.score import RUBRIC_VERSION
 
+    from screener.score import RUBRICS
+
     by_rubric = raw["placement"]["by_rubric"]
     stamps = {r["rubric_version"] for r in by_rubric}
-    assert stamps == {1, RUBRIC_VERSION}
+    assert stamps == set(RUBRICS)
     for r in by_rubric:
         assert "picks" in r and "field" in r and "total" in r["picks"]
         # The board figure is paired too — a rubric reorders the field around a

--- a/backend/tests/test_score.py
+++ b/backend/tests/test_score.py
@@ -24,6 +24,7 @@ from screener.score import DIMENSIONS, RUBRIC_VERSION, star_score
 def _det(
     *,
     cluster_k=5,
+    range_3bar_adr=0.80,
     churn_l=0.45,
     base_len=10,
     sma20_rising=True,
@@ -36,7 +37,8 @@ def _det(
         symbol="AAA", session=date(2026, 8, 5), detector_version=DETECTOR_VERSION,
         trigger=100.0, stop=3.0, stopw_adr=1.5, base_len=base_len, move_gain=103.0,
         adr=adr, close=98.0, cluster_k=cluster_k, cluster_high=100.0,
-        cluster_low=97.0, cluster_range_adr=0.99, line_ok=True, touch_zones=2,
+        cluster_low=97.0, cluster_range_adr=0.99, range_3bar_adr=range_3bar_adr,
+        line_ok=True, touch_zones=2,
         overshoot_adr=0.0, slope=-0.001, line_end=99.9, base_low=97.0,
         churn_l=churn_l, sma20_rising=sma20_rising, dryup=dryup,
     )
@@ -56,7 +58,7 @@ def test_the_permanent_half_star_floor():
     # Prior move fires for every detection by construction, so its one point is a
     # floor: a detection missing every other dimension still scores 0.5, never 0.
     stars, _ = star_score(
-        _det(cluster_k=4, churn_l=0.10, base_len=20, sma20_rising=False,
+        _det(range_3bar_adr=2.90, churn_l=0.10, base_len=20, sma20_rising=False,
              dryup=0.99, adr=0.04),
         prior_move=True, sector_share=0.05,
     )
@@ -80,10 +82,22 @@ def test_orderliness_is_now_single_weighted_and_moves_half_a_star():
 
 
 def test_tightness_stays_double_weighted_and_moves_a_full_star():
+    # Still ×2 — but graded (#154), so the full star is the span between the
+    # quietest band and the widest, not between two cluster_k values.
     base = dict(prior_move=True, sector_share=0.20)
-    with_tight = star_score(_det(cluster_k=5), **base)[0]
-    without_tight = star_score(_det(cluster_k=4), **base)[0]
+    with_tight = star_score(_det(range_3bar_adr=0.80), **base)[0]
+    without_tight = star_score(_det(range_3bar_adr=2.80), **base)[0]
     assert with_tight - without_tight == 1.0
+
+
+def test_cluster_k_no_longer_moves_the_score():
+    # v2 scored `cluster_k >= 5`; v3 grades the three-bar range instead. The row
+    # still records the old verdict (so v2 can re-score it), but the live rubric
+    # does not read it.
+    base = dict(prior_move=True, sector_share=0.20)
+    assert star_score(_det(cluster_k=7), **base)[0] == star_score(
+        _det(cluster_k=3), **base
+    )[0]
 
 
 def test_base_length_is_weighted_zero_and_never_moves_the_score():
@@ -108,15 +122,16 @@ def test_the_thresholds_are_the_published_set():
     # published boundary and denies just under it.
     def stars_with(**kw):
         return star_score(_det(**{k: v for k, v in kw.items() if k in
-                                  ("cluster_k", "churn_l", "base_len",
-                                   "sma20_rising", "dryup", "adr")}),
+                                  ("cluster_k", "range_3bar_adr", "churn_l",
+                                   "base_len", "sma20_rising", "dryup", "adr")}),
                           prior_move=kw.get("prior_move", True),
                           sector_share=kw.get("sector_share", 0.20))[0]
 
     all_hit = stars_with()
     assert all_hit == 4.5
-    # cluster_k >= 5 (×2) ; dryup <= 0.95 (×1) ; adr >= 0.05 (×2)
-    assert stars_with(cluster_k=4) == 3.5
+    # base tightness graded on the 3-bar range (×2) ; dryup <= 0.95 (×1) ;
+    # adr >= 0.05 (×2)
+    assert stars_with(range_3bar_adr=1.50) == 4.0
     assert stars_with(dryup=0.96) == 4.0
     assert stars_with(adr=0.05) == 4.5          # inclusive at the boundary
     assert stars_with(adr=0.049) == 3.5         # ×2, so a full star
@@ -154,34 +169,127 @@ def test_a_rubric_version_stamp_exists():
     assert RUBRIC_VERSION >= 2
 
 
-def test_rubric_weights_carry_the_superseded_v1_alongside_the_live_v2():
-    # The paired A2 re-run (#136) re-scores the *same* field under both rubrics so
-    # a rubric change is separated from a field change. That needs the old (v1)
-    # weights kept beside the live ones, keyed by version stamp.
-    from screener.score import RUBRIC_WEIGHTS
+def test_the_rubric_table_carries_the_superseded_versions_alongside_the_live_one():
+    # The paired A2 re-run (#136) re-scores the *same* field under several rubrics
+    # so a rubric change is separated from a field change. That needs every
+    # superseded version kept beside the live one, keyed by version stamp.
+    from screener.score import RUBRICS
 
-    assert set(RUBRIC_WEIGHTS) >= {1, RUBRIC_VERSION}
-    v1, v2 = RUBRIC_WEIGHTS[1], RUBRIC_WEIGHTS[RUBRIC_VERSION]
+    assert set(RUBRICS) >= {1, 2, RUBRIC_VERSION}
+    v1, v3 = RUBRICS[1].weights, RUBRICS[RUBRIC_VERSION].weights
     # v1 is the ten-point rubric: Tightness/Orderliness ×2, everything else ×1.
     assert v1 == {
         "Tightness": 2, "Orderliness": 2, "Prior move": 1, "Base length": 1,
         "MA support": 1, "Volume": 1, "Sector": 1, "ADR": 1,
     }
     assert sum(v1.values()) == 10
-    # v2 mirrors the live DIMENSIONS table, and totals nine.
-    assert v2 == {name: weight for name, weight in DIMENSIONS}
-    assert sum(v2.values()) == 9
+    # v3 mirrors the live DIMENSIONS table, and totals nine.
+    assert v3 == {name: weight for name, weight in DIMENSIONS}
+    assert sum(v3.values()) == 9
 
 
-def test_stars_under_rescore_a_breakdown_by_an_arbitrary_weight_map():
-    # stars_under re-totals a breakdown's *hit booleans* under a supplied weight
-    # map, so one field's detections can be scored under either rubric without
-    # re-detecting. Under the live weights it reproduces star_score exactly.
-    from screener.score import RUBRIC_WEIGHTS, stars_under
+def test_stars_under_rescore_a_breakdown_under_an_arbitrary_rubric():
+    # stars_under re-totals a breakdown under a supplied rubric, so one field's
+    # detections can be scored under any version without re-detecting. Under the
+    # live rubric it reproduces star_score exactly.
+    from screener.score import RUBRICS, stars_under
 
     det = _det(adr=0.06, churn_l=0.45, base_len=10)  # ADR + Orderliness + Base all hit
     stars, breakdown = star_score(det, prior_move=True, sector_share=0.20)
-    assert stars_under(breakdown, RUBRIC_WEIGHTS[RUBRIC_VERSION]) == stars
+    assert stars_under(breakdown, RUBRICS[RUBRIC_VERSION]) == stars
     # Under v1 the same booleans score differently: ADR was ×1 not ×2, Orderliness
     # ×2 not ×1 (net 0), and Base length ×1 not ×0 (+1 point → +0.5 star).
-    assert stars_under(breakdown, RUBRIC_WEIGHTS[1]) == stars + 0.5
+    assert stars_under(breakdown, RUBRICS[1]) == stars + 0.5
+
+
+# -- v3: Tightness graded, and the value persisted so v2 still re-scores ------
+
+
+def test_tightness_is_graded_from_the_three_bar_range_not_the_cluster_k():
+    # #145/#154: the ×2 dimension stops being `cluster_k >= 5` and grades the
+    # real-valued base tightness the row carries. §3b's own bucket edges: two
+    # points under 1.0 ADR, one through 2.0, nothing beyond.
+    base = dict(prior_move=True, sector_share=0.20)
+    quiet = star_score(_det(range_3bar_adr=0.80), **base)[0]
+    middling = star_score(_det(range_3bar_adr=1.60), **base)[0]
+    wide = star_score(_det(range_3bar_adr=2.50), **base)[0]
+    assert quiet - middling == 0.5
+    assert middling - wide == 0.5
+
+
+def test_the_tightness_bands_are_inclusive_at_their_published_edges():
+    base = dict(prior_move=True, sector_share=0.20)
+    assert star_score(_det(range_3bar_adr=1.00), **base)[0] == 4.5
+    assert star_score(_det(range_3bar_adr=1.01), **base)[0] == 4.0
+    assert star_score(_det(range_3bar_adr=2.00), **base)[0] == 4.0
+    assert star_score(_det(range_3bar_adr=2.01), **base)[0] == 3.5
+
+
+def test_the_graded_dimension_keeps_the_nine_point_ceiling_and_integral_points():
+    # Bands, not a fraction: the ceiling stays nine points and every star lands on
+    # a half — so the "n/9 ÷ 2" arithmetic and every star display are untouched.
+    stars, breakdown = star_score(
+        _det(range_3bar_adr=0.50), prior_move=True, sector_share=0.20
+    )
+    assert stars == 4.5
+    assert sum(d.weight for d in breakdown) == 9
+    assert (stars * 2) % 1 == 0
+
+
+def test_the_breakdown_persists_the_value_not_just_the_verdict():
+    # The row carries the graded quantity itself, so each rubric version owns its
+    # own value → points mapping (#154). Only Tightness is graded, so it is the
+    # only row carrying a value.
+    _, breakdown = star_score(
+        _det(range_3bar_adr=1.31), prior_move=True, sector_share=0.20
+    )
+    rows = {d.dimension: d for d in breakdown}
+    assert rows["Tightness"].value == 1.31
+    assert all(d.value is None for d in breakdown if d.dimension != "Tightness")
+
+
+def test_a_v3_row_still_carries_the_v2_tightness_verdict():
+    # v2's rule was `cluster_k >= 5`, which no value can reconstruct — so the row
+    # keeps the boolean alongside the value. Both are properties of the setup.
+    base = dict(prior_move=True, sector_share=0.20)
+    _, long_k = star_score(_det(cluster_k=5, range_3bar_adr=2.50), **base)
+    _, short_k = star_score(_det(cluster_k=4, range_3bar_adr=0.50), **base)
+    assert next(d for d in long_k if d.dimension == "Tightness").hit is True
+    assert next(d for d in short_k if d.dimension == "Tightness").hit is False
+
+
+def test_a_v2_rescore_of_a_v3_row_reproduces_the_paired_run_exactly():
+    # The #136 pairing scores one field under both rubrics without re-detecting.
+    # A graded v3 row must not break that: re-scored under v2 the Tightness
+    # dimension goes back to being the boolean, whatever v3 graded it.
+    from screener.score import RUBRICS, stars_under
+
+    base = dict(prior_move=True, sector_share=0.20)
+    # k = 4 (v2 withholds Tightness) but a 0.5 ADR three-bar range (v3 awards both
+    # points): the two rubrics disagree by a full star, in the right direction.
+    stars_v3, breakdown = star_score(_det(cluster_k=4, range_3bar_adr=0.50), **base)
+    assert stars_under(breakdown, RUBRICS[RUBRIC_VERSION]) == stars_v3 == 4.5
+    assert stars_under(breakdown, RUBRICS[2]) == 3.5
+    # v1's ten-point table re-totals the same booleans as it always did.
+    assert stars_under(breakdown, RUBRICS[1]) == 4.0
+
+
+def test_the_rubric_table_retains_the_boolean_v2_unedited():
+    from screener.score import RUBRICS
+
+    assert RUBRIC_VERSION == 3
+    # v2 is retained live for the paired comparison, and is still the nine-point
+    # boolean table — bumping the version must not edit it.
+    assert RUBRICS[2].weights == {name: weight for name, weight in DIMENSIONS}
+    assert RUBRICS[2].bands == {}
+    # Only v3 grades, and only Tightness.
+    assert set(RUBRICS[RUBRIC_VERSION].bands) == {"Tightness"}
+
+
+def test_a_graded_rubric_falls_back_to_the_boolean_when_a_row_carries_no_value():
+    # A breakdown written before the value existed (or struck by the replay) still
+    # re-totals under v3 rather than silently scoring zero.
+    from screener.score import RUBRICS, Dimension, stars_under
+
+    valueless = [Dimension("Tightness", 2, True), Dimension("ADR", 2, True)]
+    assert stars_under(valueless, RUBRICS[RUBRIC_VERSION]) == 2.0

--- a/backend/tests/test_score.py
+++ b/backend/tests/test_score.py
@@ -1,11 +1,12 @@
-"""The star score: eight boolean dimensions, nine weighted points (spec §4.7,
-PRD #138).
+"""The star score: eight dimensions — seven boolean, one banded — nine weighted
+points (spec §4.7, PRD #138, Tightness graded by #154).
 
 `points ÷ 2` = stars, real range **0.5–4.5** (not 0–5): `Prior move` fires for
 every detection by construction so half a star is a permanent floor, and
-`Base length` is weighted zero so the ninth point can never be earned. Booleans,
-not continuous, because the score is the default sort of the only list in the app
-and a sort key you cannot audit is one you will not trust. The score knows nothing
+`Base length` is weighted zero so the ninth point can never be earned. Auditable
+rather than continuous — the one graded dimension is banded to integral points —
+because the score is the default sort of the only list in the app and a sort key
+you cannot audit is one you will not trust. The score knows nothing
 about the stop and nothing about the regime — every input below is a base signal,
 a rank percentile or a sector share.
 
@@ -279,8 +280,14 @@ def test_the_rubric_table_retains_the_boolean_v2_unedited():
 
     assert RUBRIC_VERSION == 3
     # v2 is retained live for the paired comparison, and is still the nine-point
-    # boolean table — bumping the version must not edit it.
-    assert RUBRICS[2].weights == {name: weight for name, weight in DIMENSIONS}
+    # boolean table PRD #138 shipped. Spelled out rather than compared against
+    # DIMENSIONS: a superseded version records what shipped, so this assertion has
+    # to fail if a future weight edit drags v2 along with the live table.
+    assert RUBRICS[2].weights == {
+        "Tightness": 2, "Orderliness": 1, "Prior move": 1, "Base length": 0,
+        "MA support": 1, "Volume": 1, "Sector": 1, "ADR": 2,
+    }
+    assert sum(RUBRICS[2].weights.values()) == 9
     assert RUBRICS[2].bands == {}
     # Only v3 grades, and only Tightness.
     assert set(RUBRICS[RUBRIC_VERSION].bands) == {"Tightness"}

--- a/docs/adr/0002-what-evidence-licenses-loosening-a-gate.md
+++ b/docs/adr/0002-what-evidence-licenses-loosening-a-gate.md
@@ -78,6 +78,10 @@ the one-sided number the original rule was written to prevent.
 - The first change this licenses is not made here. ADR 0003 applies the four conditions to the
   decile gate and reaches `proposed`, not `accepted`, because condition 2 is only 46%
   measured pending #131.
+- The rule is stated in terms of *kinds* of gate, and so says nothing about a change that
+  alters a gate's **shape** rather than its position. ADR 0004 is the companion covering that
+  case — a threshold replaced by a graded rubric input plus an outlier guard — and it is a
+  companion rather than a correction: nothing in it says this rule is wrong.
 - The rule is stated in terms of *kinds* of gate, so the liquidity floor — also
   cross-sectional through its hysteresis band — falls under the same four conditions if it is
   ever argued about. It currently costs 9% and nobody is arguing.

--- a/docs/adr/0004-replacing-a-threshold-with-a-graded-input.md
+++ b/docs/adr/0004-replacing-a-threshold-with-a-graded-input.md
@@ -1,0 +1,109 @@
+---
+status: accepted
+---
+
+# Replacing a threshold with a graded input
+
+ADR 0002 says what evidence licenses **loosening** a gate. It does not say what licenses
+*changing the shape* of one, and #145 needed exactly that: the argument for restructuring base
+tightness was never that the dimension is null — it is the best-evidenced dimension in the
+study — but that a pass/fail line is the wrong encoding for what was measured.
+
+Left in a docstring, that argument reads as a gate loosening that walked around the rule. This
+ADR records it as a decision, with the conditions that have to hold before it can be reached
+for again.
+
+## What the rule says, and why it does not fit as written
+
+ADR 0002's **score-dimension limb**: a dimension may be loosened only when A3 shows it has no
+signal *and* real spread. Findings §3a applied that limb to `TIGHT_MULT` and refused the
+loosening, correctly — Tightness is §5b's +20.8pp selector, so the precondition fails outright.
+
+ADR 0002's **cross-sectional limb** does not apply: the cluster cut measures the name against
+itself, not against the field. And that limb's own condition 3 points back the other way —
+"a threshold move still requires the score-dimension limb above".
+
+So on the face of it `TIGHT_MULT 1.5 → OUTLIER_MULT 3.0` is a threshold move governed by a
+limb whose precondition is not met, and is not licensed. **That reading is right about the
+threshold and wrong about the change**, because the change is not a threshold move with the
+shape held fixed. The gate was removed. What replaced it is two different objects doing two
+different jobs: a graded rubric input across the range where the signal varies, and a far
+outlier guard where it does not.
+
+## Decided (#145, implemented in #154)
+
+**A threshold may be replaced by a graded input plus an outlier guard when all four hold.**
+
+1. **The dimension has demonstrated signal.** Not a null — the opposite of the score-dimension
+   limb's precondition. A null dimension should be weighted down or dropped, never elaborated.
+   Tightness has selection signal (§5b, +20.8pp) *and* outcome signal (§3b).
+2. **The outcome relation is smooth over the gated range, with no feature at the line.** This
+   is the load-bearing condition and it is what distinguishes this from a loosening. It is
+   #143's test, run in the other direction: that study set a *threshold* for entry-to-MA
+   distance because the outcome data has a cliff there, and refused to site it at a percentile
+   of his habits. §3b's table has no cliff anywhere — mean R declines monotonically and the
+   decline through 1.5 is indistinguishable from the decline through 1.0 or 2.0 — so the same
+   test that licensed a threshold there forbids one here.
+3. **The dimension's weight does not move.** A shape change and a weight change must not ride
+   together, or neither is attributable. Tightness stayed ×2.
+4. **The population cost is stated**, as ADR 0002 condition 4 requires of any widening: how
+   many more names the change admits, against what it recovers. Measured for #154 at **+111.3
+   detections per session (+123%)**, or 0.66 additional names per session per executed trade
+   recovered — reported in findings §3b beside the recall.
+
+**The guard itself is a magnitude, and ADR 0001 does not license magnitudes from the replay.**
+"The replay licenses the *direction* of a change, never its *magnitude*" (#128 Q2) is why the
+rubric's weights are read off the *ordering* of the selection gaps and never their size.
+`OUTLIER_MULT = 3.0` is a size. It is adopted anyway, under one explicit condition:
+
+- **A guard sited on a magnitude is provisional, and carries its n.** 3.0 is sited on the only
+  feature §3b's outcome table offers — the one bucket where mean R turns negative — and that
+  bucket is **10 trades**. The constant is published as provisional in `detection.py`,
+  `CONTEXT.md` and findings §3b, it is not to be swept or tuned on an in-sample number, and it
+  is re-derived by the out-of-sample backtest (`docs/out-of-sample-backtest-plan.md`), which
+  builds the denominator the negative tail needs.
+
+The graded **bands** are not in that position: their edges (1.0 and 2.0 ADR) are §3b's own
+published bucket boundaries and the points follow the *ordering* of the buckets, so they sit
+inside ADR 0001's constraint as the weights do.
+
+## Considered options
+
+- **Leave the threshold at 1.5.** §3a's verdict, and correct on the evidence it had. Rejected
+  once §3b measured the shape of the signal: the cut declines 35.6% of his own entries carrying
+  17.4% of his summed R in order to express a quantity that varies smoothly, and the study now
+  says the smoothness is real rather than unmeasured.
+- **Move the threshold to a looser value.** The change ADR 0002 actually forbids, and rightly:
+  it keeps the wrong shape, needs a magnitude the replay cannot license, and buys recall with
+  nothing on the other side of the ledger.
+- **Grade the dimension with no guard at all.** Rejected. A name with no quiet stretch is not a
+  base at a low score, it is not a base — and the rubric would be asked to express, on a
+  bounded scale, a distinction that is categorical.
+- **Amend ADR 0002 rather than add this one.** Rejected: 0002 answers "what licenses a
+  loosening" and that answer is unchanged. This is a companion, not a correction. The
+  precedent for correcting a rule in place is 0002 itself replacing §7's carve-out, which was
+  a case of the earlier rule being *wrong*; nothing here says 0002 is wrong.
+
+## Consequences
+
+- **The detector's population changed, so every field-derived figure is re-pinned.**
+  `DETECTOR_VERSION` is 2, and rows from v1 and v2 are drawn from different populations — the
+  stamp exists so that comparison cannot happen silently. Findings §3's detection row, §3's
+  condition table and §4's `in_field` anchor (104 → **159 of 656**) are re-pinned from the
+  2026-08-22 re-run.
+- **Work moved from the gate to the sort key.** The names the guard admits are the ones the
+  graded dimension scores low, so they arrive at the bottom of the list rather than beside his
+  own setups. That is only a good trade if the sort key is trusted, which is why the grade is
+  **banded to integral points** and published on the breakdown — a partial score has to read
+  as a measurement the user can check, not as a number that appeared.
+- **A graded dimension constrains what a breakdown row may store.** The row carries the
+  *value*; the rubric version owns the value → points mapping. Storing a grade would make a v2
+  re-score of a v3 row impossible and silently break the paired A2 re-run (#136), which exists
+  precisely to separate a rubric change from a field change. See `screener.score.Rubric`.
+- **This is hard to reverse in the direction that matters**, for the same reason ADR 0002 gives:
+  every digest written after it freezes scores computed over a different field, and tightening
+  back does not recover the record.
+- **Condition 2 is the one that will be argued about.** "No feature in the outcome data" is a
+  judgement over a table, not a test with a p-value, and §3b's is a side-car prototype on 649
+  trades in one regime (§8). A future dataset that finds a cliff in the tightness relation
+  would re-open this, and the honest response then is a threshold, not a defence of the grade.

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -224,7 +224,7 @@ detects must land *before* the denominator is built, or the run is stale on arri
 | Ticket | Relation | Land by |
 | --- | --- | --- |
 | **#139** — match a trade's bars to the listing that existed at its entry | **Landed.** The recycled-ticker rule this plan requires; it re-pinned the figures cited below: blind-spot 91 → **92** tickers, 170 → **172** trades, 18.15% → **18.0%** of R, replayable 658 → **656** | Phase 2 |
-| **#145** — Tightness as a graded rubric input (**decided**, implementation outstanding) | Changes what passes the funnel, so it changes the denominator *and* the detected-count anchor. File the implementation ticket if none exists. | Phase 3 |
+| **#145** — Tightness as a graded rubric input | **Landed as #154.** The hard 1.5×ADR cluster cut is now a far-outlier guard at 3.0 and the rubric grades base tightness (rubric v3, detector v2). It re-pinned the detected-count anchor 104 → **159 of 656** and more than doubled the field (90.3 → **201.6** detections per session). The guard's 3.0 is **provisional on n = 10** — firming it up is a result this run is expected to produce, not an input it needs. | Phase 3 |
 | **#149** — `DETECTION_LOOKBACKS` 3 → 5 | Same class: adopt or reject on evidence, then freeze. A rejection recorded is as good as an adoption; an open question is not. | Phase 3 |
 | **#146**, **#147** — naming and the domain model | The run persists full `Detection` records and the write-up uses this vocabulary. Cheap now, a dead language later. | Phase 3 |
 | **#141** — price the marginal cluster widen | **Downstream, not blocking.** It falls back to field inflation because no false-positive rate exists; this backtest is what supplies one. | After |
@@ -233,7 +233,9 @@ detects must land *before* the denominator is built, or the run is stale on arri
 precision is unmeasurable (findings §7, §9) — the gap this run closes. Running the backtest
 first makes those tickets answerable against outcomes; running them first only makes the
 backtest stale. Land the correctness and naming work, settle #145 and #149 either way, freeze,
-then run.
+then run. **#145 is now settled** (as #154) and its own guard is provisional on the thinnest
+bucket in the study — so it joins #141 and #149 in the set of questions this run is expected to
+answer, rather than one it was waiting on.
 
 ---
 
@@ -366,7 +368,7 @@ before reading any new figure:
 | Median trailing 5-bar range at his entries | **1.86 ADR** | Findings §3b, §3c |
 | Median 20-day ADR at entry eve | **6.08%** | Findings §3c |
 | Blind-spot tickers / trades, 2019–2022 | **92 / 172** (of 312 / 828) | Findings §2 |
-| Trades detected by the funnel | **104 of 656 replayable** (§4 measured 104 of 658; #139 removed `FUSE`'s 2 trades, neither of which was detected) | Findings §4 |
+| Trades detected by the funnel | **159 of 656 replayable** (re-pinned by #154's far-outlier guard, measured 2026-08-22; the superseded pins were 104 of 658, then 104 of 656 after #139) | Findings §4 |
 
 These are the same reference set through a differently-built pipeline. Matching them says the
 new pipeline computes what the old one computed; a mismatch is a bug in the new store or the
@@ -375,8 +377,8 @@ new chain, and every downstream number inherits it.
 **Two kinds of anchor, and only one of them is stable.** The first three are geometry measured
 from his bars: they hold whatever the detector does, so they anchor the *store and the
 indicators*. The last two depend on coverage and on the gates themselves — #139 re-pins them
-to 92 / 172 / 656, and the #145 restructure moves the detected count again. Re-pin those two
-from the run that lands last, then anchor. An anchor quoted from a superseded pin fails for a
+to 92 / 172 / 656, and the #145 restructure moved the detected count again — both are now
+re-pinned above and the restructure has landed, so these are the pins to anchor against. An anchor quoted from a superseded pin fails for a
 reason that has nothing to do with the pipeline it is testing.
 
 Anchor against **arms B and C**, whose exits match the reference set's two simulated ones.

--- a/frontend/src/ChartSheet.test.tsx
+++ b/frontend/src/ChartSheet.test.tsx
@@ -35,16 +35,19 @@ afterEach(() => {
 });
 
 // The recalibrated rubric (PRD #138): ADR ×2, Orderliness ×1, Base length ×0,
-// nine-point ceiling. Hits here sum to 2(T)+1(O)+1(P)+1(MA) = 5 → 2.5★.
+// nine-point ceiling. Points here sum to 1(T, graded)+1(O)+1(P)+1(MA) = 4 → 2.0★.
 const BREAKDOWN = [
-  scoreRow({ dimension: "Tightness", weight: 2, hit: true }),
-  scoreRow({ dimension: "Orderliness", weight: 1, hit: true }),
-  scoreRow({ dimension: "Prior move", weight: 1, hit: true }),
-  scoreRow({ dimension: "Base length", weight: 0, hit: false }),
-  scoreRow({ dimension: "MA support", weight: 1, hit: true }),
-  scoreRow({ dimension: "Volume", weight: 1, hit: false }),
-  scoreRow({ dimension: "Sector", weight: 1, hit: false }),
-  scoreRow({ dimension: "ADR", weight: 2, hit: false }),
+  // Tightness is the graded dimension (rubric v3, #154): it carries the value it
+  // was graded on and earns part of its weight, so `points` is what totals — not
+  // `hit ? weight : 0`.
+  scoreRow({ dimension: "Tightness", weight: 2, hit: true, value: 1.31, points: 1 }),
+  scoreRow({ dimension: "Orderliness", weight: 1, hit: true, points: 1 }),
+  scoreRow({ dimension: "Prior move", weight: 1, hit: true, points: 1 }),
+  scoreRow({ dimension: "Base length", weight: 0, hit: false, points: 0 }),
+  scoreRow({ dimension: "MA support", weight: 1, hit: true, points: 1 }),
+  scoreRow({ dimension: "Volume", weight: 1, hit: false, points: 0 }),
+  scoreRow({ dimension: "Sector", weight: 1, hit: false, points: 0 }),
+  scoreRow({ dimension: "ADR", weight: 2, hit: false, points: 0 }),
 ];
 
 function target(over: Partial<SheetTarget> = {}): SheetTarget {
@@ -55,7 +58,7 @@ function target(over: Partial<SheetTarget> = {}): SheetTarget {
     sector: "Technology",
     facts: chartFacts(),
     breakdown: BREAKDOWN,
-    score: 2.5,
+    score: 2.0,
     ...over,
   };
 }
@@ -111,11 +114,28 @@ describe("the chart sheet", () => {
     for (const dim of ["Tightness", "Orderliness", "Base length", "ADR"]) {
       expect(within(breakdown).getByText(dim)).toBeInTheDocument();
     }
-    expect(breakdown.textContent).toMatch(/5\s*\/\s*9/); // 2+1+1+1 hits, nine-point ceiling
+    expect(breakdown.textContent).toMatch(/4\s*\/\s*9/); // 1+1+1+1 points, nine-point ceiling
     expect(screen.queryByTestId("chart-canvas")).not.toBeInTheDocument();
 
     release();
     await screen.findByTestId("chart-canvas");
+  });
+
+  it("totals the breakdown from points, and shows a graded row's value", async () => {
+    // Rubric v3 grades Tightness on a real value (#154), so `hit ? weight : 0` no
+    // longer totals the breakdown: a row that hit under the old boolean can still
+    // earn part of its weight. The table must add up to the star it sits beside,
+    // and show the number the partial score was read off.
+    stubChart(chartResponse());
+    render(<ChartSheet target={target()} onClose={() => {}} />);
+
+    const breakdown = screen.getByLabelText("score breakdown");
+    // Tightness is `hit: true` at weight ×2 but earned only 1 point ...
+    expect(within(breakdown).getByText("1.31 ADR")).toBeInTheDocument();
+    expect(within(breakdown).getByText("+1")).toBeInTheDocument();
+    // ... so the total is 4, not the 5 the booleans would have given.
+    expect(breakdown.textContent).toMatch(/4\s*\/\s*9\s*points/);
+    expect(breakdown.textContent).toMatch(/2★/);
   });
 
   it("asks for the 60-bar window so a mini already on screen shares the read", async () => {

--- a/frontend/src/ChartSheet.tsx
+++ b/frontend/src/ChartSheet.tsx
@@ -238,6 +238,17 @@ function FactsBlock({ facts }: { facts: ChartFacts }) {
  * per-dimension hits, because a sort key you cannot audit is one you will not
  * trust.
  */
+/**
+ * What one dimension's "Scored" cell says. Three cases, and the middle one only
+ * exists because rubric v3 grades a dimension (#154): a row can earn *part* of its
+ * weight, and a tick would overstate it while a dash would deny it.
+ */
+function scoredMark(d: ScoreRow): string {
+  if (d.points === 0) return "—"; // missed, or a ×0 dimension that can earn nothing
+  if (d.points === d.weight) return "✓"; // earned everything it could
+  return `+${d.points}`; // graded: part of the weight
+}
+
 function Breakdown({ breakdown, score }: { breakdown: ScoreRow[]; score: number | null }) {
   // Points come off the row, not from `hit × weight`. Since rubric v3 one
   // dimension is *graded* — it earns part of its weight on a banded value — so
@@ -269,7 +280,7 @@ function Breakdown({ breakdown, score }: { breakdown: ScoreRow[]; score: number 
               )}
             </td>
             <td>×{d.weight}</td>
-            <td>{d.points === d.weight ? (d.weight === 0 ? "—" : "✓") : d.points > 0 ? `+${d.points}` : "—"}</td>
+            <td>{scoredMark(d)}</td>
           </tr>
         ))}
       </tbody>

--- a/frontend/src/ChartSheet.tsx
+++ b/frontend/src/ChartSheet.tsx
@@ -239,7 +239,11 @@ function FactsBlock({ facts }: { facts: ChartFacts }) {
  * trust.
  */
 function Breakdown({ breakdown, score }: { breakdown: ScoreRow[]; score: number | null }) {
-  const points = breakdown.reduce((sum, d) => sum + (d.hit ? d.weight : 0), 0);
+  // Points come off the row, not from `hit × weight`. Since rubric v3 one
+  // dimension is *graded* — it earns part of its weight on a banded value — so
+  // re-deriving the total here would need a copy of the server's band table and
+  // would silently disagree with the star the row was sorted by (#154).
+  const points = breakdown.reduce((sum, d) => sum + d.points, 0);
   // The ceiling is the sum of the weights, read off the breakdown itself rather
   // than hard-coded — so the ×0 Base length row (PRD #138) drops it to 9 without
   // a second place to keep in sync.
@@ -255,10 +259,17 @@ function Breakdown({ breakdown, score }: { breakdown: ScoreRow[]; score: number 
       </thead>
       <tbody>
         {breakdown.map((d) => (
-          <tr key={d.dimension} className={d.hit ? "hit" : "miss"}>
-            <td>{d.dimension}</td>
+          <tr key={d.dimension} className={d.points > 0 ? "hit" : "miss"}>
+            <td>
+              {d.dimension}
+              {/* A graded dimension shows the value it was graded on, so a
+                  partial score reads as a measurement rather than a mystery. */}
+              {d.value !== null && d.value !== undefined && (
+                <span className="graded-value"> {d.value.toFixed(2)} ADR</span>
+              )}
+            </td>
             <td>×{d.weight}</td>
-            <td>{d.hit ? "✓" : "—"}</td>
+            <td>{d.points === d.weight ? (d.weight === 0 ? "—" : "✓") : d.points > 0 ? `+${d.points}` : "—"}</td>
           </tr>
         ))}
       </tbody>

--- a/frontend/src/api/fixtures.ts
+++ b/frontend/src/api/fixtures.ts
@@ -38,6 +38,9 @@ export const scoreRow = builder<Schemas["ScoreRow"]>(() => ({
   dimension: "tightness",
   weight: 2,
   hit: true,
+  // What the row earned under the live rubric. Not `hit ? weight : 0` — since v3
+  // one dimension is graded, so points is its own field (#154).
+  points: 2,
 }));
 
 export const candle = builder<Schemas["Candle"]>(() => ({

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -829,7 +829,7 @@
         "type": "object"
       },
       "ScoreRow": {
-        "description": "One row of a candidate's star-score breakdown (spec \u00a74.7).\n\nEight of these reconstruct the score arithmetically next to the chart \u2014 the\ndimension's name, its weight (2 for Tightness and ADR, 0 for Base length, 1 for\nthe rest \u2014 recalibrated by PRD #138) and whether it hit. ``Tightness`` is **base\ntightness** \u2014 the setup's geometry, not the stop width the row also carries\n(issue #147); the label is published, so it is qualified here rather than\nrenamed. ``n/9 \u2192 stars`` is ``sum(weight where hit) \u00f7 2``; the ceiling is nine\npoints, not ten.",
+        "description": "One row of a candidate's star-score breakdown (spec \u00a74.7).\n\nEight of these reconstruct the score arithmetically next to the chart \u2014 the\ndimension's name, its weight (2 for Tightness and ADR, 0 for Base length, 1 for\nthe rest \u2014 recalibrated by PRD #138) and whether it hit. ``Tightness`` is **base\ntightness** \u2014 the setup's geometry, not the stop width the row also carries\n(issue #147); the label is published, so it is qualified here rather than\nrenamed. The ceiling is nine points, not ten, and stars are ``points \u00f7 2``.\n\n``value`` is the graded quantity, present only on a **graded** dimension \u2014 since\nrubric v3 that is ``Tightness`` alone, carrying its three-bar range in ADR\n(#154). On a graded row ``hit`` is *not* what scored: it is the boolean the\nsetup satisfies (Tightness keeps v1/v2's ``cluster_k >= 5``), kept so a stored\nbreakdown re-scores exactly under an older rubric.\n\n``points`` is what the row **actually earned**, under the rubric the payload's\n``rubric_version`` names. It is published because ``weight where hit`` no longer\ntotals a graded breakdown, and the client must not carry a second copy of the\nband table: a breakdown that does not add up to the star it sits beside is\nexactly the un-auditable sort key the rubric exists to avoid. ``points`` is a\nproperty of a *rubric applied to* the row, which is why it rides the API model\nand never the stored :class:`~screener.score.Dimension`.",
         "properties": {
           "dimension": {
             "title": "Dimension",
@@ -839,6 +839,21 @@
             "title": "Hit",
             "type": "boolean"
           },
+          "points": {
+            "title": "Points",
+            "type": "integer"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value"
+          },
           "weight": {
             "title": "Weight",
             "type": "integer"
@@ -847,7 +862,8 @@
         "required": [
           "dimension",
           "weight",
-          "hit"
+          "hit",
+          "points"
         ],
         "title": "ScoreRow",
         "type": "object"

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -558,14 +558,31 @@ export interface components {
          *     the rest — recalibrated by PRD #138) and whether it hit. ``Tightness`` is **base
          *     tightness** — the setup's geometry, not the stop width the row also carries
          *     (issue #147); the label is published, so it is qualified here rather than
-         *     renamed. ``n/9 → stars`` is ``sum(weight where hit) ÷ 2``; the ceiling is nine
-         *     points, not ten.
+         *     renamed. The ceiling is nine points, not ten, and stars are ``points ÷ 2``.
+         *
+         *     ``value`` is the graded quantity, present only on a **graded** dimension — since
+         *     rubric v3 that is ``Tightness`` alone, carrying its three-bar range in ADR
+         *     (#154). On a graded row ``hit`` is *not* what scored: it is the boolean the
+         *     setup satisfies (Tightness keeps v1/v2's ``cluster_k >= 5``), kept so a stored
+         *     breakdown re-scores exactly under an older rubric.
+         *
+         *     ``points`` is what the row **actually earned**, under the rubric the payload's
+         *     ``rubric_version`` names. It is published because ``weight where hit`` no longer
+         *     totals a graded breakdown, and the client must not carry a second copy of the
+         *     band table: a breakdown that does not add up to the star it sits beside is
+         *     exactly the un-auditable sort key the rubric exists to avoid. ``points`` is a
+         *     property of a *rubric applied to* the row, which is why it rides the API model
+         *     and never the stored :class:`~screener.score.Dimension`.
          */
         ScoreRow: {
             /** Dimension */
             dimension: string;
             /** Hit */
             hit: boolean;
+            /** Points */
+            points: number;
+            /** Value */
+            value?: number | null;
             /** Weight */
             weight: number;
         };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1357,3 +1357,13 @@
 .member-decile {
   white-space: nowrap;
 }
+
+/* The value a *graded* score dimension was graded on (rubric v3, #154). Secondary
+   to the dimension's name and set in the mono face, because it is a measurement
+   the reader checks the points against rather than a label. */
+.graded-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-micro);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}

--- a/references/base_tightness_restructure.txt
+++ b/references/base_tightness_restructure.txt
@@ -1,4 +1,4 @@
-Tightness restructure (#145/#154) — TIGHT_MULT 1.5 gate -> OUTLIER_MULT 3.0 guard
+Base-tightness restructure (#145/#154) — TIGHT_MULT 1.5 gate -> OUTLIER_MULT 3.0 guard
 ==============================================================================
 
 1. Detection-stage recall, 828-trade reference set
@@ -18,7 +18,7 @@ Tightness restructure (#145/#154) — TIGHT_MULT 1.5 gate -> OUTLIER_MULT 3.0 gu
      n=169  p25 1.68  median 1.83  p75 2.10  max 2.90
 
    Trades the guard still declines: 2
-     three-bar range: n=2  p25 3.18  median 3.42  p75 3.42  max 3.42
+     three-bar range: n=2  p25 3.24  median 3.30  p75 3.36  max 3.42
 
 2. Field inflation per session (same universe, same decile gate)
    sessions measured          : 505

--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -177,13 +177,21 @@ blended number can hide a disaster at one stage:
 
 | Filter | Would have kept | Excluding repeat entries |
 |---|---|---|
-| Liquid enough? | **598/658 (90.9%)** | 523/578 (90.5%) |
-| Strong enough performer? | **395/658 (60.0%)** | 340/578 (58.8%) |
-| Valid-looking setup? | **380/658 (57.8%)** | 341/578 (59.0%) |
+| Liquid enough? | **598/656 (91.2%)** | 523/577 (90.6%) |
+| Strong enough performer? | **395/656 (60.2%)** | 340/577 (58.9%) |
+| Valid-looking setup? | **549/656 (83.7%)** | 487/577 (84.4%) |
 
-**The "strongest performers" filter is the expensive one.** It discards **40% of
-his real trades on its own**, before the setup detector even looks — nearly five
-times what the liquidity check costs.
+> **The last row was re-measured in August 2026.** The "quiet enough beforehand"
+> cutoff described in Test 1b was replaced by a much looser safety net, and
+> quietness became a graded score instead. That took this row from **380/658
+> (57.8%)** to 549/656 — 169 more of his real trades the app would have shown him.
+> The first two rows are unaffected by that change and reproduced exactly. The
+> price is in Test 1b: the nightly list **more than doubled**.
+
+**The "strongest performers" filter is now the expensive one by a wide margin.** It
+discards **40% of his real trades on its own**, before the setup detector even
+looks — nearly five times what the liquidity check costs, and more than twice what
+the detector now costs.
 
 > **This filter is a third tighter than every document said.** There are two
 > versions of "strongest performers" in the code, and they were being conflated.
@@ -194,9 +202,11 @@ times what the liquidity check costs.
 > them separately.
 
 **One oddity worth noting:** the setup detector is the only stage that scores
-*better* once repeat entries are removed (59.0% vs 57.8%). His add-on buys are
-harder for it to see than his first entries — which makes sense, since an add-on
-isn't a fresh setup and the detector was never designed to catch one.
+*better* once repeat entries are removed (84.4% vs 83.7%). His add-on buys are
+still slightly harder for it to see than his first entries — which makes sense,
+since an add-on isn't a fresh setup and the detector was never designed to catch
+one. The gap used to be 1.2 points and is now 0.7: the quietness cutoff was what
+made add-ons hard to see, and it is gone.
 
 ### Why the 40% figure shouldn't be acted on directly
 
@@ -348,6 +358,45 @@ right number" but "should this be a pass/fail gate at all, rather than a graded
 score with a much looser safety net" — and that still can't be settled without the
 false-positive rate we don't have.
 
+### What was built on this, in August 2026
+
+That last question was decided in favour of the graded score, and built. Three
+things changed together:
+
+- **The pass/fail cutoff at 1.5 is gone.** In its place is a **safety net at 3.0** —
+  far enough out that it only rejects a stock genuinely still moving, with no quiet
+  stretch at all.
+- **Quietness became a graded score** instead of a yes/no box: full marks under 1.0
+  ADR, half marks up to 2.0, none beyond. It is still worth double, as before.
+- **The score sheet now records the measurement, not the verdict.** The row stores
+  how quiet the stock actually was, so a score from an older version of the rubric
+  can still be reproduced exactly from a new row. Without that, no two versions of
+  the scoring could ever be compared again.
+
+**Both sides of the ledger, measured:**
+
+| | Old hard cutoff | New safety net |
+|---|---|---|
+| His trades the detector would have found | 380 of 658 | **549 of 656** |
+| Rejections for "not quiet enough" | 171 | **2** |
+| Names on the nightly list, per night | 90 | **202** |
+
+**The second number is the cost, and it is a big one.** The list more than doubles:
+about 111 extra names a night, or roughly **two thirds of an extra name per night
+for each real trade recovered**. Nothing measures how many of those extras are
+junk — that number does not exist for this project, which is exactly why the cost is
+quoted as a population count instead. What absorbs it is the graded score: the newly
+admitted names are the ones it scores *low*, so they arrive at the bottom of the
+list rather than beside his own setups. The work moved from the gate to the sort.
+
+**The safety net at 3.0 is provisional, and here is why.** It sits where the results
+table above first turns negative — the "3.0+" row — and that row is **ten trades**.
+Ten is far too few to place a line on. What makes 3.0 the right ballpark rather than
+a guess is the other figure: widening to 3.0 keeps 98.5% of his trades and 100.4% of
+his total profit, more than 100% because the slice being cut loses money on average.
+On his own record the net turns away **two** trades. Firming it up needs more
+losing-tail data, which is precisely what the out-of-sample backtest is for.
+
 ### A useful contrast with the "extended" study
 
 Test 5 below sets a hard cutoff for a *different* quality, and its reasoning is
@@ -364,10 +413,11 @@ point:
 | Quietness (Test 1b) | A **smooth slope** — no special point anywhere | A graded score |
 
 These two qualities genuinely differ in kind, so they shouldn't be built the same
-way. And note that the current 1.5 cutoff satisfies *neither* test: it isn't a
-percentile anyone deliberately chose (it was inherited, and merely happens to land
-at his 64th), and it isn't placed at a feature in the results, because there is no
-feature there to place it at.
+way. And note that the old 1.5 cutoff satisfied *neither* test: it wasn't a
+percentile anyone deliberately chose (it was inherited, and merely happened to land
+at his 64th), and it wasn't placed at a feature in the results, because there is no
+feature there to place it at. That is the argument the rebuild rests on — not that
+quietness stopped mattering, but that a hard line was the wrong shape for it.
 
 ---
 
@@ -532,6 +582,13 @@ idea.
 
 Only **104 of 658** trades (15.8%) appeared in the app's field at all, and only
 **41** landed in the top 30 by score.
+
+> **Re-measured after the quietness rebuild (August 2026):** **159 of 656** now
+> appear in the field, and **45** land in the top 30. Half again as many of his
+> trades are visible somewhere; the same number reach a board. The rest of this
+> section is left as it was measured — it is the record of what the ten-point
+> scoring did to the field as it stood then, and re-running it on a list twice the
+> size would answer a different question.
 
 **The headline result was negative, and it's the study's most consequential
 finding.** Under the scoring system live at the time, his hand-picked entries

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -163,7 +163,7 @@ decile-dependent output carries `blind_spot_count`.
 **656 replayable trades** (of 828; the other 172 are the blind spot), of which **79** are
 tagged `continuation`.
 
-> **Re-measured after #154.** The tightness restructure changed what the detector detects, so
+> **Re-measured after #154.** The base-tightness restructure changed what the detector detects, so
 > the detection row below is a **re-run** figure and the `cluster` line in the condition table
 > collapses. Liquidity and decile are cross-sectional and untouched by that change — they
 > reproduced to the row. The superseded detector-v1 figures are kept in each cell so the two
@@ -534,7 +534,7 @@ this section.
 
 The proposal above was decided in #145 and implemented in #154. `TIGHT_MULT = 1.5` **no longer
 gates**: it shapes the cluster window, the cluster falls back to the 3-bar window when nothing
-tighter clears, and the only tightness rejection left is a **far-outlier guard** at
+tighter clears, and the only base-tightness rejection left is a **far-outlier guard** at
 `OUTLIER_MULT = 3.0 × ADR` on the 3-bar range. The rubric's ×2 `Tightness` dimension is graded on
 that same ungated quantity — 2 points at or under 1.0 ADR, 1 through 2.0, none beyond — at rubric
 **v3**. The weight did not move.
@@ -555,12 +555,14 @@ how this change sits against it:
   strong, in the same sense that #143's cliff made a threshold the right encoding there. The
   dimension keeps its ×2 and now expresses more of what it measures, not less.
 
-That reading is a **judgement about the rule's scope, not a finding**, and it is recorded here so
-the precondition does not look bypassed. What it does not do is exempt the change from the rule's
+That reading is a **judgement about the rule's scope, not a finding**. It is not left as a note
+in a write-up either: it is recorded as a decision, with the four conditions that have to hold
+before the move can be reached for again, in
+[`docs/adr/0004-replacing-a-threshold-with-a-graded-input.md`](../docs/adr/0004-replacing-a-threshold-with-a-graded-input.md). What it does not do is exempt the change from the rule's
 purpose: precision is still not measurable, so the cost side is priced explicitly below, the way
 #141 and #149 price theirs and the way ADR 0002's condition 4 requires of a cross-sectional cut.
 
-**Both halves of the ledger, measured** (`scripts/tightness_restructure.py`, over the same replay
+**Both halves of the ledger, measured** (`scripts/base_tightness_restructure.py`, over the same replay
 store; recall on the 828-trade reference set, field inflation over the 505 replayed sessions the
 store holds ranks for):
 
@@ -1446,6 +1448,10 @@ governed differently:
 
 - the **stop convention** (§6, finding 1) is a detector output and a card claim, measured
   against his own risk rather than inferred from a null — outside the rule entirely; and
+- the **base-tightness restructure** (§3b, #145/#154) is neither a loosening argued from a null
+  nor a threshold move with the shape held fixed: it replaced a threshold with a graded rubric
+  input plus a far outlier guard. ADR 0002 does not govern that, and ADR 0004 records what does;
+  and
 - the **decile gate** (§3), which costs 40% of his entries, is a **cross-sectional cut** and
   falls under the rule's second limb: the loss must be measured directly by A1, shown not to
   be a coverage artefact, addressed structurally rather than by a threshold move, and quoted
@@ -1578,7 +1584,7 @@ outcome regression #121; A3 selection contrast #122; this write-up #123. Analysi
 #133; cluster characterisation #132; recalibration #138; paired A2 re-run #136; the tightness
 restructure #145/#154. Study last run **2026-08-22**, on detector v2 and rubric v3 — the run that
 re-pinned §3's detection row, §3's condition table and §4's `in_field` anchor. The
-recall-and-inflation ledger in §3b is a side-car, `scripts/tightness_restructure.py`, run against
+recall-and-inflation ledger in §3b is a side-car, `scripts/base_tightness_restructure.py`, run against
 the same store and outside `replay.study`. The survivorship hole closed won't-do as #129._
 
 _Side-car prototypes, outside §10 and outside `replay.study` — each rebuilt by running the

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -160,14 +160,21 @@ decile-dependent output carries `blind_spot_count`.
 
 ### Per-stage recall — report headline and ex-continuation together
 
-**658 replayable trades** (of 828; the other 170 are the blind spot), of which **80** are
+**656 replayable trades** (of 828; the other 172 are the blind spot), of which **79** are
 tagged `continuation`.
+
+> **Re-measured after #154.** The tightness restructure changed what the detector detects, so
+> the detection row below is a **re-run** figure and the `cluster` line in the condition table
+> collapses. Liquidity and decile are cross-sectional and untouched by that change — they
+> reproduced to the row. The superseded detector-v1 figures are kept in each cell so the two
+> are never quietly conflated: recall is only comparable within one `detector_version`.
+> #139's re-pin of the denominator (658 → 656) applies throughout.
 
 | Stage | Recall (headline) | Recall (ex-continuation) | Notes |
 | --- | --- | --- | --- |
-| Liquidity | **598/658 (90.9%)** | **523/578 (90.5%)** | The one stage where a rejected name never reaches any tab — a miss here is otherwise invisible (user story 7). Cheapest of the three. |
-| Decile | **395/658 (60.0%)** | **340/578 (58.8%)** | The most aggressive filter — cuts to **19.4%** of the universe before the detector looks. Depends on the replayed field → coverage attached. |
-| Detection | **380/658 (57.8%)** | **341/578 (59.0%)** | Failures broken down by geometric condition below (user stories 9, 10). |
+| Liquidity | **598/656 (91.2%)** | **523/577 (90.6%)** | The one stage where a rejected name never reaches any tab — a miss here is otherwise invisible (user story 7). Cheapest of the three. |
+| Decile | **395/656 (60.2%)** | **340/577 (58.9%)** | The most aggressive filter — cuts to **19.4%** of the universe before the detector looks. Depends on the replayed field → coverage attached. Now the **largest** loss in the funnel. |
+| Detection | **549/656 (83.7%)** | **487/577 (84.4%)** | Detector v2 (#154). Was 380/658 (57.8%) under the hard 1.5 cluster cut. Failures broken down by geometric condition below (user stories 9, 10). |
 
 > **The decile gate is the expensive one.** It discards **40% of his real entries on its
 > own**, before the detector is ever consulted — the largest single loss in the funnel, and
@@ -177,13 +184,16 @@ tagged `continuation`.
 > measures is `detection_gate`, which unions only `1m`/`3m`/`6m` and admits **19.4%**. The
 > gate is a third tighter than the parent spec describes. See
 > `docs/adr/0003-the-decile-gate.md`. Each stage is evaluated *unconditionally* on
-> every row, so these are not sequential survivors: decile (60.0%) and detection (57.8%)
-> are close because they are two independent measurements, not a funnel product.
+> every row, so these are not sequential survivors: they are three independent
+> measurements, not a funnel product. Under detector v1 decile (60.0%) and detection (57.8%)
+> were close enough to argue about which was worse; after #154 the question is settled —
+> **the decile gate is now the funnel's largest loss by 23 points**, and it is the one
+> governed by a rule (ADR 0002's second limb) that it can be argued under.
 >
-> Detection is also the **only** stage whose ex-continuation recall (59.0%) is *higher*
-> than its headline (57.8%). His repeat entries into a name are harder for the detector to
-> see than his first ones — consistent with the `cluster` condition below, which fires on
-> exactly that pattern.
+> Detection is also the **only** stage whose ex-continuation recall (84.4%) is *higher*
+> than its headline (83.7%). His repeat entries into a name are still marginally harder for
+> the detector to see than his first ones, but the gap has narrowed to 0.7pp from 1.2pp: the
+> `cluster` condition, which fired on exactly that pattern, is no longer doing the work.
 
 ### The decile miss decomposed (#133) — a third of it is the gate's width, not his names
 
@@ -210,19 +220,22 @@ unmeasurable (§7), so this is a lead to size, not a change licensed here.
 
 Detection-failure breakdown (`condition_counts`) — which geometric condition to change:
 
-| Failed condition | Count | Share of the 278 detection misses |
+| Failed condition | v1 count (of 278) | v2 count (of 107) |
 | --- | --- | --- |
-| `cluster` | **171** | 61.5% |
-| `catch_up` | 47 | 16.9% |
-| `base_length` | 37 | 13.3% |
-| `history` | 23 | 8.3% |
-| `adr` | 0 | — |
-| `prior_move` | 0 | — |
+| `cluster` | **171** (61.5%) | **2** (1.9%) |
+| `catch_up` | 47 (16.9%) | **47** (43.9%) |
+| `base_length` | 37 (13.3%) | **37** (34.6%) |
+| `history` | 23 (8.3%) | **21** (19.6%) |
+| `adr` | 0 | 0 |
+| `prior_move` | 0 | 0 |
 
-`cluster` alone costs more than the other three firing conditions combined. Neither `adr`
-nor `prior_move` rejected a single one of his entries: `prior_move` cannot (every detection
-clears the decile gate by construction), and the ADR *hard gate* never bound — which is
-distinct from the ADR *score point*, which is withheld on 30.7% of entries (§6, finding 2).
+Under v1, `cluster` alone cost more than the other three firing conditions combined; under v2
+it is the smallest, and `catch_up` — price not yet back at the 10/20 MA — is the largest
+remaining detection miss. The `history` row moves 23 → 21 for a different reason entirely:
+#139 stopped charging two recycled-symbol trades to the detector. Neither `adr` nor
+`prior_move` has ever rejected one of his entries: `prior_move` cannot (every detection clears
+the decile gate by construction), and the ADR *hard gate* never bound — which is distinct from
+the ADR *score point*, withheld on 30.7% of entries (§6, finding 2).
 
 Blind-spot trades (ticker with no bars) get **no** funnel row — they are recorded as a blind
 spot by `replay.reference`, never as a stage failure, so the replayable set and the blind
@@ -328,6 +341,23 @@ measurable — a control group of setups he *passed over* — so a recall gain c
 its false-positive cost; and an out-of-regime or IDX reference set, so the window is not tuned to a
 once-in-a-decade US momentum regime (§8). Absent those, the question is re-openable rather than
 settled by omission, and the machinery above is what a re-opening would read.
+
+> **Superseded by #145/#154 — and not by finding the missing precision measurement.** The
+> constants this section left standing are gone: `TIGHT_MULT = 1.5` no longer gates, and the
+> cluster condition is now a **far-outlier guard** at `OUTLIER_MULT = 3.0` with base tightness
+> graded by the rubric. It was re-opened on a different argument than the one this section
+> anticipated. This section asked "is 1.5 the right cutoff", and answered correctly that no
+> available evidence licenses moving it. §3b reframed the question as "should this be a cutoff
+> at all", which the calibration rule's score-dimension limb does not govern — that limb
+> governs *loosening a dimension away on a null*, and Tightness has signal on both axes. The
+> change is a **shape** change with the weight held at ×2, priced with its population cost;
+> the argument and the measurement are in §3b below. The 113 marginal misses this section left
+> as its open question are recovered by the guard, but that is the change's *consequence*, not
+> its licence — a recall number still licenses nothing on its own.
+>
+> The §3a figures above are **not restated** to the new detector: they characterise the 171
+> misses the 1.5 cut produced, which is the evidence the decision was taken on, and
+> `MARGINAL_TIGHT_MULT` is kept at 2.0 so they still reproduce.
 
 ---
 
@@ -499,6 +529,79 @@ but "should tightness be a cutoff at all, or a graded rubric input with a much l
 guard". That is a larger change than §3a considered, it is still unpriceable without a control group
 of setups he passed over (§7, §9), and it is filed rather than acted on. No constant is touched by
 this section.
+
+#### What was built on this — the restructure, and where it stands against the rule (#145/#154)
+
+The proposal above was decided in #145 and implemented in #154. `TIGHT_MULT = 1.5` **no longer
+gates**: it shapes the cluster window, the cluster falls back to the 3-bar window when nothing
+tighter clears, and the only tightness rejection left is a **far-outlier guard** at
+`OUTLIER_MULT = 3.0 × ADR` on the 3-bar range. The rubric's ×2 `Tightness` dimension is graded on
+that same ungated quantity — 2 points at or under 1.0 ADR, 1 through 2.0, none beyond — at rubric
+**v3**. The weight did not move.
+
+**The position on the calibration rule, stated rather than left implicit.** ADR 0002's
+score-dimension limb permits loosening a dimension "only when A3 shows that dimension has no
+signal *and* real spread", and §3a refused the loosening on exactly that ground. Two things about
+how this change sits against it:
+
+- **The precondition is not met and is not claimed to be.** Tightness has selection signal (§5b,
+  +20.8pp, second-strongest in the rubric) and outcome signal (the table above). It is the
+  best-evidenced dimension in the study. Nothing here argues it is null.
+- **The rule's limb governs *loosening a dimension away*; this is a change of *shape*.** The
+  instrument exists because a null on a range-restricted dimension is not evidence the dimension is
+  useless, and because recall alone would widen every gate. The claim here is the opposite of a
+  null: the dimension is well evidenced, *and* the evidence says its outcome relation is a smooth
+  monotone decline with no feature anywhere — so a threshold is the wrong encoding of a signal that
+  strong, in the same sense that #143's cliff made a threshold the right encoding there. The
+  dimension keeps its ×2 and now expresses more of what it measures, not less.
+
+That reading is a **judgement about the rule's scope, not a finding**, and it is recorded here so
+the precondition does not look bypassed. What it does not do is exempt the change from the rule's
+purpose: precision is still not measurable, so the cost side is priced explicitly below, the way
+#141 and #149 price theirs and the way ADR 0002's condition 4 requires of a cross-sectional cut.
+
+**Both halves of the ledger, measured** (`scripts/tightness_restructure.py`, over the same replay
+store; recall on the 828-trade reference set, field inflation over the 505 replayed sessions the
+store holds ranks for):
+
+| | Hard 1.5 cut | Far-outlier guard | Change |
+| --- | --- | --- | --- |
+| Detection-stage recall | 380/658 (57.8%) | **549/656 (83.7%)** | **+169 trades** |
+| — ex-continuation | 341/578 (59.0%) | **487/577 (84.4%)** | +146 |
+| `cluster` misses | 171 | **2** | −169 |
+| Detections per session | 90.3 | **201.6** | **+111.3 (+123.2%)** |
+
+**The population cost is the headline, not the recall.** The field more than doubles: 111 more
+names per session, or **0.66 additional names per session for each trade recovered**. That is a
+large number and it is the honest denominator — precision cannot be measured, so this ratio is what
+stands in for it (ADR 0002, condition 4). What absorbs it is the thing the change was made for: the
+names admitted are exactly the ones the graded dimension scores *low*, so they enter the list at the
+bottom of the sort rather than beside his own setups. The restructure moves work from the gate to
+the sort key, and that is only a good trade if the sort key is trusted — which is why the grade is
+banded and published on the breakdown rather than folded invisibly into a star.
+
+**The guard is provisional, and here is its n.** The 3.0 bound is sited on the only feature §3b's
+outcome table offers, and that feature is one bucket of **10 trades** at −0.36 mean R. Ten is far
+too thin to carry a threshold on its own; what makes 3.0 the right *order of magnitude* rather than
+a guess is the complementary figure — widening to ~3.0 keeps 98.5% of his trades and 100.4% of his
+summed R, the excess over 100% being the net-negative tail the guard cuts. On his own record the
+guard declines **2 trades**, at a 3-bar range of 3.18 and 3.42 ADR. What would firm it up is a
+larger denominator in the negative tail, which is exactly what the out-of-sample backtest builds
+(`docs/out-of-sample-backtest-plan.md`); until then the constant is not to be swept or tuned on an
+in-sample number.
+
+**What the recovered trades look like.** The 169 recovered entries sit at a 3-bar range of median
+1.83 ADR (p25 1.68, p75 2.10, max 2.90) — clustered just past the old 1.5 line, which is §3a's
+"marginal" population arriving as detections. Under the graded rubric almost all of them score 1 of
+the 2 available tightness points rather than 2.
+
+**The inflation was predictable from §3d, and it lands where §3d said it would.** That section
+measured the recent 3-bar span on his entries against an ordinary-day background: **64.3% of his
+entries sit inside 1.5 ADR against 34.4% of background days**. A gate at 1.5 was therefore cutting
+roughly two thirds of the background while keeping two thirds of his entries, and removing it lets
+that two thirds back in — which is the +123% almost exactly. It is the same number read from two
+directions, and it is worth stating plainly: **the 1.5 cut was doing most of the detector's
+filtering**, and the graded dimension now has to carry that load in the sort instead.
 
 ---
 
@@ -726,6 +829,27 @@ measurement that makes the comparison legitimately.
 whatever the weights say — so it is the one figure here that survives a rubric change
 unchanged. `top_thirty` does not: the board is a re-ranking (§4a).
 
+> **The `in_field` anchor is re-pinned by #154: 104 → 159 of 656 (24.2%).** `in_field`
+> survives a *rubric* change and not a *detector* one — it is exactly the figure the
+> far-outlier guard moves, because the guard decides who is in the field at all. The rest of
+> this section is **left at its v1 measurement and is not restated**: it is the record of what
+> the ten-point rubric did to the field as it stood, and re-running it against a doubled field
+> would answer a different question than the one §4 asked. Two figures from the re-run belong
+> here because downstream work anchors on them:
+>
+> | | Detector v1 | Detector v2 (#154) |
+> | --- | --- | --- |
+> | His trades in the field (`in_field`) | 104/658 (15.8%) | **159/656 (24.2%)** |
+> | The field itself, same sessions | 14,239 detections | **29,096** (+104%) |
+> | Inside the top 30 (`top_thirty`, live rubric) | 45/104 (43.3%) | **45/159 (28.3%)** |
+>
+> Read the last row carefully, because it is the change's cost and benefit in one line: the
+> **same 45 of his trades reach a board**, out of half again as many that are now detected at
+> all. The 55 newly-visible picks land below the top 30 — which is the graded rubric doing
+> what it was built to do, sorting the wider bases downward rather than gating them out, but
+> it is also a plain statement that the board did not get better at surfacing his entries. The
+> gain is that 55 more of them exist somewhere on the list instead of nowhere.
+
 Star distribution of his picks against the replayed field, on the same sessions:
 
 | Stars | His picks | Share | The field | Share |
@@ -809,6 +933,29 @@ Before reading the v2 column, note that the v1 column is a **cell-for-cell repro
 §4 above — 17.31% / 17.82%, 41/658 inside the board, and every one of the nine histogram rows.
 That is the control: the field is demonstrably the same field §4 measured, so any v2 difference
 is the rubric and nothing else.
+
+> **The pairing survived a graded dimension (#154).** v3 grades `Tightness` on a real value
+> instead of a boolean, which would have broken this measurement outright had the *grade* been
+> stored on the breakdown row: a v2 re-score of a v3 row would then be impossible, and the
+> comparison below would be silently comparing two fields while claiming to compare two
+> rubrics. The row stores the **value** and the rubric owns the mapping, so a stored breakdown
+> still re-scores exactly under every version — v2's `cluster_k >= 5` boolean is on the row
+> too, unchanged and unread by v3.
+>
+> The block below is **left as measured**, on the detector-v1 field. On the re-run field
+> (detector v2, all three rubrics over one field, `in_field` 159):
+>
+> | Result | v1 | v2 | v3 (live) |
+> | --- | --- | --- | --- |
+> | Inside the top 30 | 31/159 | 43/159 | **45/159** |
+> | His picks at ≥3.5★ | 13.21% | 9.43% | **11.32%** |
+> | The field at ≥3.5★ | 11.06% | 4.32% | **6.75%** |
+> | Gap (picks − field) | +2.14pp | **+5.11pp** | **+4.57pp** |
+>
+> On a field twice the size, v3 keeps most of v2's discrimination (+4.57pp against +5.11pp)
+> and puts two more of his trades on a board. The gap being *slightly* narrower than v2's is
+> not a defect to tune away: v3 is separating his picks from a population that now includes
+> every wider base v2 never had to rank at all.
 
 ### Reported — same field, both rubrics
 
@@ -1428,8 +1575,11 @@ or more.
 _Provenance: PRD #114; A1 funnel #116/#119; A2 chain/field/placement #117/#118/#120; A3
 outcome regression #121; A3 selection contrast #122; this write-up #123. Analysis code:
 `backend/replay/`. Row-level seam: `backend/tests/test_replay_seam.py`. Decile decomposition
-#133; cluster characterisation #132; recalibration #138; paired A2 re-run #136. Study last run
-2026-08-19; the survivorship hole closed won't-do as #129._
+#133; cluster characterisation #132; recalibration #138; paired A2 re-run #136; the tightness
+restructure #145/#154. Study last run **2026-08-22**, on detector v2 and rubric v3 — the run that
+re-pinned §3's detection row, §3's condition table and §4's `in_field` anchor. The
+recall-and-inflation ledger in §3b is a side-car, `scripts/tightness_restructure.py`, run against
+the same store and outside `replay.study`. The survivorship hole closed won't-do as #129._
 
 _Side-car prototypes, outside §10 and outside `replay.study` — each rebuilt by running the
 scripts in its own directory, each carrying its own `FINDINGS.md`: §3b

--- a/references/replay_study_report.txt
+++ b/references/replay_study_report.txt
@@ -5,84 +5,94 @@ chain: 947 sessions (126 burn-in, 821 measured)
 total rows:          828
 rows with outcomes:  827
 distinct tickers:    312
-blind-spot tickers:  91
-blind-spot trades:   170
-blind-spot R share:  18.1%
+blind-spot tickers:  92
+blind-spot trades:   172
+blind-spot R share:  18.0%
 
 == A1 funnel ==
 funnel stages: liquidity, decile, detection
-replayable trades:    658
-continuation entries: 80
-blind-spot coverage:  91 tickers missing from the field
+replayable trades:    656
+continuation entries: 79
+blind-spot coverage:  92 tickers missing from the field
 
-liquidity  recall: 598/658 (90.9%)  ex-continuation: 523/578 (90.5%)
-decile     recall: 395/658 (60.0%)  ex-continuation: 340/578 (58.8%)
-detection  recall: 380/658 (57.8%)  ex-continuation: 341/578 (59.0%)
+liquidity  recall: 598/656 (91.2%)  ex-continuation: 523/577 (90.6%)
+decile     recall: 395/656 (60.2%)  ex-continuation: 340/577 (58.9%)
+detection  recall: 549/656 (83.7%)  ex-continuation: 487/577 (84.4%)
 
 detection misses by condition:
-  cluster      171
   catch_up     47
   base_length  37
-  history      23
+  history      21
+  cluster      2
 
-decile miss decomposed (263 misses over all replayable trades):
-  coverage gap (absent from field):   64
+decile miss decomposed (261 misses over all replayable trades):
+  coverage gap (absent from field):   62
   recovered by widening the gate 3->5: 75
   outside any union (genuine miss):   124
 
-cluster miss characterised (171 misses):
-  continuation entries (re-entries): 23
-  fresh entries:                     148
-  marginal (<= 2.0x ADR, a modest widen recovers): 113
-  far (name in motion, no base):     58
-  3-bar range in ADR: median 1.85 (p25 1.68, p75 2.13, max 3.42)
-  sessions since prior entry (continuation misses): median 4.0 (min 2, max 5)
+cluster miss characterised (2 misses):
+  continuation entries (re-entries): 0
+  fresh entries:                     2
+  marginal (<= 2.0x ADR, a modest widen recovers): 0
+  far (name in motion, no base):     2
+  3-bar range in ADR: median 3.30 (p25 3.24, p75 3.36, max 3.42)
 
 == A2 placement ==
 scope: US 2019–2022 (not an IDX expectation)
-blind-spot coverage: 91 tickers missing from the field
+blind-spot coverage: 92 tickers missing from the field
 
-placed trades:       658
-appeared in field:   104/658  (rubric-invariant)
-inside top 30:      45/658  [rubric v2 (live); see the per-rubric blocks below]
+placed trades:       656
+appeared in field:   159/656  (rubric-invariant)
+inside top 30:      43/656  [rubric v3 (live); see the per-rubric blocks below]
 
-star distribution [rubric v2 (live)] (his picks vs the field, same sessions):
-  inside top 30: 45/658 (field re-ranked under this rubric)
+star distribution [rubric v3 (live)] (his picks vs the field, same sessions):
+  inside top 30: 45/656 (field re-ranked under this rubric)
+   4.0 stars:  picks    4  field   197
+   3.5 stars:  picks   14  field  1767
+   3.0 stars:  picks   54  field  4750
+   2.5 stars:  picks   43  field  7858
+   2.0 stars:  picks   29  field  7554
+   1.5 stars:  picks   12  field  4675
+   1.0 stars:  picks    3  field  1892
+   0.5 stars:  picks    0  field   403
+
+star distribution [rubric v2] (his picks vs the field, same sessions):
+  inside top 30: 43/656 (field re-ranked under this rubric)
    4.0 stars:  picks    4  field   342
    3.5 stars:  picks   11  field   916
-   3.0 stars:  picks   22  field  2531
-   2.5 stars:  picks   36  field  3014
-   2.0 stars:  picks   15  field  3259
-   1.5 stars:  picks    9  field  2649
-   1.0 stars:  picks    4  field  1132
-   0.5 stars:  picks    3  field   396
+   3.0 stars:  picks   25  field  3247
+   2.5 stars:  picks   56  field  5451
+   2.0 stars:  picks   31  field  7381
+   1.5 stars:  picks   22  field  7178
+   1.0 stars:  picks    6  field  3319
+   0.5 stars:  picks    4  field  1262
 
 star distribution [rubric v1] (his picks vs the field, same sessions):
-  inside top 30: 41/658 (field re-ranked under this rubric)
+  inside top 30: 31/656 (field re-ranked under this rubric)
    4.5 stars:  picks    4  field   324
    4.0 stars:  picks    5  field  1049
-   3.5 stars:  picks    9  field  1165
-   3.0 stars:  picks   20  field  2822
-   2.5 stars:  picks   25  field  2533
-   2.0 stars:  picks   22  field  2394
-   1.5 stars:  picks   10  field  2129
-   1.0 stars:  picks    6  field  1511
-   0.5 stars:  picks    3  field   312
+   3.5 stars:  picks   12  field  1846
+   3.0 stars:  picks   35  field  5883
+   2.5 stars:  picks   32  field  5223
+   2.0 stars:  picks   35  field  4344
+   1.5 stars:  picks   20  field  5503
+   1.0 stars:  picks   12  field  3946
+   0.5 stars:  picks    4  field   978
 
 == A3 outcome regression ==
 outcome regression against MFE (10sma exit)
-replayable trades: 658  detected: 104  blind-spot coverage: 91 tickers missing
+replayable trades: 656  detected: 159  blind-spot coverage: 92 tickers missing
 
 dimension        weight  n   hit-rate  spread  corr(MFE)
-  Tightness      x2  103   44.7%  0.497  +0.076
-  Orderliness    x1  103   30.1%  0.459  -0.060
-  Prior move     x1  103  100.0%  0.000  untestable (no spread)
-  Base length    x0  103   48.5%  0.500  -0.083
-  MA support     x1  103   76.7%  0.423  -0.158
-  Volume         x1  103   36.9%  0.483  -0.125
-  ADR            x2  103   81.6%  0.388  +0.092
+  Tightness      x2  158   29.1%  0.454  +0.100
+  Orderliness    x1  158   35.4%  0.478  -0.055
+  Prior move     x1  158  100.0%  0.000  untestable (no spread)
+  Base length    x0  158   51.3%  0.500  -0.078
+  MA support     x1  158   77.2%  0.419  -0.127
+  Volume         x1  158   37.3%  0.484  -0.108
+  ADR            x2  158   79.1%  0.406  +0.107
 
-realised R (descriptive): n=657 min=-1.000 p25=-1.000 median=-1.000 p75=-0.490 max=104.020 mean=1.245
+realised R (descriptive): n=655 min=-1.000 p25=-1.000 median=-1.000 p75=-0.505 max=104.020 mean=1.250
 stop width in ADR       : n=649 min=0.000 p25=0.238 median=0.345 p75=0.490 max=2.753 mean=0.395
 ADR at entry            : n=649 min=0.014 p25=0.047 median=0.061 p75=0.089 max=0.652 mean=0.082
   stops at or under 1.0 ADR: 98.2%
@@ -90,16 +100,16 @@ ADR at entry            : n=649 min=0.014 p25=0.047 median=0.061 p75=0.089 max=0
 == A3 selection contrast ==
 selection contrast: executed trades vs not-taken detections
 (no outcome variable — this measures selection, not prediction)
-executed-trade detections: 69  not-taken detections: 14354  blind-spot coverage: 91 tickers missing
+executed-trade detections: 124  not-taken detections: 28672  blind-spot coverage: 92 tickers missing
 
 dimension       weight  his picks        the field he passed over
-  Tightness      x2  taken  59.4% (n=69)  not-taken  38.6% (n=14354)
-  Orderliness    x1  taken  27.5% (n=69)  not-taken  36.6% (n=14354)
-  Prior move     x1  taken 100.0% (n=69)  not-taken 100.0% (n=14354)  (untestable within his trades; no spread here either)
-  Base length    x0  taken  44.9% (n=69)  not-taken  58.3% (n=14354)
-  MA support     x1  taken  76.8% (n=69)  not-taken  72.5% (n=14354)
-  Volume         x1  taken  36.2% (n=69)  not-taken  40.1% (n=14354)
-  ADR            x2  taken  87.0% (n=69)  not-taken  57.6% (n=14354)
+  Tightness      x2  taken  33.1% (n=124)  not-taken  19.3% (n=28672)
+  Orderliness    x1  taken  31.5% (n=124)  not-taken  39.3% (n=28672)
+  Prior move     x1  taken 100.0% (n=124)  not-taken 100.0% (n=28672)  (untestable within his trades; no spread here either)
+  Base length    x0  taken  48.4% (n=124)  not-taken  60.1% (n=28672)
+  MA support     x1  taken  77.4% (n=124)  not-taken  72.0% (n=28672)
+  Volume         x1  taken  38.7% (n=124)  not-taken  38.6% (n=28672)
+  ADR            x2  taken  81.5% (n=124)  not-taken  53.4% (n=28672)
 
 The not-taken detections are a comparison group: field members present on nights he traded, in names he did not enter and may never have seen. Their absence from his trade record carries no verdict on them.
 

--- a/references/replay_study_results.json
+++ b/references/replay_study_results.json
@@ -6,9 +6,9 @@
     "total_rows": 828,
     "rows_with_outcomes": 827,
     "distinct_tickers": 312,
-    "blind_spot_tickers": 91,
-    "blind_spot_trades": 170,
-    "blind_spot_r_share": 0.18146235009109657,
+    "blind_spot_tickers": 92,
+    "blind_spot_trades": 172,
+    "blind_spot_r_share": 0.1801709812401145,
     "blind_spot_ticker_list": [
       "ACST",
       "AGRX",
@@ -37,6 +37,7 @@
       "FMCI",
       "FNGU",
       "FSR",
+      "FUSE",
       "FUV",
       "GAN",
       "GBT",
@@ -109,64 +110,56 @@
       "decile",
       "detection"
     ],
-    "blind_spot_count": 91,
-    "continuation_count": 80,
+    "blind_spot_count": 92,
+    "continuation_count": 79,
     "condition_counts": {
       "base_length": 37,
       "catch_up": 47,
-      "cluster": 171,
-      "history": 23
+      "history": 21,
+      "cluster": 2
     },
     "recall": {
       "liquidity": {
         "passed": 598,
-        "total": 658,
+        "total": 656,
         "passed_ex_continuation": 523,
-        "total_ex_continuation": 578
+        "total_ex_continuation": 577
       },
       "decile": {
         "passed": 395,
-        "total": 658,
+        "total": 656,
         "passed_ex_continuation": 340,
-        "total_ex_continuation": 578
+        "total_ex_continuation": 577
       },
       "detection": {
-        "passed": 380,
-        "total": 658,
-        "passed_ex_continuation": 341,
-        "total_ex_continuation": 578
+        "passed": 549,
+        "total": 656,
+        "passed_ex_continuation": 487,
+        "total_ex_continuation": 577
       }
     },
     "decile_decomposition": {
-      "total_misses": 263,
-      "coverage_gap": 64,
+      "total_misses": 261,
+      "coverage_gap": 62,
       "recovered_by_five": 75,
       "outside_any_union": 124
     },
     "cluster_characterisation": {
-      "total_misses": 171,
-      "continuation": 23,
-      "fresh": 148,
-      "marginal": 113,
-      "far": 58,
+      "total_misses": 2,
+      "continuation": 0,
+      "fresh": 2,
+      "marginal": 0,
+      "far": 2,
       "range_distribution": {
-        "n": 171,
-        "min": 1.5005211162855177,
-        "p25": 1.6774024501426439,
-        "median": 1.8463568887735862,
-        "p75": 2.1311034652874445,
+        "n": 2,
+        "min": 3.1760761746286734,
+        "p25": 3.237975396862097,
+        "median": 3.2998746190955206,
+        "p75": 3.3617738413289437,
         "max": 3.4236730635623673,
-        "mean": 1.9287130434823787
+        "mean": 3.2998746190955206
       },
-      "prior_distance_distribution": {
-        "n": 23,
-        "min": 2.0,
-        "p25": 2.0,
-        "median": 4.0,
-        "p75": 5.0,
-        "max": 5.0,
-        "mean": 3.5652173913043477
-      }
+      "prior_distance_distribution": null
     },
     "rows": [
       {
@@ -563,13 +556,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 611454604.8660278,
-        "range_3bar_adr": 1.9587627488253347,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -675,13 +668,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 79252000.27713776,
-        "range_3bar_adr": 2.897516755992205,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -737,13 +730,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 9800056691.139221,
-        "range_3bar_adr": 1.686945316315257,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 36
       },
       {
@@ -802,7 +795,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 456272713.1187439,
         "range_3bar_adr": null,
@@ -830,13 +823,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 70026006.8894515,
-        "range_3bar_adr": 2.229686935572363,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 10
       },
       {
@@ -861,13 +854,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 335001861.68518066,
-        "range_3bar_adr": 1.7057044579797342,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -923,13 +916,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 1345779639.7636414,
-        "range_3bar_adr": 1.540386171426201,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 5
       },
       {
@@ -954,13 +947,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 143630072.34592438,
-        "range_3bar_adr": 2.441926846438304,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 180
       },
       {
@@ -992,13 +985,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 5942330.0,
-        "range_3bar_adr": 1.7912054260176922,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -1054,13 +1047,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 226779744.19927597,
-        "range_3bar_adr": 1.7895624302526467,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 2
       },
       {
@@ -1207,13 +1200,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 647993179.814107,
-        "range_3bar_adr": 2.2719974001012204,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 79
       },
       {
@@ -1238,13 +1231,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 21559970.617842674,
-        "range_3bar_adr": 2.1133611975423965,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -1269,13 +1262,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 349522601.72777176,
-        "range_3bar_adr": 1.694826084253021,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 46
       },
       {
@@ -1331,13 +1324,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 70000226.87988281,
-        "range_3bar_adr": 2.070156988408644,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 2
       },
       {
@@ -1610,13 +1603,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1140808375.9490967,
-        "range_3bar_adr": 1.7637848851465416,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 98
       },
       {
@@ -1641,13 +1634,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 115875285.1701994,
-        "range_3bar_adr": 1.5521175126007583,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 3
       },
       {
@@ -1848,13 +1841,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 115022318.82751465,
-        "range_3bar_adr": 2.0960513936987373,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 84
       },
       {
@@ -1910,13 +1903,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 918960763.9808655,
-        "range_3bar_adr": 1.8623305160093482,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 4
       },
       {
@@ -1932,7 +1925,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "liquidity",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 9431878.951015472,
         "range_3bar_adr": null,
@@ -1960,13 +1953,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 326326086.1579895,
-        "range_3bar_adr": 1.5621764691711297,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -2052,7 +2045,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 44365778.65486145,
         "range_3bar_adr": null,
@@ -2264,13 +2257,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 261445578.57484818,
-        "range_3bar_adr": 1.6951207252456688,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -2295,13 +2288,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 22344449.0295887,
-        "range_3bar_adr": 1.9495426887742981,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -2503,7 +2496,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 896629641.1212921,
         "range_3bar_adr": null,
@@ -2565,7 +2558,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 650970946.8429565,
         "range_3bar_adr": null,
@@ -2736,13 +2729,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 168261508.4049225,
-        "range_3bar_adr": 2.42487652704151,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 291
       },
       {
@@ -2908,13 +2901,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 489615679.2907715,
-        "range_3bar_adr": 1.676154719717951,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 100
       },
       {
@@ -3018,13 +3011,13 @@
           "3m": false,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 25035714.332504272,
-        "range_3bar_adr": 1.7072662303504875,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -3081,7 +3074,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1154369041.9448853,
         "range_3bar_adr": null,
@@ -3221,13 +3214,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 605970307.1372986,
-        "range_3bar_adr": 1.7329374782109446,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 3
       },
       {
@@ -3250,13 +3243,13 @@
           "3m": true,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 386696371.79374695,
-        "range_3bar_adr": 1.535010402678797,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 33
       },
       {
@@ -3480,13 +3473,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 345299831.6078186,
-        "range_3bar_adr": 1.7090395800485292,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 3
       },
       {
@@ -3571,13 +3564,13 @@
           "3m": true,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 49628236.06438446,
-        "range_3bar_adr": 2.070333290554004,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 29
       },
       {
@@ -3602,13 +3595,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 84284160.58120728,
-        "range_3bar_adr": 1.705022137067258,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -3736,7 +3729,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 220947017.53234863,
         "range_3bar_adr": null,
@@ -3795,13 +3788,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 119765187.40844727,
-        "range_3bar_adr": 2.0336966748602343,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 29
       },
       {
@@ -3911,13 +3904,13 @@
           "1m": false,
           "3m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 29066940.130329132,
-        "range_3bar_adr": 1.6575167691259562,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -4097,13 +4090,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 673029282.611618,
-        "range_3bar_adr": 2.4000530423590627,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 24
       },
       {
@@ -4128,13 +4121,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 406011141.1628723,
-        "range_3bar_adr": 1.6659308338686272,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 126
       },
       {
@@ -4159,13 +4152,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 149816005.12161255,
-        "range_3bar_adr": 2.5953080640877406,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 15
       },
       {
@@ -4193,7 +4186,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 420001621.17233276,
         "range_3bar_adr": null,
@@ -4284,7 +4277,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 387786575.70610046,
         "range_3bar_adr": null,
@@ -4406,7 +4399,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 212291740.21148682,
         "range_3bar_adr": null,
@@ -4558,13 +4551,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 673783525.1858711,
-        "range_3bar_adr": 1.5157500721579225,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 11
       },
       {
@@ -4707,13 +4700,13 @@
           "3m": true,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 2061947527.7755737,
-        "range_3bar_adr": 1.6363867882521852,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -4738,13 +4731,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 215936942.33589172,
-        "range_3bar_adr": 1.5009251582531586,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 2
       },
       {
@@ -4769,13 +4762,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 35181954.34188843,
-        "range_3bar_adr": 2.891016540497,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -4803,7 +4796,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 465558358.2763672,
         "range_3bar_adr": null,
@@ -4855,7 +4848,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 54710941.791381836,
         "range_3bar_adr": null,
@@ -4917,7 +4910,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 493873034.88702774,
         "range_3bar_adr": null,
@@ -4976,13 +4969,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 1367755290.737152,
-        "range_3bar_adr": 1.6407318457379738,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -5007,33 +5000,14 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 219530122.22604752,
-        "range_3bar_adr": 1.9744089356451626,
-        "sessions_since_prior_entry": 13
-      },
-      {
-        "ticker": "FUSE",
-        "entry_date": "2021-01-07",
-        "eval_session": "2021-01-06",
-        "liquidity_pass": false,
-        "decile_present": false,
-        "decile_pass": false,
-        "decile_pass_five": false,
-        "eval_percentiles": {},
-        "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "history",
-        "first_failing_stage": "liquidity",
-        "entry_session_break": false,
-        "continuation": true,
-        "median_dollar_volume": 0.0,
         "range_3bar_adr": null,
-        "sessions_since_prior_entry": 3
+        "sessions_since_prior_entry": 13
       },
       {
         "ticker": "Z",
@@ -5088,13 +5062,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 37641779.15496826,
-        "range_3bar_adr": 1.549635148205623,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -5119,13 +5093,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 116606962.43171692,
-        "range_3bar_adr": 1.5005211162855177,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 50
       },
       {
@@ -5150,13 +5124,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 38744559.283447266,
-        "range_3bar_adr": 2.371444143799495,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 7
       },
       {
@@ -5575,7 +5549,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 428396111.4692688,
         "range_3bar_adr": null,
@@ -5591,13 +5565,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 13500012.119293213,
-        "range_3bar_adr": 1.6983510058126614,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -5682,13 +5656,13 @@
           "3m": false,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 20266344.168395996,
-        "range_3bar_adr": 2.148845733032492,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 5
       },
       {
@@ -5775,13 +5749,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 657073226.791954,
-        "range_3bar_adr": 1.779747869619248,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 50
       },
       {
@@ -5837,13 +5811,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 30438425.98876953,
-        "range_3bar_adr": 1.7762545897214652,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 8
       },
       {
@@ -5902,7 +5876,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 60209601.38320923,
         "range_3bar_adr": null,
@@ -5930,13 +5904,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1400720739.163971,
-        "range_3bar_adr": 1.6243248609721344,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 37
       },
       {
@@ -6023,13 +5997,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 681138910.0650787,
-        "range_3bar_adr": 1.7493824738593045,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 11
       },
       {
@@ -6178,13 +6152,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 354236136.3178253,
-        "range_3bar_adr": 2.205039020418428,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 60
       },
       {
@@ -6243,7 +6217,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 330127534.17282104,
         "range_3bar_adr": null,
@@ -6333,13 +6307,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 799178138.6112213,
-        "range_3bar_adr": 1.968065154476879,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 4
       },
       {
@@ -6364,13 +6338,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 34742799566.79382,
-        "range_3bar_adr": 1.8469444022790023,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 15
       },
       {
@@ -6455,13 +6429,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 240981423.097229,
-        "range_3bar_adr": 1.9681587197977028,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -6486,13 +6460,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 4400042379.627991,
-        "range_3bar_adr": 1.75527546772622,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -6548,13 +6522,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 239370369.2346573,
-        "range_3bar_adr": 1.6415478750060233,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 9
       },
       {
@@ -6610,13 +6584,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 33349061.134783745,
-        "range_3bar_adr": 1.9548105193904672,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 30
       },
       {
@@ -6730,13 +6704,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 4774774708.453369,
-        "range_3bar_adr": 1.7824046620760374,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 7
       },
       {
@@ -6790,13 +6764,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 99886161.9146347,
-        "range_3bar_adr": 2.1830437319269307,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 464
       },
       {
@@ -6821,13 +6795,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 739621341.0491943,
-        "range_3bar_adr": 1.8267441889958373,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 2
       },
       {
@@ -6855,7 +6829,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 49449590.333366394,
         "range_3bar_adr": null,
@@ -6883,13 +6857,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 280490549.5063782,
-        "range_3bar_adr": 1.8463568887735862,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 102
       },
       {
@@ -6977,7 +6951,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 218999374.86495972,
         "range_3bar_adr": null,
@@ -7034,13 +7008,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 533122492.12646484,
-        "range_3bar_adr": 2.31000887697007,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -7065,13 +7039,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 533177349.51782227,
-        "range_3bar_adr": 2.152611341098387,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 12
       },
       {
@@ -7189,13 +7163,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 25758650564.190674,
-        "range_3bar_adr": 1.706615527917372,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 31
       },
       {
@@ -7220,13 +7194,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 355034179.4075012,
-        "range_3bar_adr": 1.6822811425686348,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 38
       },
       {
@@ -7249,13 +7223,13 @@
           "3m": true,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 182814663.33332062,
-        "range_3bar_adr": 1.7365648678801109,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -7280,13 +7254,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1117746978.1082153,
-        "range_3bar_adr": 1.9250460849204971,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 9
       },
       {
@@ -7312,7 +7286,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1829680497.9499817,
         "range_3bar_adr": null,
@@ -7459,7 +7433,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 810810152.5054932,
         "range_3bar_adr": null,
@@ -7549,13 +7523,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 1327032006.952858,
-        "range_3bar_adr": 2.523307034056742,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 188
       },
       {
@@ -7702,13 +7676,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1061729514.617157,
-        "range_3bar_adr": 1.5686492980688551,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -7764,13 +7738,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 640503509.3799591,
-        "range_3bar_adr": 1.8207341611541634,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 8
       },
       {
@@ -7795,13 +7769,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 117063646.9116211,
-        "range_3bar_adr": 2.435427322663399,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -7829,7 +7803,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 783768048.9233017,
         "range_3bar_adr": null,
@@ -7857,13 +7831,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 70737153.47366333,
-        "range_3bar_adr": 2.149713874691997,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 207
       },
       {
@@ -8062,13 +8036,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 681138910.0650787,
-        "range_3bar_adr": 1.7206687837480672,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 5
       },
       {
@@ -8096,7 +8070,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 13931725491.645813,
         "range_3bar_adr": null,
@@ -8186,13 +8160,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1766039968.4448242,
-        "range_3bar_adr": 2.2447147985890377,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -8217,13 +8191,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 782485812.8181458,
-        "range_3bar_adr": 1.8816974901696728,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 24
       },
       {
@@ -8279,13 +8253,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 233286248.2788086,
-        "range_3bar_adr": 1.5338928857001626,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 30
       },
       {
@@ -8344,7 +8318,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 26395669.073867798,
         "range_3bar_adr": null,
@@ -8375,7 +8349,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 735467092.3843384,
         "range_3bar_adr": null,
@@ -8403,13 +8377,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 69514344.54345703,
-        "range_3bar_adr": 2.1732831446739524,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 5
       },
       {
@@ -8465,13 +8439,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 539063630.0041199,
-        "range_3bar_adr": 2.3166497428678947,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 6
       },
       {
@@ -8527,13 +8501,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 188828629.49127674,
-        "range_3bar_adr": 1.5841599254662733,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 90
       },
       {
@@ -8561,7 +8535,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 151090892.49664307,
         "range_3bar_adr": null,
@@ -8589,13 +8563,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 209884102.4963379,
-        "range_3bar_adr": 1.9561818426577966,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 284
       },
       {
@@ -8651,13 +8625,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 27093136547.47467,
-        "range_3bar_adr": 1.8815927451280723,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 6
       },
       {
@@ -8685,7 +8659,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 503464658.2710266,
         "range_3bar_adr": null,
@@ -8744,13 +8718,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 394226167.6742554,
-        "range_3bar_adr": 1.5704200534348276,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 20
       },
       {
@@ -8837,13 +8811,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 341771586.9846344,
-        "range_3bar_adr": 2.1911719310848947,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 5
       },
       {
@@ -8871,7 +8845,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1542924724.9679565,
         "range_3bar_adr": null,
@@ -8902,7 +8876,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1253181785.974121,
         "range_3bar_adr": null,
@@ -8931,7 +8905,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 55181969.03514862,
         "range_3bar_adr": null,
@@ -8962,7 +8936,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 142015781.17141724,
         "range_3bar_adr": null,
@@ -8993,7 +8967,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 721969135.461998,
         "range_3bar_adr": null,
@@ -9174,13 +9148,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 211720624.4874153,
-        "range_3bar_adr": 1.5393277958315748,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 118
       },
       {
@@ -9330,7 +9304,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 213609588.39263916,
         "range_3bar_adr": null,
@@ -9419,7 +9393,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 100245491.1037445,
         "range_3bar_adr": null,
@@ -9507,13 +9481,13 @@
           "3m": true,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 395519478.35731506,
-        "range_3bar_adr": 2.0530517361592584,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 119
       },
       {
@@ -9538,13 +9512,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 625036241.0903931,
-        "range_3bar_adr": 2.0008925318934216,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 11
       },
       {
@@ -9597,7 +9571,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 557782527.1476746,
         "range_3bar_adr": null,
@@ -9659,7 +9633,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 232754383.01296234,
         "range_3bar_adr": null,
@@ -9740,7 +9714,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 181378004.45518494,
         "range_3bar_adr": null,
@@ -9771,7 +9745,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 861103095.7004547,
         "range_3bar_adr": null,
@@ -9830,13 +9804,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 178327818.35784912,
-        "range_3bar_adr": 1.9593656786761882,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -9861,13 +9835,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 646491620.4051971,
-        "range_3bar_adr": 2.0407245413428354,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 27
       },
       {
@@ -9895,7 +9869,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 832241157.4047089,
         "range_3bar_adr": null,
@@ -9985,13 +9959,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 232921472.48535156,
-        "range_3bar_adr": 2.0888342654479377,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 11
       },
       {
@@ -10047,13 +10021,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 9333418632.803726,
-        "range_3bar_adr": 1.8125244140385905,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 297
       },
       {
@@ -10078,13 +10052,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 152817187.61634827,
-        "range_3bar_adr": 1.8694549365107582,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 11
       },
       {
@@ -10107,13 +10081,13 @@
           "3m": false,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 183337952.444458,
-        "range_3bar_adr": 1.7302212177152776,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -10169,13 +10143,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1054989450.7527351,
-        "range_3bar_adr": 1.6786501805673368,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -10234,7 +10208,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1586520295.1202393,
         "range_3bar_adr": null,
@@ -10312,13 +10286,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 939135046.7132568,
-        "range_3bar_adr": 1.8020499086435777,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 31
       },
       {
@@ -10439,7 +10413,7 @@
         "detection_pass": false,
         "failed_condition": "cluster",
         "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 426197359.8083496,
         "range_3bar_adr": 3.1760761746286734,
@@ -10467,13 +10441,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 86511651.63536072,
-        "range_3bar_adr": 2.038504882136336,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -10501,7 +10475,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 112455536.54642105,
         "range_3bar_adr": null,
@@ -10684,13 +10658,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 402874360.20851135,
-        "range_3bar_adr": 2.100900869380394,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -10746,13 +10720,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 455726173.2154846,
-        "range_3bar_adr": 1.8296427077115094,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 2
       },
       {
@@ -10836,7 +10810,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1269338812.7301025,
         "range_3bar_adr": null,
@@ -10893,13 +10867,13 @@
           "3m": false,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 159975706.92100525,
-        "range_3bar_adr": 1.762280597065675,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -11015,13 +10989,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 806011017.1348572,
-        "range_3bar_adr": 1.6686663684292775,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -11046,13 +11020,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 394150799.1897583,
-        "range_3bar_adr": 1.8760616819330336,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 4
       },
       {
@@ -11080,7 +11054,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 258926417.17071533,
         "range_3bar_adr": null,
@@ -11142,7 +11116,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1950161898.4294891,
         "range_3bar_adr": null,
@@ -11173,7 +11147,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1269687769.7486877,
         "range_3bar_adr": null,
@@ -11189,13 +11163,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 18876338.605880737,
-        "range_3bar_adr": 1.64856350684852,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 399
       },
       {
@@ -11278,13 +11252,13 @@
           "3m": true,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 70240206.61621094,
-        "range_3bar_adr": 2.714881144167653,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 11
       },
       {
@@ -11309,13 +11283,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 994098371.5763092,
-        "range_3bar_adr": 2.2671495317458072,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 11
       },
       {
@@ -11390,13 +11364,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 2958806587.703705,
-        "range_3bar_adr": 2.4769365488930037,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 26
       },
       {
@@ -11653,13 +11627,13 @@
           "3m": false,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 57309918.8123703,
-        "range_3bar_adr": 2.156205863967897,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -11684,13 +11658,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": true,
         "median_dollar_volume": 150032554.11186218,
-        "range_3bar_adr": 2.0604056171684904,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 4
       },
       {
@@ -11746,13 +11720,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 363695032.5562744,
-        "range_3bar_adr": 1.6461314080463239,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 19
       },
       {
@@ -11859,7 +11833,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 54295551.62780285,
         "range_3bar_adr": null,
@@ -11949,13 +11923,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 870874189.3493652,
-        "range_3bar_adr": 2.161282344408914,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 4
       },
       {
@@ -11980,13 +11954,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 403030651.66778564,
-        "range_3bar_adr": 1.5946933154113194,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 22
       },
       {
@@ -12040,13 +12014,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 359418732.30514526,
-        "range_3bar_adr": 1.6934731423193117,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 91
       },
       {
@@ -12105,7 +12079,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 234842396.4668274,
         "range_3bar_adr": null,
@@ -12133,13 +12107,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 408710001.98604584,
-        "range_3bar_adr": 2.466671605646029,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 4
       },
       {
@@ -12198,7 +12172,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 5827553348.057556,
         "range_3bar_adr": null,
@@ -12257,13 +12231,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 56904045.52838802,
-        "range_3bar_adr": 1.5641428779728859,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -12477,7 +12451,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 54570804.26559448,
         "range_3bar_adr": null,
@@ -12537,7 +12511,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 182787046.29592896,
         "range_3bar_adr": null,
@@ -12565,13 +12539,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 562520150.1903534,
-        "range_3bar_adr": 1.6868368174393762,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 26
       },
       {
@@ -12594,13 +12568,13 @@
           "3m": false,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 20579681.033706665,
-        "range_3bar_adr": 1.6325335325642252,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 12
       },
       {
@@ -12686,7 +12660,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 299223555.0945282,
         "range_3bar_adr": null,
@@ -12717,7 +12691,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 199090497.8942871,
         "range_3bar_adr": null,
@@ -12841,7 +12815,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 251984776.9809723,
         "range_3bar_adr": null,
@@ -12965,7 +12939,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 430873260.3178024,
         "range_3bar_adr": null,
@@ -12993,13 +12967,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 564280651.5701294,
-        "range_3bar_adr": 2.4270945080278934,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 10
       },
       {
@@ -13055,13 +13029,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 1290957716.8075562,
-        "range_3bar_adr": 1.89900244881799,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 90
       },
       {
@@ -13177,13 +13151,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 559186313.571167,
-        "range_3bar_adr": 1.7124909557585701,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 77
       },
       {
@@ -13304,7 +13278,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 606131654.7805786,
         "range_3bar_adr": null,
@@ -13361,13 +13335,13 @@
           "3m": true,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 351599771.47865295,
-        "range_3bar_adr": 2.284157410386644,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 47
       },
       {
@@ -13392,13 +13366,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 757078494.1532135,
-        "range_3bar_adr": 2.2234329574931024,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 30
       },
       {
@@ -13516,13 +13490,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 263144593.0229187,
-        "range_3bar_adr": 1.77243027701507,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -13579,7 +13553,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 160150974.2904663,
         "range_3bar_adr": null,
@@ -13732,7 +13706,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 125075137.71514893,
         "range_3bar_adr": null,
@@ -13792,7 +13766,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 151416574.1672516,
         "range_3bar_adr": null,
@@ -13882,13 +13856,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 241229453.56537056,
-        "range_3bar_adr": 1.8998567235102362,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 27
       },
       {
@@ -13938,13 +13912,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 648400354.0878296,
-        "range_3bar_adr": 1.643815058566333,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 110
       },
       {
@@ -13969,13 +13943,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 1334350783.121109,
-        "range_3bar_adr": 2.0233503187198334,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 73
       },
       {
@@ -14096,7 +14070,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 568093685.9736443,
         "range_3bar_adr": null,
@@ -14127,7 +14101,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 2869848081.192398,
         "range_3bar_adr": null,
@@ -14217,13 +14191,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 265871899.6887207,
-        "range_3bar_adr": 2.171919391907321,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -14248,13 +14222,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 328359613.36502075,
-        "range_3bar_adr": 1.7227168566883935,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 9
       },
       {
@@ -14313,7 +14287,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 238201986.5715027,
         "range_3bar_adr": null,
@@ -14391,13 +14365,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 41361520.5242157,
-        "range_3bar_adr": 1.5525373740879183,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 2
       },
       {
@@ -14422,13 +14396,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 58896824.39804077,
-        "range_3bar_adr": 2.184630234735632,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 2
       },
       {
@@ -14453,13 +14427,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 603715868.3898926,
-        "range_3bar_adr": 1.593013769166573,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -14549,7 +14523,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 261969128.42407227,
         "range_3bar_adr": null,
@@ -14577,13 +14551,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 505215350.3528595,
-        "range_3bar_adr": 1.7702665904811545,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 71
       },
       {
@@ -14728,13 +14702,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 884604520.9510803,
-        "range_3bar_adr": 1.973516632073895,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 187
       },
       {
@@ -14759,13 +14733,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 409317475.3015518,
-        "range_3bar_adr": 2.490681386689015,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 9
       },
       {
@@ -14788,13 +14762,13 @@
           "3m": false,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 298921630.0,
-        "range_3bar_adr": 1.6492202696562759,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -14838,13 +14812,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 6190896.9886779785,
-        "range_3bar_adr": 2.6984021174314825,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -14900,13 +14874,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 755517127.7927399,
-        "range_3bar_adr": 2.7296617146208715,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 22
       },
       {
@@ -14934,7 +14908,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 563093671.0090637,
         "range_3bar_adr": null,
@@ -15085,7 +15059,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 102984916.65434837,
         "range_3bar_adr": null,
@@ -15113,13 +15087,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 37673618.52769852,
-        "range_3bar_adr": 1.555905732312668,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 10
       },
       {
@@ -15175,13 +15149,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 32890232.208251953,
-        "range_3bar_adr": 2.2492538195875507,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 59
       },
       {
@@ -15207,7 +15181,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 54095493.56272888,
         "range_3bar_adr": null,
@@ -15378,13 +15352,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 549203832.5939178,
-        "range_3bar_adr": 1.9208057067606292,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 76
       },
       {
@@ -15469,25 +15443,6 @@
         "sessions_since_prior_entry": null
       },
       {
-        "ticker": "FUSE",
-        "entry_date": "2021-01-04",
-        "eval_session": "2020-12-31",
-        "liquidity_pass": false,
-        "decile_present": false,
-        "decile_pass": false,
-        "decile_pass_five": false,
-        "eval_percentiles": {},
-        "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "history",
-        "first_failing_stage": "liquidity",
-        "entry_session_break": false,
-        "continuation": false,
-        "median_dollar_volume": 0.0,
-        "range_3bar_adr": null,
-        "sessions_since_prior_entry": null
-      },
-      {
         "ticker": "FUTU",
         "entry_date": "2021-03-16",
         "eval_session": "2021-03-15",
@@ -15512,7 +15467,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1966726581.4117432,
         "range_3bar_adr": null,
@@ -15752,7 +15707,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 250658145.47157288,
         "range_3bar_adr": null,
@@ -15780,13 +15735,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 107123525.09689331,
-        "range_3bar_adr": 2.4957177955842185,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -15923,13 +15878,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 431115386.3937378,
-        "range_3bar_adr": 1.519390810367637,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 91
       },
       {
@@ -15942,13 +15897,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 294185.98980903625,
-        "range_3bar_adr": 1.9800527917850324,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -16035,13 +15990,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 302759825.61893463,
-        "range_3bar_adr": 1.6872881830599367,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -16181,7 +16136,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 278677478.70788574,
         "range_3bar_adr": null,
@@ -16209,13 +16164,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 33786726457.24182,
-        "range_3bar_adr": 1.8548593906698618,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 5
       },
       {
@@ -16336,7 +16291,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 646672421.6972351,
         "range_3bar_adr": null,
@@ -16364,13 +16319,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 61776499.34310913,
-        "range_3bar_adr": 2.1799605802205275,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -16383,13 +16338,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 3648408.9710235596,
-        "range_3bar_adr": 2.073367494788934,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -16445,13 +16400,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 1142989040.638733,
-        "range_3bar_adr": 1.7987223873889335,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 66
       },
       {
@@ -16505,13 +16460,13 @@
           "3m": true,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 288600923.20098877,
-        "range_3bar_adr": 1.6514522705405943,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 7
       },
       {
@@ -16534,13 +16489,13 @@
           "3m": false,
           "6m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 46815433.97426605,
-        "range_3bar_adr": 1.7332702872448464,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -16646,13 +16601,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 547610625.704956,
-        "range_3bar_adr": 1.9228595029181579,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 432
       },
       {
@@ -16768,13 +16723,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 211272709.88826752,
-        "range_3bar_adr": 1.6121068609688294,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -16799,13 +16754,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 433225925.4764557,
-        "range_3bar_adr": 1.616324590093261,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 13
       },
       {
@@ -17002,13 +16957,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 9149115.893936157,
-        "range_3bar_adr": 2.2871198612425734,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -17067,7 +17022,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 71053193.42422485,
         "range_3bar_adr": null,
@@ -17083,13 +17038,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 14921594.76829052,
-        "range_3bar_adr": 1.6693827712444853,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 9
       },
       {
@@ -17114,13 +17069,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 350134125.6767273,
-        "range_3bar_adr": 1.6445846979600511,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -17148,7 +17103,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 72353514.48822021,
         "range_3bar_adr": null,
@@ -17236,13 +17191,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 851038562.7319336,
-        "range_3bar_adr": 2.079824869089526,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 62
       },
       {
@@ -17267,13 +17222,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 346381920.5505371,
-        "range_3bar_adr": 1.6662457526613292,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 86
       },
       {
@@ -17469,7 +17424,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 44424495.2221632,
         "range_3bar_adr": null,
@@ -17531,7 +17486,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 82408511.18564606,
         "range_3bar_adr": null,
@@ -17562,7 +17517,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 103485719.67811584,
         "range_3bar_adr": null,
@@ -17590,13 +17545,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "decile",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 513931582.78656006,
-        "range_3bar_adr": 1.9167443805974453,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 121
       },
       {
@@ -17649,7 +17604,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": null,
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 37590277.93159485,
         "range_3bar_adr": null,
@@ -17797,13 +17752,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 433747757.0640564,
-        "range_3bar_adr": 1.732346169291726,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 130
       },
       {
@@ -17890,13 +17845,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 488415051.7738342,
-        "range_3bar_adr": 1.6124083943766316,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -18191,13 +18146,13 @@
           "6m": false,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 212312692.85125732,
-        "range_3bar_adr": 1.8632642254528433,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 144
       },
       {
@@ -18423,13 +18378,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 28910449.16419983,
-        "range_3bar_adr": 1.7685434767345012,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 6
       },
       {
@@ -18503,7 +18458,7 @@
         "detection_pass": true,
         "failed_condition": null,
         "first_failing_stage": "liquidity",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 18111610.0,
         "range_3bar_adr": null,
@@ -18548,13 +18503,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 14919048.374772072,
-        "range_3bar_adr": 1.8037106097531106,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 9
       },
       {
@@ -18648,13 +18603,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 812808417.7631378,
-        "range_3bar_adr": 2.203253523002488,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 6
       },
       {
@@ -18696,13 +18651,13 @@
           "3m": true,
           "6m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 90912243.82572174,
-        "range_3bar_adr": 2.193412484345611,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -18758,13 +18713,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 120628685.81643105,
-        "range_3bar_adr": 1.9178765372565159,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -18789,13 +18744,13 @@
           "6m": true,
           "12m": false
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 28052267.162275314,
-        "range_3bar_adr": 1.5473981914330113,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -18942,7 +18897,7 @@
         "detection_pass": false,
         "failed_condition": "base_length",
         "first_failing_stage": "liquidity",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 12136086.31927967,
         "range_3bar_adr": null,
@@ -18970,13 +18925,13 @@
           "6m": false,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 105022284.73235607,
-        "range_3bar_adr": 1.9646170219864627,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 183
       },
       {
@@ -19001,13 +18956,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 38756283.17292929,
-        "range_3bar_adr": 1.8892056888012305,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -19033,7 +18988,7 @@
         "detection_pass": false,
         "failed_condition": "base_length",
         "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 25775558.0,
         "range_3bar_adr": null,
@@ -19109,13 +19064,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
-        "entry_session_break": false,
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 636427760.4358673,
-        "range_3bar_adr": 1.6710947083366972,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 10
       },
       {
@@ -19197,13 +19152,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
         "entry_session_break": false,
         "continuation": false,
         "median_dollar_volume": 49579.50061559677,
-        "range_3bar_adr": 1.6023395267090115,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -19366,13 +19321,13 @@
         "decile_pass_five": false,
         "eval_percentiles": {},
         "decile_verdicts": {},
-        "detection_pass": false,
-        "failed_condition": "cluster",
+        "detection_pass": true,
+        "failed_condition": null,
         "first_failing_stage": "liquidity",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 929879.1655960083,
-        "range_3bar_adr": 1.563707684981835,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": null
       },
       {
@@ -19495,13 +19450,13 @@
           "6m": true,
           "12m": true
         },
-        "detection_pass": false,
-        "failed_condition": "cluster",
-        "first_failing_stage": "detection",
+        "detection_pass": true,
+        "failed_condition": null,
+        "first_failing_stage": null,
         "entry_session_break": true,
         "continuation": true,
         "median_dollar_volume": 28329912.497663498,
-        "range_3bar_adr": 1.7306853638581172,
+        "range_3bar_adr": null,
         "sessions_since_prior_entry": 5
       },
       {
@@ -19517,7 +19472,7 @@
         "detection_pass": false,
         "failed_condition": "catch_up",
         "first_failing_stage": "liquidity",
-        "entry_session_break": false,
+        "entry_session_break": true,
         "continuation": false,
         "median_dollar_volume": 287160.0,
         "range_3bar_adr": null,
@@ -19577,98 +19532,126 @@
   },
   "placement": {
     "board_size": 30,
-    "blind_spot_count": 91,
+    "blind_spot_count": 92,
     "scope": "US 2019\u20132022",
-    "in_field_count": 104,
-    "top_thirty_count": 45,
+    "in_field_count": 159,
+    "top_thirty_count": 43,
     "picks": {
-      "total": 104,
+      "total": 159,
       "counts": {
         "4.0": 4,
-        "3.5": 11,
-        "3.0": 22,
-        "2.5": 36,
-        "2.0": 15,
-        "1.5": 9,
-        "1.0": 4,
-        "0.5": 3
+        "3.5": 14,
+        "3.0": 54,
+        "2.5": 43,
+        "2.0": 29,
+        "1.5": 12,
+        "1.0": 3
       }
     },
     "field": {
-      "total": 14239,
+      "total": 29096,
       "counts": {
-        "4.0": 342,
-        "3.5": 916,
-        "3.0": 2531,
-        "2.5": 3014,
-        "2.0": 3259,
-        "1.5": 2649,
-        "1.0": 1132,
-        "0.5": 396
+        "4.0": 197,
+        "3.5": 1767,
+        "3.0": 4750,
+        "2.5": 7858,
+        "2.0": 7554,
+        "1.5": 4675,
+        "1.0": 1892,
+        "0.5": 403
       }
     },
     "by_rubric": [
       {
-        "rubric_version": 2,
+        "rubric_version": 3,
         "picks": {
-          "total": 104,
+          "total": 159,
           "counts": {
             "4.0": 4,
-            "3.5": 11,
-            "3.0": 22,
-            "2.5": 36,
-            "2.0": 15,
-            "1.5": 9,
-            "1.0": 4,
-            "0.5": 3
+            "3.5": 14,
+            "3.0": 54,
+            "2.5": 43,
+            "2.0": 29,
+            "1.5": 12,
+            "1.0": 3
           }
         },
         "field": {
-          "total": 14239,
+          "total": 29096,
           "counts": {
-            "4.0": 342,
-            "3.5": 916,
-            "3.0": 2531,
-            "2.5": 3014,
-            "2.0": 3259,
-            "1.5": 2649,
-            "1.0": 1132,
-            "0.5": 396
+            "4.0": 197,
+            "3.5": 1767,
+            "3.0": 4750,
+            "2.5": 7858,
+            "2.0": 7554,
+            "1.5": 4675,
+            "1.0": 1892,
+            "0.5": 403
           }
         },
         "top_thirty": 45
       },
       {
-        "rubric_version": 1,
+        "rubric_version": 2,
         "picks": {
-          "total": 104,
+          "total": 159,
           "counts": {
-            "4.5": 4,
-            "4.0": 5,
-            "3.5": 9,
-            "3.0": 20,
-            "2.5": 25,
-            "2.0": 22,
-            "1.5": 10,
+            "4.0": 4,
+            "3.5": 11,
+            "3.0": 25,
+            "2.5": 56,
+            "2.0": 31,
+            "1.5": 22,
             "1.0": 6,
-            "0.5": 3
+            "0.5": 4
           }
         },
         "field": {
-          "total": 14239,
+          "total": 29096,
+          "counts": {
+            "4.0": 342,
+            "3.5": 916,
+            "3.0": 3247,
+            "2.5": 5451,
+            "2.0": 7381,
+            "1.5": 7178,
+            "1.0": 3319,
+            "0.5": 1262
+          }
+        },
+        "top_thirty": 43
+      },
+      {
+        "rubric_version": 1,
+        "picks": {
+          "total": 159,
+          "counts": {
+            "4.5": 4,
+            "4.0": 5,
+            "3.5": 12,
+            "3.0": 35,
+            "2.5": 32,
+            "2.0": 35,
+            "1.5": 20,
+            "1.0": 12,
+            "0.5": 4
+          }
+        },
+        "field": {
+          "total": 29096,
           "counts": {
             "4.5": 324,
             "4.0": 1049,
-            "3.5": 1165,
-            "3.0": 2822,
-            "2.5": 2533,
-            "2.0": 2394,
-            "1.5": 2129,
-            "1.0": 1511,
-            "0.5": 312
+            "3.5": 1846,
+            "3.0": 5883,
+            "2.5": 5223,
+            "2.0": 4344,
+            "1.5": 5503,
+            "1.0": 3946,
+            "0.5": 978
           }
         },
-        "top_thirty": 41
+        "top_thirty": 31
       }
     ],
     "placements": [
@@ -19677,7 +19660,7 @@
         "entry_date": "2021-02-24",
         "eval_session": "2021-02-23",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 2.5
       },
       {
@@ -19788,9 +19771,9 @@
         "ticker": "MSTR",
         "entry_date": "2021-01-28",
         "eval_session": "2021-01-27",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "GBTC",
@@ -19805,7 +19788,7 @@
         "entry_date": "2021-01-12",
         "eval_session": "2021-01-11",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 2.5
       },
       {
@@ -19860,9 +19843,9 @@
         "ticker": "ETHE",
         "entry_date": "2021-03-29",
         "eval_session": "2021-03-26",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "W",
@@ -19964,9 +19947,9 @@
         "ticker": "GBTC",
         "entry_date": "2021-02-02",
         "eval_session": "2021-02-01",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "CAN",
@@ -19980,9 +19963,9 @@
         "ticker": "CAN",
         "entry_date": "2021-03-09",
         "eval_session": "2021-03-08",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
+        "in_field": true,
+        "top_thirty": true,
+        "stars": 2.5
       },
       {
         "ticker": "APT",
@@ -20076,9 +20059,9 @@
         "ticker": "ETHE",
         "entry_date": "2021-02-02",
         "eval_session": "2021-02-01",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "OKTA",
@@ -20244,17 +20227,17 @@
         "ticker": "CLF",
         "entry_date": "2021-03-26",
         "eval_session": "2021-03-25",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "WWR",
         "entry_date": "2021-01-19",
         "eval_session": "2021-01-15",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "XOP",
@@ -20285,7 +20268,7 @@
         "entry_date": "2022-02-28",
         "eval_session": "2022-02-25",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 2.5
       },
       {
@@ -20372,9 +20355,9 @@
         "ticker": "NUGT",
         "entry_date": "2022-03-01",
         "eval_session": "2022-02-28",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "LABU",
@@ -20580,9 +20563,9 @@
         "ticker": "MSTR",
         "entry_date": "2021-11-02",
         "eval_session": "2021-11-01",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "ZM",
@@ -20612,9 +20595,9 @@
         "ticker": "NTLA",
         "entry_date": "2021-03-30",
         "eval_session": "2021-03-29",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "COPX",
@@ -20748,9 +20731,9 @@
         "ticker": "GBTC",
         "entry_date": "2021-03-09",
         "eval_session": "2021-03-08",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "IGV",
@@ -20861,7 +20844,7 @@
         "entry_date": "2021-01-29",
         "eval_session": "2021-01-28",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 2.0
       },
       {
@@ -20908,25 +20891,25 @@
         "ticker": "COIN",
         "entry_date": "2021-11-15",
         "eval_session": "2021-11-12",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "GUSH",
         "entry_date": "2021-11-08",
         "eval_session": "2021-11-05",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
+        "in_field": true,
+        "top_thirty": true,
+        "stars": 3.0
       },
       {
         "ticker": "PBW",
         "entry_date": "2021-11-11",
         "eval_session": "2021-11-10",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "DXCM",
@@ -20993,14 +20976,6 @@
         "stars": null
       },
       {
-        "ticker": "FUSE",
-        "entry_date": "2021-01-07",
-        "eval_session": "2021-01-06",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
-      },
-      {
         "ticker": "Z",
         "entry_date": "2020-07-30",
         "eval_session": "2020-07-29",
@@ -21012,9 +20987,9 @@
         "ticker": "QCLN",
         "entry_date": "2021-11-22",
         "eval_session": "2021-11-19",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "JNUG",
@@ -21212,9 +21187,9 @@
         "ticker": "AGQ",
         "entry_date": "2021-05-03",
         "eval_session": "2021-04-30",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "LMT",
@@ -21300,9 +21275,9 @@
         "ticker": "ERX",
         "entry_date": "2022-03-30",
         "eval_session": "2022-03-29",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "UBER",
@@ -21348,9 +21323,9 @@
         "ticker": "TSLA",
         "entry_date": "2021-11-19",
         "eval_session": "2021-11-18",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "SHOP",
@@ -21460,9 +21435,9 @@
         "ticker": "ERX",
         "entry_date": "2021-12-07",
         "eval_session": "2021-12-06",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "JD",
@@ -21484,9 +21459,9 @@
         "ticker": "NET",
         "entry_date": "2021-09-16",
         "eval_session": "2021-09-15",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "BABA",
@@ -21564,9 +21539,9 @@
         "ticker": "TSLA",
         "entry_date": "2022-01-12",
         "eval_session": "2022-01-11",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
+        "in_field": true,
+        "top_thirty": true,
+        "stars": 2.5
       },
       {
         "ticker": "DDOG",
@@ -21716,17 +21691,17 @@
         "ticker": "NEM",
         "entry_date": "2022-03-31",
         "eval_session": "2022-03-30",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.0
       },
       {
         "ticker": "UCO",
         "entry_date": "2022-04-21",
         "eval_session": "2022-04-20",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "SNAP",
@@ -21740,9 +21715,9 @@
         "ticker": "JNUG",
         "entry_date": "2022-03-21",
         "eval_session": "2022-03-18",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "EWZ",
@@ -21828,9 +21803,9 @@
         "ticker": "F",
         "entry_date": "2021-12-16",
         "eval_session": "2021-12-15",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "JD",
@@ -21884,9 +21859,9 @@
         "ticker": "JNUG",
         "entry_date": "2022-03-30",
         "eval_session": "2022-03-29",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "UAL",
@@ -21932,9 +21907,9 @@
         "ticker": "LI",
         "entry_date": "2021-11-26",
         "eval_session": "2021-11-24",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 0.5
       },
       {
         "ticker": "OKTA",
@@ -21948,9 +21923,9 @@
         "ticker": "TSLA",
         "entry_date": "2021-02-02",
         "eval_session": "2021-02-01",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "KRE",
@@ -22084,9 +22059,9 @@
         "ticker": "ETHE",
         "entry_date": "2021-09-15",
         "eval_session": "2021-09-14",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "FCX",
@@ -22180,9 +22155,9 @@
         "ticker": "TNA",
         "entry_date": "2021-05-24",
         "eval_session": "2021-05-21",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "PTON",
@@ -22268,9 +22243,9 @@
         "ticker": "PINS",
         "entry_date": "2021-01-20",
         "eval_session": "2021-01-19",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
+        "in_field": true,
+        "top_thirty": true,
+        "stars": 3.0
       },
       {
         "ticker": "JD",
@@ -22324,9 +22299,9 @@
         "ticker": "TAN",
         "entry_date": "2021-11-11",
         "eval_session": "2021-11-10",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "VEEV",
@@ -22348,9 +22323,9 @@
         "ticker": "AAL",
         "entry_date": "2021-03-30",
         "eval_session": "2021-03-29",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "PLUG",
@@ -22437,7 +22412,7 @@
         "entry_date": "2022-01-12",
         "eval_session": "2022-01-11",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 1.5
       },
       {
@@ -22484,16 +22459,16 @@
         "ticker": "DVN",
         "entry_date": "2021-12-07",
         "eval_session": "2021-12-06",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.0
       },
       {
         "ticker": "UAL",
         "entry_date": "2021-03-11",
         "eval_session": "2021-03-10",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 2.5
       },
       {
@@ -22525,7 +22500,7 @@
         "entry_date": "2021-11-15",
         "eval_session": "2021-11-12",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 2.5
       },
       {
@@ -22652,9 +22627,9 @@
         "ticker": "SOXL",
         "entry_date": "2021-12-07",
         "eval_session": "2021-12-06",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
+        "in_field": true,
+        "top_thirty": true,
+        "stars": 2.5
       },
       {
         "ticker": "MDB",
@@ -22772,9 +22747,9 @@
         "ticker": "GBTC",
         "entry_date": "2021-05-07",
         "eval_session": "2021-05-06",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "OIH",
@@ -22852,9 +22827,9 @@
         "ticker": "XPEV",
         "entry_date": "2021-11-04",
         "eval_session": "2021-11-03",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "NIO",
@@ -22876,9 +22851,9 @@
         "ticker": "GBTC",
         "entry_date": "2021-04-09",
         "eval_session": "2021-04-08",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "ALB",
@@ -23116,9 +23091,9 @@
         "ticker": "AMC",
         "entry_date": "2021-11-03",
         "eval_session": "2021-11-02",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "ACAD",
@@ -23148,9 +23123,9 @@
         "ticker": "GME",
         "entry_date": "2021-09-13",
         "eval_session": "2021-09-10",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
+        "in_field": true,
+        "top_thirty": true,
+        "stars": 2.5
       },
       {
         "ticker": "SPOT",
@@ -23204,9 +23179,9 @@
         "ticker": "CCL",
         "entry_date": "2021-04-26",
         "eval_session": "2021-04-23",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "MDB",
@@ -23332,9 +23307,9 @@
         "ticker": "ETHE",
         "entry_date": "2021-11-29",
         "eval_session": "2021-11-26",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "RBLX",
@@ -23564,9 +23539,9 @@
         "ticker": "XPEV",
         "entry_date": "2022-01-12",
         "eval_session": "2022-01-11",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "NUGT",
@@ -23761,14 +23736,6 @@
         "stars": null
       },
       {
-        "ticker": "FUSE",
-        "entry_date": "2021-01-04",
-        "eval_session": "2020-12-31",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
-      },
-      {
         "ticker": "FUTU",
         "entry_date": "2021-03-16",
         "eval_session": "2021-03-15",
@@ -23844,9 +23811,9 @@
         "ticker": "BBBY",
         "entry_date": "2021-11-11",
         "eval_session": "2021-11-10",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "BE",
@@ -23884,9 +23851,9 @@
         "ticker": "PENN",
         "entry_date": "2021-03-01",
         "eval_session": "2021-02-26",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "KODK",
@@ -23964,9 +23931,9 @@
         "ticker": "TSLA",
         "entry_date": "2021-11-29",
         "eval_session": "2021-11-26",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "SEDG",
@@ -24004,9 +23971,9 @@
         "ticker": "DPST",
         "entry_date": "2021-05-21",
         "eval_session": "2021-05-20",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "INSG",
@@ -24116,17 +24083,17 @@
         "ticker": "CLNE",
         "entry_date": "2021-06-18",
         "eval_session": "2021-06-17",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "XPEV",
         "entry_date": "2021-11-23",
         "eval_session": "2021-11-22",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "RBLX",
@@ -24309,7 +24276,7 @@
         "entry_date": "2021-01-22",
         "eval_session": "2021-01-21",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 3.0
       },
       {
@@ -24373,7 +24340,7 @@
         "entry_date": "2021-10-19",
         "eval_session": "2021-10-18",
         "in_field": true,
-        "top_thirty": true,
+        "top_thirty": false,
         "stars": 2.5
       },
       {
@@ -24420,9 +24387,9 @@
         "ticker": "BLNK",
         "entry_date": "2021-02-03",
         "eval_session": "2021-02-02",
-        "in_field": false,
-        "top_thirty": false,
-        "stars": null
+        "in_field": true,
+        "top_thirty": true,
+        "stars": 3.0
       },
       {
         "ticker": "BBBY",
@@ -24644,9 +24611,9 @@
         "ticker": "TNA",
         "entry_date": "2021-04-23",
         "eval_session": "2021-04-22",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "WKHS",
@@ -24676,9 +24643,9 @@
         "ticker": "SIGA",
         "entry_date": "2022-06-07",
         "eval_session": "2022-06-06",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "BCRX",
@@ -24740,9 +24707,9 @@
         "ticker": "ETHE",
         "entry_date": "2021-01-28",
         "eval_session": "2021-01-27",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 1.5
       },
       {
         "ticker": "RIOT",
@@ -24780,9 +24747,9 @@
         "ticker": "TNA",
         "entry_date": "2021-05-07",
         "eval_session": "2021-05-06",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.0
       },
       {
         "ticker": "OCGN",
@@ -24908,9 +24875,9 @@
         "ticker": "ZKIN",
         "entry_date": "2021-03-30",
         "eval_session": "2021-03-29",
-        "in_field": false,
+        "in_field": true,
         "top_thirty": false,
-        "stars": null
+        "stars": 2.5
       },
       {
         "ticker": "UAVS",
@@ -24940,32 +24907,32 @@
   },
   "regression": {
     "exit_label": "10sma",
-    "n_replayable": 658,
-    "n_detected": 104,
-    "blind_spot_count": 91,
+    "n_replayable": 656,
+    "n_detected": 159,
+    "blind_spot_count": 92,
     "dimension_stats": [
       {
         "dimension": "Tightness",
         "weight": 2,
-        "n": 103,
-        "hit_rate": 0.44660194174757284,
-        "spread": 0.4971404704657129,
-        "correlation": 0.07638922655962738,
+        "n": 158,
+        "hit_rate": 0.2911392405063291,
+        "spread": 0.45428755556775596,
+        "correlation": 0.09973884395195816,
         "untestable": false
       },
       {
         "dimension": "Orderliness",
         "weight": 1,
-        "n": 103,
-        "hit_rate": 0.30097087378640774,
-        "spread": 0.4586800703307851,
-        "correlation": -0.06008334816839063,
+        "n": 158,
+        "hit_rate": 0.35443037974683544,
+        "spread": 0.47834034500484013,
+        "correlation": -0.05519586000209199,
         "untestable": false
       },
       {
         "dimension": "Prior move",
         "weight": 1,
-        "n": 103,
+        "n": 158,
         "hit_rate": 1.0,
         "spread": 0.0,
         "correlation": null,
@@ -24974,57 +24941,57 @@
       {
         "dimension": "Base length",
         "weight": 0,
-        "n": 103,
-        "hit_rate": 0.4854368932038835,
-        "spread": 0.499787870921699,
-        "correlation": -0.08312228163102753,
+        "n": 158,
+        "hit_rate": 0.5126582278481012,
+        "spread": 0.4998397435856272,
+        "correlation": -0.07778000337374383,
         "untestable": false
       },
       {
         "dimension": "MA support",
         "weight": 1,
-        "n": 103,
-        "hit_rate": 0.7669902912621359,
-        "spread": 0.4227483700403348,
-        "correlation": -0.15822133843285885,
+        "n": 158,
+        "hit_rate": 0.7721518987341772,
+        "spread": 0.4194440892602757,
+        "correlation": -0.12693810221465202,
         "untestable": false
       },
       {
         "dimension": "Volume",
         "weight": 1,
-        "n": 103,
-        "hit_rate": 0.36893203883495146,
-        "spread": 0.4825154811568612,
-        "correlation": -0.124624233788689,
+        "n": 158,
+        "hit_rate": 0.37341772151898733,
+        "spread": 0.483711615298367,
+        "correlation": -0.10808150512343133,
         "untestable": false
       },
       {
         "dimension": "ADR",
         "weight": 2,
-        "n": 103,
-        "hit_rate": 0.8155339805825242,
-        "spread": 0.3878637738920035,
-        "correlation": 0.09244439850188962,
+        "n": 158,
+        "hit_rate": 0.7911392405063291,
+        "spread": 0.40649470185649145,
+        "correlation": 0.10657532739162139,
         "untestable": false
       }
     ],
     "mfe_distribution": {
-      "n": 657,
+      "n": 655,
       "min": -0.25,
-      "p25": 1.75,
+      "p25": 1.76,
       "median": 4.47,
-      "p75": 12.68,
+      "p75": 12.7,
       "max": 656.18,
-      "mean": 18.299741248097412
+      "mean": 18.344290076335877
     },
     "r_distribution": {
-      "n": 657,
+      "n": 655,
       "min": -1.0,
       "p25": -1.0,
       "median": -1.0,
-      "p75": -0.49,
+      "p75": -0.505,
       "max": 104.02,
-      "mean": 1.2445509893455098
+      "mean": 1.250320610687023
     },
     "stop_width_adr_distribution": {
       "n": 649,
@@ -25227,8 +25194,16 @@
         "ticker": "MSTR",
         "entry_date": "2021-01-28",
         "eval_session": "2021-01-27",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.0882669109255946,
         "stop_width_adr": 0.2639131985479106,
         "mfe": 132.07,
@@ -25350,8 +25325,16 @@
         "ticker": "ETHE",
         "entry_date": "2021-03-29",
         "eval_session": "2021-03-26",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.08232935626071086,
         "stop_width_adr": 0.24573803227451715,
         "mfe": 57.45,
@@ -25493,8 +25476,16 @@
         "ticker": "GBTC",
         "entry_date": "2021-02-02",
         "eval_session": "2021-02-01",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.09814048990968187,
         "stop_width_adr": 0.3539427115462601,
         "mfe": 61.72,
@@ -25515,8 +25506,16 @@
         "ticker": "CAN",
         "entry_date": "2021-03-09",
         "eval_session": "2021-03-08",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.242571763556527,
         "stop_width_adr": 0.22782189107455134,
         "mfe": 71.49,
@@ -25655,8 +25654,16 @@
         "ticker": "ETHE",
         "entry_date": "2021-02-02",
         "eval_session": "2021-02-01",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.12322083745133842,
         "stop_width_adr": 0.3940536751078926,
         "mfe": 30.3,
@@ -25926,8 +25933,16 @@
         "ticker": "CLF",
         "entry_date": "2021-03-26",
         "eval_session": "2021-03-25",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.07272024999444894,
         "stop_width_adr": 0.3973373628943057,
         "mfe": 31.09,
@@ -25937,8 +25952,16 @@
         "ticker": "WWR",
         "entry_date": "2021-01-19",
         "eval_session": "2021-01-15",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.09848463885143614,
         "stop_width_adr": 0.6769245178147342,
         "mfe": 60.53,
@@ -26150,8 +26173,16 @@
         "ticker": "NUGT",
         "entry_date": "2022-03-01",
         "eval_session": "2022-02-28",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.06385335125727329,
         "stop_width_adr": 0.29790437280795945,
         "mfe": 30.7,
@@ -26468,8 +26499,16 @@
         "ticker": "MSTR",
         "entry_date": "2021-11-02",
         "eval_session": "2021-11-01",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": false
+        },
         "adr_at_entry": 0.044997942701320646,
         "stop_width_adr": 0.32310610960506536,
         "mfe": 17.82,
@@ -26512,8 +26551,16 @@
         "ticker": "NTLA",
         "entry_date": "2021-03-30",
         "eval_session": "2021-03-29",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.11387003229255928,
         "stop_width_adr": 0.7412992075826272,
         "mfe": 26.32,
@@ -26707,8 +26754,16 @@
         "ticker": "GBTC",
         "entry_date": "2021-03-09",
         "eval_session": "2021-03-08",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.08479987542221305,
         "stop_width_adr": 0.42530220228418514,
         "mfe": 10.66,
@@ -26967,8 +27022,16 @@
         "ticker": "COIN",
         "entry_date": "2021-11-15",
         "eval_session": "2021-11-12",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.05163495125748981,
         "stop_width_adr": 0.05148958269305481,
         "mfe": 1.54,
@@ -26978,8 +27041,16 @@
         "ticker": "GUSH",
         "entry_date": "2021-11-08",
         "eval_session": "2021-11-05",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.06049121368905548,
         "stop_width_adr": 0.04669478265531093,
         "mfe": 3.02,
@@ -26989,8 +27060,16 @@
         "ticker": "PBW",
         "entry_date": "2021-11-11",
         "eval_session": "2021-11-10",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.03042098087895284,
         "stop_width_adr": 0.7456463683911245,
         "mfe": 3.15,
@@ -27085,17 +27164,6 @@
         "r": -0.28
       },
       {
-        "ticker": "FUSE",
-        "entry_date": "2021-01-07",
-        "eval_session": "2021-01-06",
-        "detected": false,
-        "dimension_hits": {},
-        "adr_at_entry": null,
-        "stop_width_adr": null,
-        "mfe": 6.99,
-        "r": -0.29
-      },
-      {
         "ticker": "Z",
         "entry_date": "2020-07-30",
         "eval_session": "2020-07-29",
@@ -27110,8 +27178,16 @@
         "ticker": "QCLN",
         "entry_date": "2021-11-22",
         "eval_session": "2021-11-19",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.028418029231861663,
         "stop_width_adr": 0.17888344212613283,
         "mfe": 1.32,
@@ -27393,8 +27469,16 @@
         "ticker": "AGQ",
         "entry_date": "2021-05-03",
         "eval_session": "2021-04-30",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": true,
+          "ADR": false
+        },
         "adr_at_entry": 0.027171663555365842,
         "stop_width_adr": 0.27408143929734985,
         "mfe": 4.43,
@@ -27522,8 +27606,16 @@
         "ticker": "ERX",
         "entry_date": "2022-03-30",
         "eval_session": "2022-03-29",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.05592516048757999,
         "stop_width_adr": 0.1495539105776671,
         "mfe": 0.73,
@@ -27604,8 +27696,16 @@
         "ticker": "TSLA",
         "entry_date": "2021-11-19",
         "eval_session": "2021-11-18",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.05800626941255897,
         "stop_width_adr": 0.1543141673500314,
         "mfe": 7.59,
@@ -27766,8 +27866,16 @@
         "ticker": "ERX",
         "entry_date": "2021-12-07",
         "eval_session": "2021-12-06",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.0510515611635539,
         "stop_width_adr": 0.19670528881098392,
         "mfe": 2.75,
@@ -27799,8 +27907,16 @@
         "ticker": "NET",
         "entry_date": "2021-09-16",
         "eval_session": "2021-09-15",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": false
+        },
         "adr_at_entry": 0.03408478686228361,
         "stop_width_adr": 0.29789965226632525,
         "mfe": 3.04,
@@ -27909,8 +28025,16 @@
         "ticker": "TSLA",
         "entry_date": "2022-01-12",
         "eval_session": "2022-01-11",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.055562250649040926,
         "stop_width_adr": 0.19533425810499597,
         "mfe": 2.35,
@@ -28134,8 +28258,16 @@
         "ticker": "NEM",
         "entry_date": "2022-03-31",
         "eval_session": "2022-03-30",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.03482479848726069,
         "stop_width_adr": 0.3445820369754518,
         "mfe": 3.77,
@@ -28145,8 +28277,16 @@
         "ticker": "UCO",
         "entry_date": "2022-04-21",
         "eval_session": "2022-04-20",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.06138498388468213,
         "stop_width_adr": 0.19635302665591736,
         "mfe": 1.17,
@@ -28175,8 +28315,16 @@
         "ticker": "JNUG",
         "entry_date": "2022-03-21",
         "eval_session": "2022-03-18",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.0734428798010288,
         "stop_width_adr": 0.16695162552263165,
         "mfe": 4.22,
@@ -28296,8 +28444,16 @@
         "ticker": "F",
         "entry_date": "2021-12-16",
         "eval_session": "2021-12-15",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.042364662000573663,
         "stop_width_adr": 0.3053778754139456,
         "mfe": 1.1,
@@ -28381,8 +28537,16 @@
         "ticker": "JNUG",
         "entry_date": "2022-03-30",
         "eval_session": "2022-03-29",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.06482012586482899,
         "stop_width_adr": 0.20368667737585072,
         "mfe": 1.95,
@@ -28455,8 +28619,16 @@
         "ticker": "LI",
         "entry_date": "2021-11-26",
         "eval_session": "2021-11-24",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.049208077467358405,
         "stop_width_adr": 0.27289364103848773,
         "mfe": 3.6,
@@ -28477,8 +28649,16 @@
         "ticker": "TSLA",
         "entry_date": "2021-02-02",
         "eval_session": "2021-02-01",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": false
+        },
         "adr_at_entry": 0.042969771986338834,
         "stop_width_adr": 0.317719077858871,
         "mfe": 3.01,
@@ -28688,8 +28868,16 @@
         "ticker": "ETHE",
         "entry_date": "2021-09-15",
         "eval_session": "2021-09-14",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.0645561518449393,
         "stop_width_adr": 0.22539100494711917,
         "mfe": 5.26,
@@ -28844,8 +29032,16 @@
         "ticker": "TNA",
         "entry_date": "2021-05-24",
         "eval_session": "2021-05-21",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.05564600286219403,
         "stop_width_adr": 0.2786474711566853,
         "mfe": 0.76,
@@ -28981,8 +29177,16 @@
         "ticker": "PINS",
         "entry_date": "2021-01-20",
         "eval_session": "2021-01-19",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.05058248601954005,
         "stop_width_adr": 0.32032316474586536,
         "mfe": 1.12,
@@ -29074,8 +29278,16 @@
         "ticker": "TAN",
         "entry_date": "2021-11-11",
         "eval_session": "2021-11-10",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.029044682817495303,
         "stop_width_adr": 0.5671111421008678,
         "mfe": 3.4,
@@ -29107,8 +29319,16 @@
         "ticker": "AAL",
         "entry_date": "2021-03-30",
         "eval_session": "2021-03-29",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.05902563350926723,
         "stop_width_adr": 0.28152104146214374,
         "mfe": 5.88,
@@ -29318,8 +29538,16 @@
         "ticker": "DVN",
         "entry_date": "2021-12-07",
         "eval_session": "2021-12-06",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": false,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.04674463749999297,
         "stop_width_adr": 0.3786341276954062,
         "mfe": 3.36,
@@ -29589,8 +29817,16 @@
         "ticker": "SOXL",
         "entry_date": "2021-12-07",
         "eval_session": "2021-12-06",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.07870432778829829,
         "stop_width_adr": 0.23832650132461733,
         "mfe": 6.27,
@@ -29770,8 +30006,16 @@
         "ticker": "GBTC",
         "entry_date": "2021-05-07",
         "eval_session": "2021-05-06",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.05603831221274068,
         "stop_width_adr": 0.35310189156722,
         "mfe": 2.81,
@@ -29880,8 +30124,16 @@
         "ticker": "XPEV",
         "entry_date": "2021-11-04",
         "eval_session": "2021-11-03",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": false
+        },
         "adr_at_entry": 0.04912414399861782,
         "stop_width_adr": 0.41765672567767576,
         "mfe": 0.21,
@@ -29913,8 +30165,16 @@
         "ticker": "GBTC",
         "entry_date": "2021-04-09",
         "eval_session": "2021-04-08",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.05331007212154756,
         "stop_width_adr": 0.39326883343201813,
         "mfe": 10.3,
@@ -30299,8 +30559,16 @@
         "ticker": "AMC",
         "entry_date": "2021-11-03",
         "eval_session": "2021-11-02",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.05796725052916231,
         "stop_width_adr": 0.3916999830571411,
         "mfe": 4.56,
@@ -30343,8 +30611,16 @@
         "ticker": "GME",
         "entry_date": "2021-09-13",
         "eval_session": "2021-09-10",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.08856848468716952,
         "stop_width_adr": 0.2590021056903179,
         "mfe": 3.71,
@@ -30428,8 +30704,16 @@
         "ticker": "CCL",
         "entry_date": "2021-04-26",
         "eval_session": "2021-04-23",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": false
+        },
         "adr_at_entry": 0.0437055537733884,
         "stop_width_adr": 0.5395937884331018,
         "mfe": 0.32,
@@ -30652,8 +30936,16 @@
         "ticker": "ETHE",
         "entry_date": "2021-11-29",
         "eval_session": "2021-11-26",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": false
+        },
         "adr_at_entry": 0.046790058601085836,
         "stop_width_adr": 0.5210429385755022,
         "mfe": 8.98,
@@ -30995,8 +31287,16 @@
         "ticker": "XPEV",
         "entry_date": "2022-01-12",
         "eval_session": "2022-01-11",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.0664364730115008,
         "stop_width_adr": 0.40765760290503217,
         "mfe": 1.0,
@@ -31291,17 +31591,6 @@
         "r": -1.0
       },
       {
-        "ticker": "FUSE",
-        "entry_date": "2021-01-04",
-        "eval_session": "2020-12-31",
-        "detected": false,
-        "dimension_hits": {},
-        "adr_at_entry": null,
-        "stop_width_adr": null,
-        "mfe": 0.43,
-        "r": -1.0
-      },
-      {
         "ticker": "FUTU",
         "entry_date": "2021-03-16",
         "eval_session": "2021-03-15",
@@ -31420,8 +31709,16 @@
         "ticker": "BBBY",
         "entry_date": "2021-11-11",
         "eval_session": "2021-11-10",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.05983439091147923,
         "stop_width_adr": 0.5193035241490918,
         "mfe": 4.68,
@@ -31475,8 +31772,16 @@
         "ticker": "PENN",
         "entry_date": "2021-03-01",
         "eval_session": "2021-02-26",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.06775996182982144,
         "stop_width_adr": 0.5450630871057828,
         "mfe": 6.1,
@@ -31617,8 +31922,16 @@
         "ticker": "TSLA",
         "entry_date": "2021-11-29",
         "eval_session": "2021-11-26",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.059048951503814354,
         "stop_width_adr": 0.5481249039836315,
         "mfe": 2.43,
@@ -31680,8 +31993,16 @@
         "ticker": "DPST",
         "entry_date": "2021-05-21",
         "eval_session": "2021-05-20",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.07408060511726129,
         "stop_width_adr": 0.4471665635076919,
         "mfe": 2.15,
@@ -31850,8 +32171,16 @@
         "ticker": "CLNE",
         "entry_date": "2021-06-18",
         "eval_session": "2021-06-17",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.10487193146191731,
         "stop_width_adr": 0.33335277710786726,
         "mfe": 2.85,
@@ -31861,8 +32190,16 @@
         "ticker": "XPEV",
         "entry_date": "2021-11-23",
         "eval_session": "2021-11-22",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.053787557105786955,
         "stop_width_adr": 0.661053416181548,
         "mfe": 8.48,
@@ -32324,8 +32661,16 @@
         "ticker": "BLNK",
         "entry_date": "2021-02-03",
         "eval_session": "2021-02-02",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": true,
+          "ADR": true
+        },
         "adr_at_entry": 0.15126592591113228,
         "stop_width_adr": 0.2933932621698713,
         "mfe": 2.29,
@@ -32680,8 +33025,16 @@
         "ticker": "TNA",
         "entry_date": "2021-04-23",
         "eval_session": "2021-04-22",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.060691587256528456,
         "stop_width_adr": 0.9354450826845994,
         "mfe": 7.28,
@@ -32724,8 +33077,16 @@
         "ticker": "SIGA",
         "entry_date": "2022-06-07",
         "eval_session": "2022-06-06",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.16432019481236132,
         "stop_width_adr": 0.5963233081527405,
         "mfe": 4.04,
@@ -32812,8 +33173,16 @@
         "ticker": "ETHE",
         "entry_date": "2021-01-28",
         "eval_session": "2021-01-27",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": false,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.13144828067876999,
         "stop_width_adr": 0.49374804377685866,
         "mfe": 8.57,
@@ -32875,8 +33244,16 @@
         "ticker": "TNA",
         "entry_date": "2021-05-07",
         "eval_session": "2021-05-06",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": false,
+          "Prior move": true,
+          "Base length": false,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.05051428669847228,
         "stop_width_adr": 1.432033459651543,
         "mfe": 1.43,
@@ -33067,8 +33444,16 @@
         "ticker": "ZKIN",
         "entry_date": "2021-03-30",
         "eval_session": "2021-03-29",
-        "detected": false,
-        "dimension_hits": {},
+        "detected": true,
+        "dimension_hits": {
+          "Tightness": false,
+          "Orderliness": true,
+          "Prior move": true,
+          "Base length": true,
+          "MA support": true,
+          "Volume": false,
+          "ADR": true
+        },
         "adr_at_entry": 0.2566746257559392,
         "stop_width_adr": 0.42371060266812177,
         "mfe": 0.0,
@@ -33118,22 +33503,22 @@
     ]
   },
   "contrast": {
-    "n_executed": 69,
-    "n_not_taken": 14354,
-    "blind_spot_count": 91,
+    "n_executed": 124,
+    "n_not_taken": 28672,
+    "blind_spot_count": 92,
     "comparison_group_note": "The not-taken detections are a comparison group: field members present on nights he traded, in names he did not enter and may never have seen. Their absence from his trade record carries no verdict on them.",
     "precision_note": "Precision is not measurable: the reference set records only the trades he entered, never a setup he passed over, so there is no control group and no false-positive rate is claimed. This comparison group is the nearest honest substitute, and no precision is asserted.",
     "dimension_contrasts": [
       {
         "dimension": "Tightness",
         "weight": 2,
-        "taken_n": 69,
-        "taken_hit_rate": 0.5942028985507246,
-        "taken_spread": 0.49104563322021494,
-        "not_taken_n": 14354,
-        "not_taken_hit_rate": 0.38574613348195624,
-        "not_taken_spread": 0.48677104883679867,
-        "combined_spread": 0.48700404684397547,
+        "taken_n": 124,
+        "taken_hit_rate": 0.33064516129032256,
+        "taken_spread": 0.4704454682592013,
+        "not_taken_n": 28672,
+        "not_taken_hit_rate": 0.193115234375,
+        "not_taken_spread": 0.39474262580482594,
+        "combined_spread": 0.395202327364131,
         "untestable_within_executed": false,
         "testable_in_contrast": true,
         "testability_restored": false
@@ -33141,13 +33526,13 @@
       {
         "dimension": "Orderliness",
         "weight": 1,
-        "taken_n": 69,
-        "taken_hit_rate": 0.2753623188405797,
-        "taken_spread": 0.44669666688180987,
-        "not_taken_n": 14354,
-        "not_taken_hit_rate": 0.36623937578375365,
-        "not_taken_spread": 0.48177598052339654,
-        "combined_spread": 0.4816550626217143,
+        "taken_n": 124,
+        "taken_hit_rate": 0.31451612903225806,
+        "taken_spread": 0.46432287646725107,
+        "not_taken_n": 28672,
+        "not_taken_hit_rate": 0.39292689732142855,
+        "not_taken_spread": 0.4884008094616389,
+        "combined_spread": 0.4883266636828799,
         "untestable_within_executed": false,
         "testable_in_contrast": true,
         "testability_restored": false
@@ -33155,10 +33540,10 @@
       {
         "dimension": "Prior move",
         "weight": 1,
-        "taken_n": 69,
+        "taken_n": 124,
         "taken_hit_rate": 1.0,
         "taken_spread": 0.0,
-        "not_taken_n": 14354,
+        "not_taken_n": 28672,
         "not_taken_hit_rate": 1.0,
         "not_taken_spread": 0.0,
         "combined_spread": 0.0,
@@ -33169,13 +33554,13 @@
       {
         "dimension": "Base length",
         "weight": 0,
-        "taken_n": 69,
-        "taken_hit_rate": 0.4492753623188406,
-        "taken_spread": 0.497420356571899,
-        "not_taken_n": 14354,
-        "not_taken_hit_rate": 0.5828340532255817,
-        "not_taken_spread": 0.49309078233751386,
-        "combined_spread": 0.493197693331357,
+        "taken_n": 124,
+        "taken_hit_rate": 0.4838709677419355,
+        "taken_spread": 0.49973978660740864,
+        "not_taken_n": 28672,
+        "not_taken_hit_rate": 0.6011090959821429,
+        "not_taken_spread": 0.4896702469107898,
+        "combined_spread": 0.48977421814868133,
         "untestable_within_executed": false,
         "testable_in_contrast": true,
         "testability_restored": false
@@ -33183,13 +33568,13 @@
       {
         "dimension": "MA support",
         "weight": 1,
-        "taken_n": 69,
-        "taken_hit_rate": 0.7681159420289855,
-        "taken_spread": 0.4220353559003199,
-        "not_taken_n": 14354,
-        "not_taken_hit_rate": 0.7253727184060192,
-        "not_taken_spread": 0.44632626832652494,
-        "combined_spread": 0.4462229548682126,
+        "taken_n": 124,
+        "taken_hit_rate": 0.7741935483870968,
+        "taken_spread": 0.4181123031230877,
+        "not_taken_n": 28672,
+        "not_taken_hit_rate": 0.7195870535714286,
+        "not_taken_spread": 0.44920098608954384,
+        "combined_spread": 0.44908596223241,
         "untestable_within_executed": false,
         "testable_in_contrast": true,
         "testability_restored": false
@@ -33197,13 +33582,13 @@
       {
         "dimension": "Volume",
         "weight": 1,
-        "taken_n": 69,
-        "taken_hit_rate": 0.36231884057971014,
-        "taken_spread": 0.48067025947179703,
-        "not_taken_n": 14354,
-        "not_taken_hit_rate": 0.40100320468162187,
-        "not_taken_spread": 0.49010165732905975,
-        "combined_spread": 0.4900642388402321,
+        "taken_n": 124,
+        "taken_hit_rate": 0.3870967741935484,
+        "taken_spread": 0.48708609259811286,
+        "not_taken_n": 28672,
+        "not_taken_hit_rate": 0.38636997767857145,
+        "not_taken_spread": 0.4869170545660027,
+        "combined_spread": 0.486917784921253,
         "untestable_within_executed": false,
         "testable_in_contrast": true,
         "testability_restored": false
@@ -33211,13 +33596,13 @@
       {
         "dimension": "ADR",
         "weight": 2,
-        "taken_n": 69,
-        "taken_hit_rate": 0.8695652173913043,
-        "taken_spread": 0.33678116053977536,
-        "not_taken_n": 14354,
-        "not_taken_hit_rate": 0.5764943569736659,
-        "not_taken_spread": 0.494113967978224,
-        "combined_spread": 0.4938948759203955,
+        "taken_n": 124,
+        "taken_hit_rate": 0.8145161290322581,
+        "taken_spread": 0.3886895992672868,
+        "not_taken_n": 28672,
+        "not_taken_hit_rate": 0.5339006696428571,
+        "not_taken_spread": 0.4988494207651903,
+        "combined_spread": 0.4987658319342425,
         "untestable_within_executed": false,
         "testable_in_contrast": true,
         "testability_restored": false

--- a/references/tightness_restructure.txt
+++ b/references/tightness_restructure.txt
@@ -1,0 +1,29 @@
+Tightness restructure (#145/#154) — TIGHT_MULT 1.5 gate -> OUTLIER_MULT 3.0 guard
+==============================================================================
+
+1. Detection-stage recall, 828-trade reference set
+   replayable trades          : 656
+   v1 (hard 1.5 cut)          : 380/658 (57.8%)
+   v2 (far-outlier guard)     : 549/656 (83.7%)
+   recovered                  : 169 trades
+   ex-continuation            : 487/577 (84.4%)
+
+   Failed condition           v1     v2
+     cluster                  171      2
+     catch_up                  47     47
+     base_length               37     37
+     history                   23     21
+
+   Three-bar range of the recovered trades (all past the old 1.5 cut):
+     n=169  p25 1.68  median 1.83  p75 2.10  max 2.90
+
+   Trades the guard still declines: 2
+     three-bar range: n=2  p25 3.18  median 3.42  p75 3.42  max 3.42
+
+2. Field inflation per session (same universe, same decile gate)
+   sessions measured          : 505
+   v1 detections / session    : 90.3
+   v2 detections / session    : 201.6
+   inflation                  : +111.3 names/session (+123.2%)
+   names admitted per trade recovered, per session: 0.66
+

--- a/scripts/base_tightness_restructure.py
+++ b/scripts/base_tightness_restructure.py
@@ -1,4 +1,4 @@
-"""Price the #145/#154 tightness restructure: recall recovered, field admitted.
+"""Price the #145/#154 base-tightness restructure: recall recovered, field admitted.
 
 The hard 1.5×ADR cluster cut became a far-outlier guard at ``OUTLIER_MULT``. A
 loosening is only reportable with **both** halves of the ledger (ADR 0002's
@@ -25,7 +25,7 @@ pass (§10) and writes nothing to the store it reads. It needs a replay store bu
 by `replay.store.build_replay_store`; give it a **copy** if another process holds
 the live one's lock.
 
-    python scripts/tightness_restructure.py --store data/replay.duckdb
+    python scripts/base_tightness_restructure.py --store data/replay.duckdb
 
 ``--sessions N`` samples N sessions evenly for part 2 instead of walking all of
 them; the sample size is reported with the result either way.
@@ -47,6 +47,8 @@ from replay.funnel import (  # noqa: E402
     COND_CLUSTER,
     diagnose_detection,
 )
+from replay.regression import distribution  # noqa: E402
+from replay.funnel import CONTINUATION_SESSIONS  # noqa: E402
 from replay.reference import (  # noqa: E402
     classify,
     evaluation_session,
@@ -78,12 +80,17 @@ REFERENCE = Path(__file__).resolve().parent.parent / "references" / (
 
 @dataclass
 class RecallResult:
+    """One walk of the funnel's detection stage, both sides of the ledger."""
+
     passed: int
     total: int
     passed_ex_continuation: int
     total_ex_continuation: int
     condition_counts: dict[str, int]
-    recovered_three_bar_ranges: list[float]
+    # Trades the old 1.5 cut declined and the guard admits, by three-bar range ...
+    recovered: list[float]
+    # ... and the ones the guard still declines, by the same ruler.
+    still_declined: list[float]
 
 
 def measure_recall(store: Store, market: str) -> RecallResult:
@@ -91,25 +98,28 @@ def measure_recall(store: Store, market: str) -> RecallResult:
 
     Reproduces :func:`replay.funnel._funnel_row`'s detection half exactly — the
     same evaluation session (the last session strictly before entry), the same
-    ``detect``, the same ``diagnose_detection`` attribution — without the chain
-    the decile stage would need.
+    ``detect``, the same ``diagnose_detection`` attribution — without the chain the
+    decile stage would need. One walk yields both the recall and the two three-bar
+    range samples the write-up quotes; walking twice would read every trade's bars
+    twice to answer halves of the same question.
     """
     trades = load_trades(REFERENCE)
     classified = classify(trades, store, market=market)
     calendar = store.sessions(market)
 
-    # Continuation tagging: an entry within 5 sessions of a prior entry in the
-    # same ticker. Recomputed here off the calendar, as the funnel does.
+    # Continuation tagging: an entry within CONTINUATION_SESSIONS of a prior entry
+    # in the same ticker. Recomputed here off the calendar, as the funnel does.
     index = {s: i for i, s in enumerate(calendar)}
-    by_ticker: dict[str, list[date]] = {}
+    entries_by_ticker: dict[str, list[date]] = {}
     for c in classified:
-        by_ticker.setdefault(c.trade.ticker, []).append(c.trade.entry_date)
-    for entries in by_ticker.values():
+        entries_by_ticker.setdefault(c.trade.ticker, []).append(c.trade.entry_date)
+    for entries in entries_by_ticker.values():
         entries.sort()
 
     passed = total = passed_ex = total_ex = 0
     conditions: dict[str, int] = {}
     recovered: list[float] = []
+    still_declined: list[float] = []
     bars_cache: dict[str, list] = {}
     for c in classified:
         if not c.replayable:
@@ -120,27 +130,33 @@ def measure_recall(store: Store, market: str) -> RecallResult:
         bars = bars_cache[ticker]
         eval_session = evaluation_session(calendar, c.trade.entry_date)
 
-        entries = by_ticker[ticker]
-        prior = [e for e in entries if e < c.trade.entry_date]
-        distance = None
-        if prior and prior[-1] in index and c.trade.entry_date in index:
-            distance = index[c.trade.entry_date] - index[prior[-1]]
-        continuation = distance is not None and distance <= 5
+        prior = [e for e in entries_by_ticker[ticker] if e < c.trade.entry_date]
+        distance = (
+            index[c.trade.entry_date] - index[prior[-1]]
+            if prior and prior[-1] in index and c.trade.entry_date in index
+            else None
+        )
+        continuation = distance is not None and distance <= CONTINUATION_SESSIONS
 
         total += 1
         if not continuation:
             total_ex += 1
+
         found = detect(ticker, bars, eval_session) if eval_session else None
         if found is not None:
             passed += 1
             if not continuation:
                 passed_ex += 1
-            # A trade the old 1.5 cut would have declined: recovered by the guard.
             if found.range_3bar_adr is not None and found.range_3bar_adr > TIGHT_MULT:
                 recovered.append(found.range_3bar_adr)
-        else:
-            cond = diagnose_detection(bars, eval_session) if eval_session else "history"
-            conditions[cond] = conditions.get(cond, 0) + 1
+            continue
+
+        cond = diagnose_detection(bars, eval_session) if eval_session else "history"
+        conditions[cond] = conditions.get(cond, 0) + 1
+        if cond == COND_CLUSTER:
+            r3 = _eval_three_bar_range(bars, eval_session)
+            if r3 is not None:
+                still_declined.append(r3)
 
     return RecallResult(
         passed=passed,
@@ -148,45 +164,22 @@ def measure_recall(store: Store, market: str) -> RecallResult:
         passed_ex_continuation=passed_ex,
         total_ex_continuation=total_ex,
         condition_counts=conditions,
-        recovered_three_bar_ranges=sorted(recovered),
+        recovered=recovered,
+        still_declined=still_declined,
     )
 
 
-def far_misses(store: Store, market: str) -> list[float]:
-    """The three-bar range of every trade the far-outlier guard still declines.
-
-    The guard's own cost, in his trades: what is left of the 171 `cluster` misses
-    once the graded range takes over. Reported so the guard's n is visible rather
-    than implied.
-    """
-    trades = load_trades(REFERENCE)
-    classified = classify(trades, store, market=market)
-    calendar = store.sessions(market)
-    out: list[float] = []
-    bars_cache: dict[str, list] = {}
-    for c in classified:
-        if not c.replayable:
-            continue
-        eval_session = evaluation_session(calendar, c.trade.entry_date)
-        if eval_session is None:
-            continue
-        ticker = c.trade.ticker
-        if ticker not in bars_cache:
-            bars_cache[ticker] = store.bars(market, ticker)
-        bars = bars_cache[ticker]
-        if diagnose_detection(bars, eval_session) != COND_CLUSTER:
-            continue
-        upto = [b for b in bars if b.session <= eval_session]
-        a = _adr(upto)
-        if a is None or a <= 0:
-            continue
-        r3 = range_3bar_adr(
-            [b.high for b in upto], [b.low for b in upto], len(upto) - 1,
-            a * upto[-1].close,
-        )
-        if r3 is not None:
-            out.append(r3)
-    return sorted(out)
+def _eval_three_bar_range(bars: list, as_of: date) -> float | None:
+    """The trailing three-bar range in ADR at ``as_of``, off the detector's own
+    diagnostic — the ruler the guard tested, recomputed for a trade it declined."""
+    upto = [b for b in bars if b.session <= as_of]
+    a = _adr(upto)
+    if a is None or a <= 0 or not upto:
+        return None
+    return range_3bar_adr(
+        [b.high for b in upto], [b.low for b in upto], len(upto) - 1,
+        a * upto[-1].close,
+    )
 
 
 @dataclass
@@ -243,17 +236,16 @@ def measure_field_inflation(
     return InflationResult(len(sessions), v1_total, v2_total, deltas)
 
 
-def _quantiles(values: list[float]) -> str:
-    if not values:
+def _summary(values: list[float]) -> str:
+    """A one-line five-number summary, from the study's own
+    :func:`replay.regression.distribution` rather than a second implementation of
+    the same quantiles."""
+    d = distribution(values)
+    if d is None:
         return "n=0"
-    n = len(values)
-
-    def q(p: float) -> float:
-        return values[min(n - 1, int(p * n))]
-
     return (
-        f"n={n}  p25 {q(0.25):.2f}  median {q(0.50):.2f}  p75 {q(0.75):.2f}  "
-        f"max {values[-1]:.2f}"
+        f"n={d.n}  p25 {d.p25:.2f}  median {d.median:.2f}  p75 {d.p75:.2f}  "
+        f"max {d.maximum:.2f}"
     )
 
 
@@ -272,8 +264,8 @@ def main(argv: list[str] | None = None) -> int:
         lines.append(line)
         print(line)
 
-    emit(f"Tightness restructure (#145/#154) — TIGHT_MULT {TIGHT_MULT} gate -> "
-         f"OUTLIER_MULT {OUTLIER_MULT} guard")
+    emit(f"Base-tightness restructure (#145/#154) — TIGHT_MULT {TIGHT_MULT} gate "
+         f"-> OUTLIER_MULT {OUTLIER_MULT} guard")
     emit("=" * 78)
     emit()
 
@@ -299,13 +291,10 @@ def main(argv: list[str] | None = None) -> int:
             emit(f"     {cond:<22} {v1:>5}  {v2:>5}")
     emit()
     emit("   Three-bar range of the recovered trades (all past the old 1.5 cut):")
-    emit(f"     {_quantiles(r.recovered_three_bar_ranges)}")
+    emit(f"     {_summary(r.recovered)}")
     emit()
-
-    print("measuring the guard's residual misses ...", file=sys.stderr)
-    far = far_misses(store, args.market)
-    emit(f"   Trades the guard still declines: {len(far)}")
-    emit(f"     three-bar range: {_quantiles(far)}")
+    emit(f"   Trades the guard still declines: {len(r.still_declined)}")
+    emit(f"     three-bar range: {_summary(r.still_declined)}")
     emit()
 
     print("measuring field inflation ...", file=sys.stderr)

--- a/scripts/tightness_restructure.py
+++ b/scripts/tightness_restructure.py
@@ -1,0 +1,334 @@
+"""Price the #145/#154 tightness restructure: recall recovered, field admitted.
+
+The hard 1.5×ADR cluster cut became a far-outlier guard at ``OUTLIER_MULT``. A
+loosening is only reportable with **both** halves of the ledger (ADR 0002's
+condition 4, and the discipline #141/#149 used): how many of his executed trades
+the change recovers, *and* how many more names it puts in the field per session.
+Quoting the first without the second is the one-sided recall number the
+calibration rule exists to prevent.
+
+Two measurements, each against a committed baseline:
+
+1. **Detection-stage recall**, over the 828-trade reference set. The detection
+   stage is per-name — it reads bars and nothing cross-sectional — so it is
+   re-measured without rebuilding the 947-session forward chain. Liquidity and
+   decile are cross-sectional and untouched by this change, so their committed
+   figures stand. Baseline: findings §3 (380/658, `cluster` 171 of 278).
+
+2. **Field inflation per session.** For every session the replay store holds both
+   ranks and v1 detection rows for, the detector is re-run over that night's
+   *same* gated members and the count compared to the persisted v1 count. The
+   gate itself does not move, so the difference is the detector's alone.
+
+A side-car, like §3b's prototype: it is not part of `replay.study`'s reproducible
+pass (§10) and writes nothing to the store it reads. It needs a replay store built
+by `replay.store.build_replay_store`; give it a **copy** if another process holds
+the live one's lock.
+
+    python scripts/tightness_restructure.py --store data/replay.duckdb
+
+``--sessions N`` samples N sessions evenly for part 2 instead of walking all of
+them; the sample size is reported with the result either way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "backend"))
+
+from replay.caching_store import CachingStore  # noqa: E402
+from replay.funnel import (  # noqa: E402
+    COND_CLUSTER,
+    diagnose_detection,
+)
+from replay.reference import (  # noqa: E402
+    classify,
+    evaluation_session,
+    load_trades,
+)
+from replay.store import REPLAY_MARKET  # noqa: E402
+from screener.detection import (  # noqa: E402
+    OUTLIER_MULT,
+    TIGHT_MULT,
+    detect,
+    detection_gate,
+    range_3bar_adr,
+)
+from screener.indicators import adr as _adr  # noqa: E402
+from screener.store import Store  # noqa: E402
+
+# The committed v1 figures this run is read against (findings §3, `replay.study`
+# last run 2026-08-19). Hard-coded rather than re-derived: the point of the
+# comparison is that the *old* numbers are the published ones.
+V1_DETECTION_PASSED, V1_TOTAL = 380, 658
+V1_CONDITION_COUNTS = {
+    "cluster": 171, "catch_up": 47, "base_length": 37, "history": 23,
+}
+
+REFERENCE = Path(__file__).resolve().parent.parent / "references" / (
+    "trades_bo_gain10smaPct_desc.json"
+)
+
+
+@dataclass
+class RecallResult:
+    passed: int
+    total: int
+    passed_ex_continuation: int
+    total_ex_continuation: int
+    condition_counts: dict[str, int]
+    recovered_three_bar_ranges: list[float]
+
+
+def measure_recall(store: Store, market: str) -> RecallResult:
+    """Re-run the funnel's detection stage over every replayable trade.
+
+    Reproduces :func:`replay.funnel._funnel_row`'s detection half exactly — the
+    same evaluation session (the last session strictly before entry), the same
+    ``detect``, the same ``diagnose_detection`` attribution — without the chain
+    the decile stage would need.
+    """
+    trades = load_trades(REFERENCE)
+    classified = classify(trades, store, market=market)
+    calendar = store.sessions(market)
+
+    # Continuation tagging: an entry within 5 sessions of a prior entry in the
+    # same ticker. Recomputed here off the calendar, as the funnel does.
+    index = {s: i for i, s in enumerate(calendar)}
+    by_ticker: dict[str, list[date]] = {}
+    for c in classified:
+        by_ticker.setdefault(c.trade.ticker, []).append(c.trade.entry_date)
+    for entries in by_ticker.values():
+        entries.sort()
+
+    passed = total = passed_ex = total_ex = 0
+    conditions: dict[str, int] = {}
+    recovered: list[float] = []
+    bars_cache: dict[str, list] = {}
+    for c in classified:
+        if not c.replayable:
+            continue
+        ticker = c.trade.ticker
+        if ticker not in bars_cache:
+            bars_cache[ticker] = store.bars(market, ticker)
+        bars = bars_cache[ticker]
+        eval_session = evaluation_session(calendar, c.trade.entry_date)
+
+        entries = by_ticker[ticker]
+        prior = [e for e in entries if e < c.trade.entry_date]
+        distance = None
+        if prior and prior[-1] in index and c.trade.entry_date in index:
+            distance = index[c.trade.entry_date] - index[prior[-1]]
+        continuation = distance is not None and distance <= 5
+
+        total += 1
+        if not continuation:
+            total_ex += 1
+        found = detect(ticker, bars, eval_session) if eval_session else None
+        if found is not None:
+            passed += 1
+            if not continuation:
+                passed_ex += 1
+            # A trade the old 1.5 cut would have declined: recovered by the guard.
+            if found.range_3bar_adr is not None and found.range_3bar_adr > TIGHT_MULT:
+                recovered.append(found.range_3bar_adr)
+        else:
+            cond = diagnose_detection(bars, eval_session) if eval_session else "history"
+            conditions[cond] = conditions.get(cond, 0) + 1
+
+    return RecallResult(
+        passed=passed,
+        total=total,
+        passed_ex_continuation=passed_ex,
+        total_ex_continuation=total_ex,
+        condition_counts=conditions,
+        recovered_three_bar_ranges=sorted(recovered),
+    )
+
+
+def far_misses(store: Store, market: str) -> list[float]:
+    """The three-bar range of every trade the far-outlier guard still declines.
+
+    The guard's own cost, in his trades: what is left of the 171 `cluster` misses
+    once the graded range takes over. Reported so the guard's n is visible rather
+    than implied.
+    """
+    trades = load_trades(REFERENCE)
+    classified = classify(trades, store, market=market)
+    calendar = store.sessions(market)
+    out: list[float] = []
+    bars_cache: dict[str, list] = {}
+    for c in classified:
+        if not c.replayable:
+            continue
+        eval_session = evaluation_session(calendar, c.trade.entry_date)
+        if eval_session is None:
+            continue
+        ticker = c.trade.ticker
+        if ticker not in bars_cache:
+            bars_cache[ticker] = store.bars(market, ticker)
+        bars = bars_cache[ticker]
+        if diagnose_detection(bars, eval_session) != COND_CLUSTER:
+            continue
+        upto = [b for b in bars if b.session <= eval_session]
+        a = _adr(upto)
+        if a is None or a <= 0:
+            continue
+        r3 = range_3bar_adr(
+            [b.high for b in upto], [b.low for b in upto], len(upto) - 1,
+            a * upto[-1].close,
+        )
+        if r3 is not None:
+            out.append(r3)
+    return sorted(out)
+
+
+@dataclass
+class InflationResult:
+    sessions: int
+    v1_total: int
+    v2_total: int
+    per_session_deltas: list[int]
+
+
+def measure_field_inflation(
+    store: Store, market: str, sample: int | None
+) -> InflationResult:
+    """Re-detect each session's *same* gated members and compare to the v1 rows.
+
+    The population cost, in the app's own units: how many more names land on the
+    Setups list per night. The decile gate is held fixed — the members and the
+    ranks come from the persisted chain — so the whole difference is the
+    detector's.
+    """
+    sessions = sorted(
+        s for s, in store._cursor().execute(  # noqa: SLF001 — a side-car, read-only
+            "SELECT DISTINCT session FROM detections WHERE market = ? ORDER BY session",
+            [market],
+        ).fetchall()
+    )
+    if sample and sample < len(sessions):
+        step = len(sessions) / sample
+        sessions = [sessions[int(i * step)] for i in range(sample)]
+
+    store = CachingStore.wrap(store)
+    v1_total = v2_total = 0
+    deltas: list[int] = []
+    started = time.time()
+    for i, session in enumerate(sessions, start=1):
+        members = store.universe(market, session)
+        gated = detection_gate(store.ranks(market, session))
+        v1 = len(store.detections(market, session))
+        v2 = sum(
+            1
+            for symbol in members
+            if symbol in gated
+            and detect(symbol, store.bars(market, symbol), session) is not None
+        )
+        v1_total += v1
+        v2_total += v2
+        deltas.append(v2 - v1)
+        elapsed = time.time() - started
+        print(
+            f"  [{i}/{len(sessions)}] {session}  v1={v1}  v2={v2}  "
+            f"({elapsed / i:.1f}s/session, ETA {(len(sessions) - i) * elapsed / i / 60:.0f}m)",
+            file=sys.stderr,
+        )
+    return InflationResult(len(sessions), v1_total, v2_total, deltas)
+
+
+def _quantiles(values: list[float]) -> str:
+    if not values:
+        return "n=0"
+    n = len(values)
+
+    def q(p: float) -> float:
+        return values[min(n - 1, int(p * n))]
+
+    return (
+        f"n={n}  p25 {q(0.25):.2f}  median {q(0.50):.2f}  p75 {q(0.75):.2f}  "
+        f"max {values[-1]:.2f}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--store", required=True)
+    ap.add_argument("--market", default=REPLAY_MARKET)
+    ap.add_argument("--sessions", type=int, default=None)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args(argv)
+
+    store = Store.open(args.store)
+    lines: list[str] = []
+
+    def emit(line: str = "") -> None:
+        lines.append(line)
+        print(line)
+
+    emit(f"Tightness restructure (#145/#154) — TIGHT_MULT {TIGHT_MULT} gate -> "
+         f"OUTLIER_MULT {OUTLIER_MULT} guard")
+    emit("=" * 78)
+    emit()
+
+    print("measuring detection-stage recall ...", file=sys.stderr)
+    r = measure_recall(store, args.market)
+    emit("1. Detection-stage recall, 828-trade reference set")
+    emit(f"   replayable trades          : {r.total}")
+    emit(f"   v1 (hard 1.5 cut)          : {V1_DETECTION_PASSED}/{V1_TOTAL} "
+         f"({V1_DETECTION_PASSED / V1_TOTAL:.1%})")
+    emit(f"   v2 (far-outlier guard)     : {r.passed}/{r.total} "
+         f"({r.passed / r.total:.1%})")
+    emit(f"   recovered                  : {r.passed - V1_DETECTION_PASSED} trades")
+    emit(f"   ex-continuation            : {r.passed_ex_continuation}/"
+         f"{r.total_ex_continuation} "
+         f"({r.passed_ex_continuation / r.total_ex_continuation:.1%})")
+    emit()
+    emit("   Failed condition           v1     v2")
+    for cond in ("cluster", "catch_up", "base_length", "history", "adr",
+                 "prior_move"):
+        v1 = V1_CONDITION_COUNTS.get(cond, 0)
+        v2 = r.condition_counts.get(cond, 0)
+        if v1 or v2:
+            emit(f"     {cond:<22} {v1:>5}  {v2:>5}")
+    emit()
+    emit("   Three-bar range of the recovered trades (all past the old 1.5 cut):")
+    emit(f"     {_quantiles(r.recovered_three_bar_ranges)}")
+    emit()
+
+    print("measuring the guard's residual misses ...", file=sys.stderr)
+    far = far_misses(store, args.market)
+    emit(f"   Trades the guard still declines: {len(far)}")
+    emit(f"     three-bar range: {_quantiles(far)}")
+    emit()
+
+    print("measuring field inflation ...", file=sys.stderr)
+    inf = measure_field_inflation(store, args.market, args.sessions)
+    per_v1 = inf.v1_total / inf.sessions
+    per_v2 = inf.v2_total / inf.sessions
+    emit("2. Field inflation per session (same universe, same decile gate)")
+    emit(f"   sessions measured          : {inf.sessions}")
+    emit(f"   v1 detections / session    : {per_v1:.1f}")
+    emit(f"   v2 detections / session    : {per_v2:.1f}")
+    emit(f"   inflation                  : +{per_v2 - per_v1:.1f} names/session "
+         f"(+{(per_v2 / per_v1 - 1):.1%})")
+    if r.passed > V1_DETECTION_PASSED:
+        admitted = (inf.v2_total - inf.v1_total) / inf.sessions
+        emit(f"   names admitted per trade recovered, per session: "
+         f"{admitted / (r.passed - V1_DETECTION_PASSED):.2f}")
+    emit()
+
+    if args.out:
+        Path(args.out).write_text("\n".join(lines) + "\n")
+        print(f"wrote {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #154. Implements the decision taken in #145.

## What changed

**`detection.py`** — `TIGHT_MULT = 1.5` no longer gates. It shapes the cluster window; when nothing clears it the 3-bar window *is* the cluster (the tightest one there is), so a name that already passed is unchanged in every output — same `k`, same trigger, same span. The only base-tightness rejection left is a **far-outlier guard**, `OUTLIER_MULT = 3.0` on the trailing 3-bar range. `DETECTOR_VERSION` → 2.

**`score.py`** — rubric **v3**: `Tightness` is graded, 2 points at or under 1.0 ADR, 1 through 2.0, none beyond. Weight unchanged at ×2.

**The shape of the fix mattered more than the curve.** A breakdown row stores the **value**; each rubric version owns its own value→points mapping. So a v2 re-score of a v3 row is exact and #136's pairing survives — covered by a test. The row also keeps v2's `cluster_k >= 5` boolean, since no value can reconstruct it. Points stay **integral**, so the nine-point ceiling and the `÷ 2` are untouched.

### One deviation from the issue, deliberate

The issue says grade from `cluster_range_adr`. That quantity is *gated*: it is the span of whichever window cleared 1.5, so a quieter name earns a longer window and reports a **wider** span — non-monotone in the thing being measured. Worse, §3b's outcome table (the only evidence licensing the bands) is denominated in the **3-bar range**, so grading `cluster_range_adr` against those edges would grade a different variable than the one measured. The implementation persists and grades `range_3bar_adr` instead (schema v10).

`RUBRIC_WEIGHTS` also became `RUBRICS` — a weight map alone can no longer describe a rubric. v1 and v2 are retained, unedited and spelled out literally.

## Measured — both halves of the ledger

`scripts/base_tightness_restructure.py`, plus a full `replay.study` re-run on detector v2:

| | Hard 1.5 cut | Far-outlier guard |
| --- | --- | --- |
| Detection-stage recall | 380/658 (57.8%) | **549/656 (83.7%)** |
| `cluster` misses | 171 | **2** |
| Detections per session | 90.3 | **201.6 (+123%)** |
| `in_field` anchor | 104 of 656 | **159 of 656** |

**The population cost is the headline, not the recall.** The field more than doubles — 0.66 extra names per session for each trade recovered. What absorbs it is the graded dimension: the admitted names are the ones it scores low, so they arrive at the bottom of the sort rather than beside his own setups. Work moved from the gate to the sort key.

## On the calibration rule

ADR 0002's score-dimension limb licenses a loosening only on an A3 null, and Tightness is the *best-evidenced* dimension in the study — the precondition is not met and is not claimed to be. The position is that this is a change of **shape**, not a loosening: §3b's outcome relation is a smooth monotone decline with no feature to hang a threshold on, the opposite of the cliff #143 found. That argument is now a decision record — **ADR 0004** — with the four conditions required to reach for it again, rather than a docstring.

The 3.0 guard is marked **provisional** everywhere it appears: it is sited on the one bucket where mean R turns negative, and that bucket is **n = 10**. It is also a *magnitude*, which ADR 0001 says the replay does not license; ADR 0004 records the exception and hands the number to the out-of-sample backtest to re-derive.

## Also

Findings §3/§3a/§3b/§4/§4a, the plain-language findings, `CONTEXT.md` and the backtest plan are updated and re-pinned. Superseded figures are kept beside the new ones rather than overwritten — recall is only comparable within one `detector_version`. Acceptance B4 and B8 will now flag deviation; that is deliberate and documented (the flag firing is the pass working).

Tests: 507 backend, 174 frontend, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwSgjzYz8tGbd7qvh2hGyB