### PR TITLE
Reject widening the detection gate 3→5, and admit 12m alone (#149)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -58,14 +58,24 @@ there is exactly one definition of "strong".
 
 **Decile**:
 Top 10% of a lookback's own population. The union of all five lookbacks' deciles is the
-breadth substrate — 27.2% of the universe, not 10%. It is not the gate the detector runs;
+breadth substrate — **26.5%** of the universe, not 10%. It is not the gate the detector runs;
 see **Detection gate**.
 
 **Detection gate**:
-The union of the top deciles of the *three* detection lookbacks (`1m`, `3m`, `6m`) — 19.4%
-of the universe. The cut a name must clear before the detector is consulted. Distinct from
-the five-lookback union, and materially tighter; conflating the two misattributes the
-gate's cost.
+The union of the top deciles of the *four* detection lookbacks (`1m`, `3m`, `6m`, `12m`) —
+**21.9%** of the universe. The cut a name must clear before the detector is consulted.
+Still distinct from the five-lookback union (26.5%), which adds `1w`: a name top-decile in
+the last week alone is a momentum burst, not a prior move, and it is the one window measured
+to be worth excluding. It unioned only three lookbacks, at 19.3%, until #149 measured what
+`12m` admits and found the staleness the exclusion assumed did not occur — 1 of the 49
+entries it recovers is dead on the other three windows (ADR 0003, amendment).
+
+Three widths now exist in this codebase's history — **19.3%, 21.9% and 26.5%** — and quoting
+one against a result measured under another misattributes the gate's cost. All three are from
+`references/detection_gate_sweep.txt`, over the replay's 821 measured sessions
+(2019-09-30 to 2022-12-30). ADR 0003 and findings §3 quote **19.4%** and **27.2%** for the
+outer two: the same gates over the 505 sessions the store still held ranks for. The gates are
+identical; the windows are not.
 
 **Board / leaderboard**:
 Top 30 names by raw return for one market and lookback. Five boards per market.

--- a/backend/replay/field.py
+++ b/backend/replay/field.py
@@ -39,7 +39,7 @@ from dataclasses import dataclass
 from datetime import date
 from typing import Callable, Iterable, Sequence
 
-from screener.detection import Detection, detection_gate
+from screener.detection import DETECTION_LOOKBACKS, Detection, detection_gate
 from screener.pipeline import rebuild_detections
 from screener.ranks import Rank
 from screener.score import DIMENSIONS, Dimension, star_score
@@ -179,6 +179,7 @@ def build_field(
     *,
     entered: Iterable[str] = (),
     any_entry: bool = False,
+    lookbacks: Sequence[str] = DETECTION_LOOKBACKS,
 ) -> list[ScoredDetection]:
     """Score each detection and sort into star order — the replayed candidate list.
 
@@ -193,9 +194,15 @@ def build_field(
     a *not-taken detection* when a trade was entered this session but not in its
     name (PRD user story 25), and a *taken detection* when its own name was the one
     entered — the two groups A3's selection contrast compares (issue #122).
+
+    ``lookbacks`` is the gate's lookback set, defaulting to the live
+    :data:`~screener.detection.DETECTION_LOOKBACKS`. It is a parameter only so the
+    gate-width sweep (:mod:`replay.gate_sweep`, #149) can score a field under the
+    width that admitted it — a name admitted by a widened gate holds the prior-move
+    point under that gate, and scoring it against the live gate would understate it.
     """
     entered = set(entered)
-    gated = detection_gate(ranks)
+    gated = detection_gate(ranks, lookbacks=lookbacks)
     scored = [
         (det, seven_dimension_score(det, prior_move=det.symbol in gated))
         for det in detections

--- a/backend/replay/funnel.py
+++ b/backend/replay/funnel.py
@@ -135,13 +135,16 @@ class FunnelRow:
     but ranked outside the decile — both fail the decile stage, but only the
     second is a ranking verdict (PRD "A1 funnel").
 
-    ``decile_pass`` is the app's *three-union* gate (:func:`detection_gate`, over
-    1m/3m/6m); ``decile_pass_five`` is the app's *five-union* gate
-    (:func:`screener.ranks.decile_gate`, adding 1w and 12m), so a miss recovered by
-    widening the gate 3→5 is recoverable without a second rebuild (#133). Both come
-    straight from the app's own gate functions — never a hand-rolled percentile
-    test, the trap #133 calls out. ``eval_percentiles`` and ``decile_verdicts``
-    carry the *margin* of a decile miss: the ticker's percentile per detection
+    ``decile_pass`` is the app's own detection gate (:func:`detection_gate`);
+    ``decile_pass_five`` is the app's *five-union* gate
+    (:func:`screener.ranks.decile_gate`), so a miss recovered by widening the gate to
+    the full five lookbacks is recoverable without a second rebuild (#133). The
+    detection gate unioned three lookbacks (1m/3m/6m) when #133 landed and unions
+    four since #149 admitted 12m, so the gap between the two verdicts is now what
+    ``1w`` alone would add. Both come straight from the app's own gate functions, at
+    whatever width they currently run — never a hand-rolled percentile test, the trap
+    #133 calls out. ``eval_percentiles`` and ``decile_verdicts``
+    carry the *margin* of a decile miss: the ticker's percentile per
     lookback at the eval session, and the per-lookback top-decile verdict, so a miss
     clustered at the 11th percentile is distinguishable from one scattered across
     the distribution, and the lookback he was strong in is recoverable. Both are
@@ -153,7 +156,7 @@ class FunnelRow:
     eval_session: date | None
     liquidity_pass: bool
     decile_present: bool              # the ticker was a member of the field at all
-    decile_pass: bool                 # top decile on the *three-union* detection gate
+    decile_pass: bool                 # top decile on the app's detection gate
     decile_pass_five: bool            # top decile on the *five-union* gate (1w..12m)
     eval_percentiles: dict[str, float]  # per-lookback percentile at the eval session
     decile_verdicts: dict[str, bool]    # per-lookback top-decile verdict (#133)
@@ -199,15 +202,15 @@ class StageRecall:
 class DecileDecomposition:
     """The decile miss, decomposed into three exclusive, exhaustive buckets (#133).
 
-    Every replayable trade that fails the three-union decile gate lands in exactly
+    Every replayable trade that fails the detection gate lands in exactly
     one bucket, so the buckets sum to :attr:`total_misses`:
 
     - ``coverage_gap`` — the ticker was absent from the replayed field entirely
       (``decile_present`` ``False``): a survivorship hole, not a ranking verdict.
-    - ``recovered_by_five`` — present and outside the three-union gate, but inside
-      the *five-union* gate (top decile in 1w or 12m): the loss widening 3→5 would
-      recover. A preliminary #114 read put this near a third of the decile loss;
-      the full run confirms or kills it.
+    - ``recovered_by_five`` — present and outside the detection gate, but inside
+      the *five-union* gate: the loss widening the gate to all five lookbacks would
+      recover. Measured at 75 of 658 when the gate unioned three (#133); since #149
+      moved the gate to four, this bucket is what ``1w`` alone would add.
     - ``outside_any_union`` — present and outside even the five-union gate: a
       genuine ranking miss no gate widening reaches.
     """
@@ -219,9 +222,9 @@ class DecileDecomposition:
 
 
 def decompose_decile_misses(rows: Iterable[FunnelRow]) -> DecileDecomposition:
-    """Decompose every three-union decile miss across ``rows`` (#133).
+    """Decompose every decile miss across ``rows`` (#133).
 
-    A miss is any row that fails the three-union gate (``decile_pass`` ``False``);
+    A miss is any row that fails the detection gate (``decile_pass`` ``False``);
     each is attributed to exactly one bucket, so the three counts partition the
     misses. The verdicts read here (``decile_present``, ``decile_pass``,
     ``decile_pass_five``) are the ones the row carried straight off the app's gate
@@ -546,7 +549,7 @@ def _funnel_row(
     # eval session. Absent from the field (not a member) is a coverage gap kept
     # apart from present-but-outside-the-decile; both fail the decile stage. The
     # pass/fail verdicts come straight from the app's gate functions
-    # (detection_gate -> three-union, decile_gate -> five-union); the per-lookback
+    # (detection_gate -> the live gate, decile_gate -> five-union); the per-lookback
     # percentiles carry the *margin* of a miss but never re-decide the verdict.
     members = members_by_session.get(eval_session, set())
     decile_present = trade.ticker in members
@@ -710,9 +713,17 @@ def run_funnel(
     )
 
 
-def _stage_recall(
-    stage: str, rows: list[FunnelRow], predicate: Callable[[FunnelRow], bool]
+def stage_recall(
+    stage: str, rows: Sequence[FunnelRow], predicate: Callable[[FunnelRow], bool]
 ) -> StageRecall:
+    """One stage's recall over ``rows``, headline and ex-continuation together.
+
+    Both figures come off the same object and neither is ever emitted on its own
+    (PRD user story 6). Public because the gate-width sweep reports the same pair
+    for a stage the app does not currently run (:mod:`replay.gate_sweep`, #149), and
+    a second copy of this would be free to compute the ex-continuation split
+    differently.
+    """
     ex = [r for r in rows if not r.continuation]
     return StageRecall(
         stage=stage,
@@ -733,9 +744,9 @@ def _build_report(rows: list[FunnelRow], blind_spot_count: int) -> FunnelReport:
     return FunnelReport(
         rows=rows,
         stages=FUNNEL_STAGES,
-        liquidity=_stage_recall(STAGE_LIQUIDITY, rows, lambda r: r.liquidity_pass),
-        decile=_stage_recall(STAGE_DECILE, rows, lambda r: r.decile_pass),
-        detection=_stage_recall(STAGE_DETECTION, rows, lambda r: r.detection_pass),
+        liquidity=stage_recall(STAGE_LIQUIDITY, rows, lambda r: r.liquidity_pass),
+        decile=stage_recall(STAGE_DECILE, rows, lambda r: r.decile_pass),
+        detection=stage_recall(STAGE_DETECTION, rows, lambda r: r.detection_pass),
         condition_counts=condition_counts,
         continuation_count=sum(1 for r in rows if r.continuation),
         blind_spot_count=blind_spot_count,

--- a/backend/replay/gate_sweep.py
+++ b/backend/replay/gate_sweep.py
@@ -1,0 +1,1247 @@
+"""What widening the detection gate actually admits — the price of 3→5 (#149).
+
+ADR 0003 records **widen the gate from three lookbacks to five** as its leading
+candidate: it recovers 75 of Kullamägi's real entries (11.4pp, decile recall
+60.0% → 71.4%) for 7.8 points of universe. It deliberately did not authorise the
+edit. This module is the measurement that decides it.
+
+**The objection the headline number cannot answer.** ``DETECTION_LOOKBACKS`` is
+not an arbitrary narrowing: ``1w`` (a momentum burst) and ``12m`` (stale) are
+excluded *on purpose* (:func:`screener.detection.detection_gate`, spec §4.5
+gates), so a name that topped out a year ago cannot qualify on staleness alone.
+Widening 3→5 re-admits exactly those two. So the decisive figure is not the 75 —
+it is the **composition** of the 75 by admitting lookback (:func:`decompose_recovered`),
+and then, one level down, what those trades looked like on the lookbacks the gate
+already unions (:func:`profile_recovered`). Both are needed, because "admitted by
+``12m``" and "topped out months ago and has done nothing since" are different
+claims, and only the second is what the exclusion was written against: a name
+still sitting high in ``6m`` is not stale, whichever lookback let it in.
+
+**Precision stays unmeasurable, so the cost is priced as volume.** The reference
+set records no setup he declined, so there is no control group and no
+false-positive rate (findings §7, §9). What *is* countable is **field inflation**:
+how many more detections the widened gate emits per session, and therefore how
+many extra names the app shows per real entry recovered. That is the basis #141
+sets for the cluster gate, mirrored here so the funnel's two most expensive gates
+are priced the same way. Field inflation is a volume proxy and is **never** a
+false-positive rate: the added names carry no verdict.
+
+**One pass, every variant.** Detection geometry does not depend on the gate — the
+gate only decides *which* members are handed to :func:`screener.detection.detect`
+— so the sweep runs the detector once over the union of every swept lookback set
+and derives each variant's field by filtering that superset against the variant's
+own gate. Four gate widths therefore cost one detection pass, not four.
+
+**Read-only, and it never mutates the live width.** Every gate here goes through
+the app's own :func:`~screener.detection.detection_gate` with its ``lookbacks``
+handed in (#149's first acceptance criterion), and the baseline is
+:data:`GATE_AS_MEASURED` rather than the live constant, so the report stays
+reproducible after its own verdict moves that constant. Nothing here writes to the
+store: the
+forward chain is reconstructed from the universe rows the replay store already
+holds and the ranks are recomputed in memory, exactly as
+:func:`replay.chain._replay_session` does on reuse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, Sequence
+
+from screener.detection import Detection, detect, detection_gate
+from screener.indicators import LOOKBACKS
+from screener.ranks import Rank, rank_table
+from screener.store import Store
+
+from .caching_store import CachingStore
+from .chain import BURN_IN_SESSIONS, REPLAY_MARKET, SessionField
+from .field import build_field
+from .funnel import FunnelRow, StageRecall, build_funnel_report, stage_recall
+from .placement import BOARD_SIZE
+from .study import progress_printer
+from .reference import (
+    DEFAULT_BLIND_SPOT_OUT,
+    DEFAULT_REFERENCE_JSON,
+    ExecutedTrade,
+    classify,
+    load_trades,
+)
+
+# The two lookbacks the gate excluded when #149 asked the question, and the reason
+# each was kept out (:func:`screener.detection.detection_gate`): `1w` as a momentum
+# burst rather than §3.1's big prior move, `12m` as staleness. Named rather than
+# inlined because the whole ticket turns on telling them apart — the two exclusions
+# rest on different arguments and have to be priced separately.
+LOOKBACK_STALE = "12m"
+LOOKBACK_BURST = "1w"
+EXCLUDED_LOOKBACKS = (LOOKBACK_BURST, LOOKBACK_STALE)
+
+# The width the detection gate ran at when this question was asked. **Pinned here,
+# not read off** :data:`~screener.detection.DETECTION_LOOKBACKS`: this module is the
+# evidence that settles what the live width should be, so it has to keep producing
+# the same report after the decision moves the live value. A sweep whose baseline
+# drifted with the constant it is arguing about could not be re-run to audit its own
+# verdict.
+GATE_AS_MEASURED: tuple[str, ...] = ("1m", "3m", "6m")
+
+
+@dataclass(frozen=True)
+class GateVariant:
+    """One detection-gate width to price: a name and the lookbacks it unions.
+
+    ``lookbacks`` is handed straight to :func:`screener.detection.detection_gate`,
+    so a variant is the app's own gate under a different width — never a
+    reimplementation of the top-decile test.
+    """
+
+    name: str
+    lookbacks: tuple[str, ...]
+
+    @property
+    def added(self) -> tuple[str, ...]:
+        """What this variant adds to the as-measured gate, in ``LOOKBACKS`` order."""
+        return tuple(
+            lb for lb in LOOKBACKS if lb in set(self.lookbacks) - set(GATE_AS_MEASURED)
+        )
+
+
+BASELINE_VARIANT = GateVariant("1m/3m/6m (as measured)", GATE_AS_MEASURED)
+
+# The widths worth pricing. 3→5 is ADR 0003's candidate; the two four-lookback
+# variants exist because #149 refuses to let the five-lookback set be adopted as
+# one indivisible move — if the recovered trades come overwhelmingly through one
+# of the excluded lookbacks, the honest options are the narrower widenings, each
+# justified on its own evidence rather than on the union's headline.
+GATE_VARIANTS: tuple[GateVariant, ...] = (
+    BASELINE_VARIANT,
+    GateVariant("+1w (burst)", GATE_AS_MEASURED + (LOOKBACK_BURST,)),
+    GateVariant("+12m (stale)", GATE_AS_MEASURED + (LOOKBACK_STALE,)),
+    GateVariant("five (3→5)", GATE_AS_MEASURED + EXCLUDED_LOOKBACKS),
+)
+
+
+# -- gate membership, per session, per single lookback ------------------------
+
+
+# ``{session: {lookback: {symbols top-decile in it}}}`` — the substrate every
+# figure here is read off. Built one lookback at a time so a variant's gate is a
+# union of these sets *and* a recovered trade's admitting lookbacks are readable
+# off the same structure, with no second definition of "top decile" anywhere.
+GateMembership = Mapping[date, Mapping[str, set[str]]]
+
+
+def gate_membership(ranks: list[Rank]) -> dict[str, set[str]]:
+    """One session's top-decile set per lookback, via the app's own gate function.
+
+    Each entry is :func:`screener.detection.detection_gate` restricted to a single
+    lookback, so ``union(membership[lb] for lb in variant.lookbacks)`` is exactly
+    the gate that variant would run — asserted, not assumed, by the seam test.
+    """
+    return {lb: detection_gate(ranks, lookbacks=(lb,)) for lb in LOOKBACKS}
+
+
+def variant_gate(membership: Mapping[str, set[str]], variant: GateVariant) -> set[str]:
+    """The variant's gate at one session — the union of its lookbacks' deciles."""
+    gated: set[str] = set()
+    for lb in variant.lookbacks:
+        gated |= membership.get(lb, set())
+    return gated
+
+
+# -- the composition of the 75 ------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RecoveredComposition:
+    """The trades a widening recovers, split by *which* lookback admits them (#149).
+
+    Every trade counted here fails the as-measured three-union gate, was present in the
+    replayed field, and clears the five-union one — the ``recovered_by_five``
+    bucket of :class:`replay.funnel.DecileDecomposition`, decomposed one level
+    further.
+
+    The four buckets are exclusive and exhaustive over ``total``:
+
+    - ``stale_only`` — admitted by ``12m`` and nothing else: the *candidate* for
+      §4.5's stale qualifier. Whether it is one is a separate question these counts
+      cannot answer — see :func:`profile_recovered`, which asks what these names
+      looked like on the windows the gate already unions.
+    - ``burst_only`` — admitted by ``1w`` and nothing else: the momentum-burst
+      candidate, on the same footing.
+    - ``both_excluded`` — admitted by ``1w`` *and* ``12m``, by neither of the
+      gate's own lookbacks.
+    - ``also_gated`` — admitted by an excluded lookback *and* by one already in
+      the gate. **Zero by construction** (such a name already clears the
+      as-measured gate), and carried explicitly so that fact is visible in the
+      output rather than assumed by the reader.
+
+    ``continuation`` counts how many of ``total`` are continuation entries — adds
+    to a running position, tagged and never dropped (PRD user story 5).
+    """
+
+    total: int
+    stale_only: int
+    burst_only: int
+    both_excluded: int
+    also_gated: int
+    continuation: int
+
+    @property
+    def excluded_only(self) -> int:
+        """Recovered *solely* by the two deliberately-excluded lookbacks."""
+        return self.stale_only + self.burst_only + self.both_excluded
+
+    def share(self, count: int) -> float:
+        """``count`` as a share of the recovered trades, 0.0 when none were."""
+        return count / self.total if self.total else 0.0
+
+
+# Where a recovered trade sits on the lookbacks the gate **already** unions, and
+# so whether it is really the qualifier the exclusion was written against. The
+# spec's objection is not "12m admitted it" — it is "a name that topped out months
+# ago and has done nothing since". A name admitted by 12m while still sitting in
+# the upper reaches of 3m and 6m has not gone quiet in that sense; one below the
+# field's median on every gated lookback has.
+FIELD_MEDIAN = 0.50   # mid-pack on a lookback — the "has done nothing since" line
+NEAR_DECILE = 0.80    # within reach of the cut the gate already applies
+
+
+def baseline_pass(row: FunnelRow, membership: GateMembership) -> bool:
+    """Whether ``row`` clears the **as-measured** three-union gate.
+
+    Read off :func:`gate_membership` rather than off ``row.decile_pass``, which is
+    the *live* gate and therefore moves the moment this study's verdict is adopted.
+    Both are the app's own :func:`~screener.detection.detection_gate`; only the
+    width differs.
+    """
+    if row.eval_session is None:
+        return False
+    per_lookback = membership.get(row.eval_session, {})
+    return any(row.ticker in per_lookback.get(lb, set()) for lb in GATE_AS_MEASURED)
+
+
+def recovered_rows(
+    rows: Iterable[FunnelRow], membership: GateMembership
+) -> list[FunnelRow]:
+    """The decile misses a 3→5 widening would recover — present, outside the
+    three-union gate, inside the five-union one.
+
+    ``decile_present`` and ``decile_pass_five`` are the verdicts the funnel row
+    carried straight off the app's gate functions; this never re-derives a decile
+    verdict from a percentile (the trap #133 calls out).
+    """
+    return [
+        r
+        for r in rows
+        if not baseline_pass(r, membership) and r.decile_present and r.decile_pass_five
+    ]
+
+
+def admitting_lookbacks(row: FunnelRow, membership: GateMembership) -> set[str]:
+    """Which lookbacks had ``row``'s ticker top-decile at its evaluation session."""
+    per_lookback = membership.get(row.eval_session, {}) if row.eval_session else {}
+    return {lb for lb, gated in per_lookback.items() if row.ticker in gated}
+
+
+# The four admitting-lookback groups a recovered trade can fall into. Exclusive and
+# exhaustive, and named once because both the count decomposition and the profile
+# read the same split — two hand-rolled copies of it would be free to disagree
+# about which group a trade belongs to.
+GROUP_STALE_ONLY = f"{LOOKBACK_STALE} only"
+GROUP_BURST_ONLY = f"{LOOKBACK_BURST} only"
+GROUP_BOTH = "both"
+GROUP_ALSO_GATED = "also gated"
+
+
+def group_recovered(
+    rows: Iterable[FunnelRow], membership: GateMembership
+) -> dict[str, list[FunnelRow]]:
+    """Split the recovered decile misses by which lookback admits each of them."""
+    groups: dict[str, list[FunnelRow]] = {
+        GROUP_STALE_ONLY: [], GROUP_BURST_ONLY: [], GROUP_BOTH: [], GROUP_ALSO_GATED: [],
+    }
+    for row in recovered_rows(rows, membership):
+        admitting = admitting_lookbacks(row, membership)
+        if admitting & set(GATE_AS_MEASURED):
+            groups[GROUP_ALSO_GATED].append(row)
+        elif LOOKBACK_STALE in admitting and LOOKBACK_BURST in admitting:
+            groups[GROUP_BOTH].append(row)
+        elif LOOKBACK_STALE in admitting:
+            groups[GROUP_STALE_ONLY].append(row)
+        else:
+            groups[GROUP_BURST_ONLY].append(row)
+    return groups
+
+
+def flatten_groups(groups: Mapping[str, list[FunnelRow]]) -> list[FunnelRow]:
+    """Every recovered trade across the admitting-lookback groups, as one list."""
+    return [row for rs in groups.values() for row in rs]
+
+
+def decompose_recovered(
+    rows: Iterable[FunnelRow], membership: GateMembership
+) -> RecoveredComposition:
+    """Split the recovered decile misses by their admitting lookback (#149).
+
+    This is the ticket's headline. A widening whose recovered trades arrive through
+    ``3m``/``6m`` adjacency is a different proposition from one that arrives through
+    ``12m`` staleness, and ADR 0003's single number cannot tell them apart.
+    """
+    groups = group_recovered(rows, membership)
+    recovered = flatten_groups(groups)
+    return RecoveredComposition(
+        total=len(recovered),
+        stale_only=len(groups[GROUP_STALE_ONLY]),
+        burst_only=len(groups[GROUP_BURST_ONLY]),
+        both_excluded=len(groups[GROUP_BOTH]),
+        also_gated=len(groups[GROUP_ALSO_GATED]),
+        continuation=sum(1 for row in recovered if row.continuation),
+    )
+
+
+@dataclass(frozen=True)
+class AdmittedGroup:
+    """One admitting-lookback group of the recovered trades, profiled against the
+    lookbacks the as-measured gate already unions (#149).
+
+    The bucket counts alone cannot settle the §4.5 objection. "Admitted by ``12m``"
+    is not the same claim as "topped out months ago and has done nothing since" —
+    the second is what the exclusion was written against, and it is a statement
+    about the name's *recent* ranks, not about which lookback let it in. So each
+    group carries where its trades sat on ``1m``/``3m``/``6m`` at the evaluation
+    session, off the per-lookback margins the funnel row already records (#133):
+
+    - ``dead_on_gated`` — below :data:`FIELD_MEDIAN` on **every** gated lookback.
+      This is the stale (or burst) qualifier as the spec describes it, counted.
+    - ``within_reach`` — at or above :data:`NEAR_DECILE` on at least one gated
+      lookback: a name the as-measured gate very nearly admitted on its own terms.
+    - ``median_percentiles`` — the group's median percentile per lookback.
+    """
+
+    label: str
+    n: int
+    dead_on_gated: int
+    within_reach: int
+    median_percentiles: Mapping[str, float]
+
+
+def _group_profile(label: str, rows: Sequence[FunnelRow]) -> AdmittedGroup:
+    def best_gated(row: FunnelRow) -> float:
+        return max(
+            (row.eval_percentiles.get(lb, 0.0) for lb in GATE_AS_MEASURED),
+            default=0.0,
+        )
+
+    medians = {}
+    for lb in LOOKBACKS:
+        values = [r.eval_percentiles[lb] for r in rows if lb in r.eval_percentiles]
+        if values:
+            medians[lb] = statistics.median(values)
+    return AdmittedGroup(
+        label=label,
+        n=len(rows),
+        dead_on_gated=sum(1 for r in rows if best_gated(r) < FIELD_MEDIAN),
+        within_reach=sum(1 for r in rows if best_gated(r) >= NEAR_DECILE),
+        median_percentiles=medians,
+    )
+
+
+def profile_recovered(
+    rows: Iterable[FunnelRow], membership: GateMembership
+) -> tuple[AdmittedGroup, ...]:
+    """Profile each admitting-lookback group against the gate's own lookbacks (#149).
+
+    Answers the question the bucket counts raise but cannot settle: of the trades a
+    widening recovers through an excluded lookback, how many are the stale or burst
+    qualifiers the exclusion exists to keep out, and how many are simply names the
+    as-measured gate came close to admitting anyway.
+    """
+    groups = group_recovered(rows, membership)
+    return tuple(_group_profile(label, rs) for label, rs in groups.items() if rs)
+
+
+# -- outcome quality of the recovered trades ----------------------------------
+
+
+# R in this trade record is fat-tailed — every group's median R is −1.00 and the
+# return lives in a handful of names — so a group's mean is a statement about its
+# best trade unless it is read beside a trimmed mean and a tail rate.
+TRIM_FRACTION = 0.05   # share of the group dropped from the top before re-meaning
+BIG_WIN_R = 3.0        # the tail a breakout method is actually trading for
+
+
+@dataclass(frozen=True)
+class OutcomeQuality:
+    """Realised outcome for one group of executed trades (#149).
+
+    Reported so a recall gain is never read as a gain in *quality*: if the trades a
+    widening recovers run materially worse than the ones the gate already passes,
+    the recovered count is buying less than it looks like.
+
+    **R is fat-tailed here, so the mean alone decides nothing.** Every group in this
+    study has a median R of −1.00 — the method stops out most of the time and earns
+    in the tail — which makes ``mean_r`` a statement about one or two names. Four
+    robust figures are carried beside it, and the comparison between groups is meant
+    to be read off these:
+
+    - ``trimmed_mean_r`` — the mean after dropping the top :data:`TRIM_FRACTION` of
+      the group by R. A *fraction*, not a count, so groups of very different sizes
+      are trimmed comparably.
+    - ``win_rate`` — the share with positive R.
+    - ``big_win_rate`` — the share reaching :data:`BIG_WIN_R`, where a breakout
+      method's whole edge lives.
+    - ``top_trade_r_share`` — how much of the group's total R its single best trade
+      supplies. A group whose figure is near 1 has no measured central tendency
+      worth quoting.
+
+    Figures are ``None`` when no trade in the group carries an outcome.
+    """
+
+    label: str
+    n: int
+    n_with_r: int
+    mean_r: float | None
+    median_r: float | None
+    trimmed_mean_r: float | None
+    win_rate: float | None
+    big_win_rate: float | None
+    top_trade_r_share: float | None
+    mean_mfe: float | None
+
+
+def outcome_quality(
+    label: str,
+    rows: Iterable[FunnelRow],
+    trades: Mapping[tuple[str, date], ExecutedTrade],
+) -> OutcomeQuality:
+    """Realised R and win rate for the trades behind ``rows``.
+
+    ``trades`` is keyed ``(ticker, entry_date)`` — the identity of an executed
+    trade. A row with no matching outcome is counted in ``n`` and excluded from the
+    averages, so the group's size is never quietly shrunk to the rows that happened
+    to carry a result.
+    """
+    rows = list(rows)
+    rs: list[float] = []
+    mfes: list[float] = []
+    for row in rows:
+        trade = trades.get((row.ticker, row.entry_date))
+        if trade is None:
+            continue
+        if trade.r is not None:
+            rs.append(trade.r)
+        primary = trade.primary
+        if primary is not None and primary.mfe_pct is not None:
+            mfes.append(primary.mfe_pct)
+    ordered = sorted(rs)
+    drop = math.ceil(TRIM_FRACTION * len(ordered)) if ordered else 0
+    trimmed = ordered[: len(ordered) - drop] if ordered else []
+    total_r = sum(rs)
+    return OutcomeQuality(
+        label=label,
+        n=len(rows),
+        n_with_r=len(rs),
+        mean_r=statistics.fmean(rs) if rs else None,
+        median_r=statistics.median(rs) if rs else None,
+        trimmed_mean_r=statistics.fmean(trimmed) if trimmed else None,
+        win_rate=sum(1 for r in rs if r > 0) / len(rs) if rs else None,
+        big_win_rate=sum(1 for r in rs if r >= BIG_WIN_R) / len(rs) if rs else None,
+        top_trade_r_share=(max(rs) / total_r if rs and total_r > 0 else None),
+        mean_mfe=statistics.fmean(mfes) if mfes else None,
+    )
+
+
+# -- the per-session pass every variant is measured against -------------------
+
+
+@dataclass(frozen=True)
+class SweepSession:
+    """One measured session, prepared once for every variant.
+
+    ``detections`` is the detector's output over the **widest** gate swept, so a
+    variant's field is a filter of it rather than a second detection pass:
+    detection geometry does not depend on the gate, only on which members reach
+    :func:`screener.detection.detect`. ``membership`` is that session's per-lookback
+    top-decile sets.
+    """
+
+    session: date
+    members: list[str]
+    ranks: list[Rank]
+    membership: dict[str, set[str]]
+    detections: list[Detection]
+
+
+def build_sweep_sessions(
+    store: Store,
+    market: str,
+    sessions: Sequence[date],
+    *,
+    lookbacks: Sequence[str],
+    progress: Callable[[int, int, date], None] | None = None,
+) -> list[SweepSession]:
+    """Reconstruct each session's universe, ranks and widest-gate detections.
+
+    **Read-only.** Membership is read from the universe rows the replay store
+    already holds and the rank table is recomputed in memory — the same pair
+    :func:`replay.chain._replay_session` returns when it reuses a session, so the
+    reconstruction is the chain's own reuse path with nothing written back. The
+    detector then runs over the union gate ``lookbacks`` describes.
+
+    ``progress`` is called as ``progress(i, total, session)`` after each session, so
+    a long pass reports rather than hanging silently.
+    """
+    store = CachingStore.wrap(store)
+    total = len(sessions)
+    out: list[SweepSession] = []
+    for i, session in enumerate(sessions, start=1):
+        members = store.universe(market, session)
+        bars = {symbol: store.bars(market, symbol) for symbol in members}
+        ranks = rank_table(bars, session)
+        membership = gate_membership(ranks)
+        gated = detection_gate(ranks, lookbacks=lookbacks)
+        detections = [
+            found
+            for symbol in members
+            if symbol in gated
+            and (found := detect(symbol, bars[symbol], session)) is not None
+        ]
+        out.append(
+            SweepSession(
+                session=session,
+                members=members,
+                ranks=ranks,
+                membership=membership,
+                detections=detections,
+            )
+        )
+        if progress is not None:
+            progress(i, total, session)
+    return out
+
+
+def session_fields(
+    sessions: Sequence[SweepSession], blind_spot_count: int
+) -> list[SessionField]:
+    """The sweep's sessions as a chain, so the funnel can be walked over the same pass."""
+    return [
+        SessionField(
+            session=s.session,
+            burn_in=False,
+            members=s.members,
+            ranks=s.ranks,
+            blind_spot_count=blind_spot_count,
+        )
+        for s in sessions
+    ]
+
+
+# -- one variant, measured ----------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VariantMeasurement:
+    """Everything #149 asks to be reported at one gate width.
+
+    ``gate_population_share`` is the share of the universe the gate admits, averaged
+    over the measured sessions — the gate's *cost* in ADR 0003's own currency.
+    ``decile_recall`` is the share of replayable trades clearing this gate;
+    ``surfaced_recall`` is the share clearing it **and** the detector, which is what
+    the app would actually have shown. Detection recall on its own is gate-invariant
+    (the funnel evaluates every stage unconditionally), so it is not restated per
+    variant.
+
+    ``field_detections`` is the total detections emitted across the measured
+    sessions — the **field inflation** figure, priced as volume because precision is
+    unmeasurable (findings §7, §9). ``field_detections_on_trade_sessions`` is the
+    same count restricted to the sessions an executed trade was evaluated at, which
+    is the basis A2's star distribution uses; both are carried because the two are
+    easy to mistake for each other and differ by more than 4×. ``board_displacement`` counts how many
+    baseline top-``board_size`` places are taken by names this variant admits,
+    summed over sessions; ``picks_in_field`` and ``picks_on_board`` are his own
+    entries' counts under this width — his ticker appearing in that session's
+    field at all, and inside the top ``board_size`` of it. ``picks_in_field`` tracks
+    ``surfaced_recall`` closely and is not a second reading of it: the recall figure
+    asks whether the detector fires on the trade's own bars, while this one asks
+    whether the name reached the *field*, which additionally requires it to have been
+    a universe member that session. They diverge exactly on the coverage gap.
+    """
+
+    variant: GateVariant
+    sessions: int
+    gate_population_share: float
+    decile_recall: StageRecall
+    surfaced_recall: StageRecall
+    field_detections: int
+    field_detections_on_trade_sessions: int
+    added_detections_stale: int
+    added_detections_total: int
+    board_displacement: int
+    picks_in_field: int
+    picks_on_board: int
+
+    @property
+    def detections_per_surfaced_entry(self) -> float | None:
+        """The width's own exchange rate: detections shown per entry surfaced.
+
+        The denominator every marginal ratio has to be read against. A widening
+        whose *marginal* cost per entry sits near the funnel's *average* cost is not
+        degrading the funnel — it is buying at the going rate.
+        """
+        n = self.surfaced_recall.passed
+        return self.field_detections / n if n else None
+
+    @property
+    def added_stale_share(self) -> float | None:
+        """Share of the detections this width adds that are stale by §4.5's own test.
+
+        A name below :data:`FIELD_MEDIAN` on **every** lookback the as-measured gate unions
+        — mid-pack or worse on 1m, 3m and 6m — reaching the field only because a
+        wider gate admitted it. This is the exclusion's worry measured against the
+        *field*, not against his trades: a widening can leave his recovered entries
+        looking healthy while flooding the list with names that topped out long ago.
+        """
+        n = self.added_detections_total
+        return self.added_detections_stale / n if n else None
+
+
+def _gated_percentiles(ranks: list[Rank]) -> dict[str, float]:
+    """Each symbol's **best** percentile across the as-measured gate's lookbacks.
+
+    The one number that says how strong a name is on the gate's own terms, so a name
+    the wider gate admitted can be asked whether the as-measured gate had any reason to
+    want it.
+    """
+    best: dict[str, float] = {}
+    gated = set(GATE_AS_MEASURED)
+    for r in ranks:
+        if r.lookback in gated:
+            best[r.symbol] = max(best.get(r.symbol, 0.0), r.percentile)
+    return best
+
+
+def measure_variant(
+    variant: GateVariant,
+    sessions: Sequence[SweepSession],
+    rows: Sequence[FunnelRow],
+    *,
+    baseline_boards: Mapping[date, list[str]] | None = None,
+    baseline_gates: Mapping[date, set[str]] | None = None,
+    board_size: int = BOARD_SIZE,
+) -> tuple[VariantMeasurement, dict[date, list[str]], dict[date, set[str]]]:
+    """Measure one gate width over the prepared pass.
+
+    Returns the measurement, this variant's per-session board and its per-session
+    gate, so the baseline's pair can be handed back in to price displacement and the
+    added field against it — without a second pass over the sessions.
+    """
+    gates = {s.session: variant_gate(s.membership, variant) for s in sessions}
+    universe = sum(len(s.members) for s in sessions)
+    gated_total = sum(len(g) for g in gates.values())
+
+    field_detections = 0
+    boards: dict[date, list[str]] = {}
+    in_field = on_board = 0
+    # Counted per *trade*, as A2 counts a placement — the same ticker entered twice
+    # off one session is two placements, not one (:mod:`replay.placement`).
+    picks_by_session: dict[date, list[FunnelRow]] = {}
+    for row in rows:
+        if row.eval_session is not None:
+            picks_by_session.setdefault(row.eval_session, []).append(row)
+
+    added_stale = added_total = 0
+    on_trade_sessions = 0
+    for s in sessions:
+        gate = gates[s.session]
+        detections = [d for d in s.detections if d.symbol in gate]
+        field_detections += len(detections)
+        if s.session in picks_by_session:
+            on_trade_sessions += len(detections)
+        if baseline_gates is not None:
+            base_gate = baseline_gates.get(s.session, set())
+            added = [d for d in detections if d.symbol not in base_gate]
+            added_total += len(added)
+            percentiles = _gated_percentiles(s.ranks)
+            added_stale += sum(
+                1 for d in added if percentiles.get(d.symbol, 0.0) < FIELD_MEDIAN
+            )
+        scored = build_field(detections, s.ranks, lookbacks=variant.lookbacks)
+        board = [d.symbol for d in scored[:board_size]]
+        boards[s.session] = board
+        present = {d.symbol for d in scored}
+        for row in picks_by_session.get(s.session, ()):
+            in_field += row.ticker in present
+            on_board += row.ticker in set(board)
+
+    displacement = 0
+    if baseline_boards is not None:
+        for session, board in boards.items():
+            base = set(baseline_boards.get(session, ()))
+            displacement += sum(1 for symbol in board if symbol not in base)
+
+    def gate_pass(row: FunnelRow) -> bool:
+        if row.eval_session is None:
+            return False
+        return row.ticker in gates.get(row.eval_session, set())
+
+    measurement = VariantMeasurement(
+        variant=variant,
+        sessions=len(sessions),
+        gate_population_share=gated_total / universe if universe else 0.0,
+        decile_recall=stage_recall("decile", rows, gate_pass),
+        surfaced_recall=stage_recall(
+            "surfaced", rows, lambda r: gate_pass(r) and r.detection_pass
+        ),
+        field_detections=field_detections,
+        field_detections_on_trade_sessions=on_trade_sessions,
+        added_detections_stale=added_stale,
+        added_detections_total=added_total,
+        board_displacement=displacement,
+        picks_in_field=in_field,
+        picks_on_board=on_board,
+    )
+    return measurement, boards, gates
+
+
+# -- the whole sweep ----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Inflation:
+    """What one variant costs, per real entry it recovers (#141's basis, #149's mirror).
+
+    ``added_detections`` is the extra field volume over the baseline width across
+    the measured sessions; ``recovered_entries`` is the extra executed trades the
+    wider gate lets through the decile stage, and ``surfaced_entries`` the extra
+    that also clear the detector — the ones the app would truly have shown.
+
+    ``per_recovered_entry`` is the ticket's price tag: **added detections per real
+    entry recovered**. It is a *volume* ratio and never a false-positive rate — the
+    added names carry no verdict, they are simply names he may never have seen
+    (findings §7, §9).
+    """
+
+    added_detections: int
+    recovered_entries: int
+    surfaced_entries: int
+
+    @property
+    def per_recovered_entry(self) -> float | None:
+        """Added detections per executed trade this width lets through the decile
+        stage — #149's headline price. ``None`` when it recovers none."""
+        n = self.recovered_entries
+        return self.added_detections / n if n else None
+
+    @property
+    def per_surfaced_entry(self) -> float | None:
+        """Added detections per executed trade this width would actually have put in
+        front of the trader — the decile gain that also clears the detector."""
+        n = self.surfaced_entries
+        return self.added_detections / n if n else None
+
+
+@dataclass(frozen=True)
+class GateSweep:
+    """The #149 measurement: every gate width priced against the as-measured one.
+
+    ``composition`` is the headline — the recovered trades split by admitting
+    lookback. ``outcomes`` pairs the recovered group with the group the as-measured gate
+    already passes, so the recall gain is read against its quality. ``variants``
+    and ``inflation`` carry the per-width figures, the baseline first.
+    """
+
+    market: str
+    sessions: int
+    first_session: date | None
+    last_session: date | None
+    replayable_trades: int
+    blind_spot_count: int
+    detection_recall: StageRecall
+    composition: RecoveredComposition
+    profile: tuple[AdmittedGroup, ...]
+    outcomes: tuple[OutcomeQuality, ...]
+    variants: tuple[VariantMeasurement, ...]
+    inflation: Mapping[str, Inflation]
+
+    @property
+    def baseline(self) -> VariantMeasurement:
+        """The width every other one is priced against — :data:`GATE_AS_MEASURED`."""
+        return self.variants[0]
+
+
+def sweep_gates(
+    sessions: Sequence[SweepSession],
+    rows: Sequence[FunnelRow],
+    trades: Mapping[tuple[str, date], ExecutedTrade],
+    *,
+    market: str = REPLAY_MARKET,
+    variants: Sequence[GateVariant] = GATE_VARIANTS,
+    blind_spot_count: int = 0,
+    board_size: int = BOARD_SIZE,
+) -> GateSweep:
+    """Price every gate width in ``variants`` against the first one (the baseline).
+
+    The baseline is ``variants[0]`` — its board is what displacement is measured
+    against and its field volume is what inflation is measured from.
+    """
+    rows = list(rows)
+    membership = {s.session: s.membership for s in sessions}
+
+    measurements: list[VariantMeasurement] = []
+    baseline_boards: dict[date, list[str]] | None = None
+    baseline_gates: dict[date, set[str]] | None = None
+    for variant in variants:
+        measurement, boards, gates = measure_variant(
+            variant, sessions, rows,
+            baseline_boards=baseline_boards,
+            baseline_gates=baseline_gates,
+            board_size=board_size,
+        )
+        if baseline_boards is None:
+            baseline_boards, baseline_gates = boards, gates
+        measurements.append(measurement)
+
+    base = measurements[0]
+    inflation = {
+        m.variant.name: Inflation(
+            added_detections=m.field_detections - base.field_detections,
+            recovered_entries=m.decile_recall.passed - base.decile_recall.passed,
+            surfaced_entries=m.surfaced_recall.passed - base.surfaced_recall.passed,
+        )
+        for m in measurements[1:]
+    }
+
+    groups = group_recovered(rows, membership)
+    recovered = flatten_groups(groups)
+    passing = [r for r in rows if baseline_pass(r, membership)]
+    return GateSweep(
+        market=market,
+        sessions=len(sessions),
+        first_session=sessions[0].session if sessions else None,
+        last_session=sessions[-1].session if sessions else None,
+        replayable_trades=len(rows),
+        blind_spot_count=blind_spot_count,
+        detection_recall=stage_recall("detection", rows, lambda r: r.detection_pass),
+        composition=decompose_recovered(rows, membership),
+        profile=profile_recovered(rows, membership),
+        # The recovered group whole, then split by admitting lookback, against the
+        # group the as-measured gate already passes. The split is what decides between the
+        # two narrower widenings if 3→5 itself does not stand.
+        outcomes=(
+            outcome_quality("recovered by 3→5", recovered, trades),
+            *(
+                outcome_quality(f"…{label}", rs, trades)
+                for label, rs in groups.items()
+                if rs
+            ),
+            outcome_quality("passing 1m/3m/6m", passing, trades),
+        ),
+        variants=tuple(measurements),
+        inflation=inflation,
+    )
+
+
+# -- human-readable report ----------------------------------------------------
+
+
+def _pct(value: float | None) -> str:
+    return "—" if value is None else f"{value:.1%}"
+
+
+def _num(value: float | None, places: int = 2) -> str:
+    return "—" if value is None else f"{value:.{places}f}"
+
+
+def _format_composition(comp: RecoveredComposition) -> str:
+    lines = [
+        f"recovered by widening 3→5: {comp.total} trades "
+        f"({comp.continuation} of them continuation entries)",
+        "",
+        "  admitted by                          count   share",
+        f"  12m only (excluded as stale)       {comp.stale_only:6d}  "
+        f"{_pct(comp.share(comp.stale_only))}",
+        f"  1w only (excluded as a burst)      {comp.burst_only:6d}  "
+        f"{_pct(comp.share(comp.burst_only))}",
+        f"  both 1w and 12m                     {comp.both_excluded:6d}  "
+        f"{_pct(comp.share(comp.both_excluded))}",
+        f"  also by a lookback already gated    {comp.also_gated:6d}  "
+        f"{_pct(comp.share(comp.also_gated))}",
+        "",
+        f"  recovered solely by the two excluded lookbacks: {comp.excluded_only}"
+        f" ({_pct(comp.share(comp.excluded_only))})",
+    ]
+    return "\n".join(lines)
+
+
+def _recall_line(recall: StageRecall) -> str:
+    """One stage's recall, headline and ex-continuation on the same line (§6)."""
+    return (
+        f"{recall.passed}/{recall.total} ({_pct(recall.recall)})   "
+        f"ex-continuation: {recall.passed_ex_continuation}/"
+        f"{recall.total_ex_continuation} ({_pct(recall.recall_ex_continuation)})"
+    )
+
+
+def _format_profile(groups: Sequence[AdmittedGroup]) -> str:
+    header = (
+        "admitted by       n   dead on 1m/3m/6m   within reach   "
+        + "  ".join(f"med {lb:>4}" for lb in LOOKBACKS)
+    )
+    lines = [header]
+    for g in groups:
+        medians = "  ".join(
+            f"{g.median_percentiles.get(lb, float('nan')):8.3f}" for lb in LOOKBACKS
+        )
+        lines.append(
+            f"{g.label:<15} {g.n:3d}   {g.dead_on_gated:16d}   {g.within_reach:12d}   {medians}"
+        )
+    lines.append("")
+    lines.append(
+        "`dead on 1m/3m/6m` is below the field median on every lookback the "
+        "as-measured gate unions —\nthe stale (or burst) qualifier as §4.5 describes it. "
+        "`within reach` is at or above the 80th\npercentile on one of them: a name "
+        "the as-measured gate nearly admitted on its own terms."
+    )
+    return "\n".join(lines)
+
+
+def _format_outcomes(outcomes: Sequence[OutcomeQuality]) -> str:
+    lines = [
+        "group                    n   mean R   trim5% R   median R   win rate   "
+        "R>=3 rate   best trade's share of R   mean MFE%"
+    ]
+    for o in outcomes:
+        lines.append(
+            f"{o.label:<22} {o.n:4d}   {_num(o.mean_r):>6}   {_num(o.trimmed_mean_r):>8}   "
+            f"{_num(o.median_r):>8}   {_pct(o.win_rate):>8}   {_pct(o.big_win_rate):>9}   "
+            f"{_pct(o.top_trade_r_share):>23}   {_num(o.mean_mfe, 1):>9}"
+        )
+    lines.append("")
+    lines.append(
+        "Median R is −1.00 in every group — the method stops out most of the time "
+        "and earns in\nthe tail — so read the trimmed mean and the R>=3 rate, not "
+        "the mean. A group whose best\ntrade supplies most of its R has no central "
+        "tendency worth quoting."
+    )
+    return "\n".join(lines)
+
+
+def _format_variants(sweep: GateSweep) -> str:
+    lines = [
+        f"{'gate width':<22} universe   decile recall (ex-cont)      "
+        "surfaced recall (ex-cont)     field    in-field   on board",
+    ]
+    for m in sweep.variants:
+        d, s = m.decile_recall, m.surfaced_recall
+        lines.append(
+            f"{m.variant.name:<22} {_pct(m.gate_population_share):>8}   "
+            f"{d.passed:3d}/{d.total} ({_pct(d.recall)})  ({_pct(d.recall_ex_continuation)})   "
+            f"{s.passed:3d}/{s.total} ({_pct(s.recall)})  ({_pct(s.recall_ex_continuation)})  "
+            f"{m.field_detections:8d}    {m.picks_in_field:5d}    {m.picks_on_board:5d}"
+        )
+    return "\n".join(lines)
+
+
+def _format_inflation(sweep: GateSweep) -> str:
+    base = sweep.baseline
+    lines = [
+        f"baseline field: {base.field_detections} detections over {base.sessions} "
+        f"measured sessions,",
+        f"                {base.field_detections_on_trade_sessions} of them on the "
+        f"sessions his trades were evaluated at (A2's basis),",
+        f"                {_num(base.detections_per_surfaced_entry, 1)} detections "
+        f"per entry surfaced — the funnel's own going rate.",
+        "",
+        f"{'gate width':<22} added detections   recovered entries   per entry   "
+        "surfaced   per surfaced   vs going rate   board displacement   stale share of added",
+    ]
+    for m in sweep.variants[1:]:
+        inf = sweep.inflation[m.variant.name]
+        going = base.detections_per_surfaced_entry
+        marginal = inf.per_surfaced_entry
+        ratio = (
+            f"{marginal / going:.2f}x" if marginal is not None and going else "—"
+        )
+        lines.append(
+            f"{m.variant.name:<22} {inf.added_detections:16d}   {inf.recovered_entries:17d}   "
+            f"{_num(inf.per_recovered_entry, 1):>9}   {inf.surfaced_entries:8d}   "
+            f"{_num(inf.per_surfaced_entry, 1):>12}   {ratio:>13}   {m.board_displacement:18d}   "
+            f"{_pct(m.added_stale_share):>20}"
+        )
+    lines.append("")
+    lines.append(
+        "Field inflation is a volume measure, not a false-positive rate: the added "
+        "names carry\nno verdict (findings §7, §9). `vs going rate` divides the "
+        "width's marginal cost per\nsurfaced entry by the baseline's average one — "
+        "a widening at 1.0x is buying entries at\nexactly the price the funnel "
+        "already pays. `stale share of added` is the share of the\ndetections the "
+        "width adds that sit below the field median on every lookback the\nas-measured "
+        "gate unions: §4.5's worry, measured against the field rather than against his "
+        "trades.\nBoard displacement counts board places taken by names the wider "
+        "gate admits, summed\nover the measured sessions."
+    )
+    return "\n".join(lines)
+
+
+def format_report(sweep: GateSweep) -> str:
+    """The #149 report: composition first, then the per-width price."""
+    window = (
+        f"{sweep.first_session} to {sweep.last_session}"
+        if sweep.first_session
+        else "no sessions"
+    )
+    return "\n".join(
+        [
+            f"detection-gate width sweep ({sweep.market}) — #149",
+            f"sessions: {sweep.sessions} measured ({window})",
+            f"replayable trades: {sweep.replayable_trades}   "
+            f"blind-spot coverage: {sweep.blind_spot_count} tickers missing from the field",
+            f"detection recall (gate-invariant): {_recall_line(sweep.detection_recall)}",
+            "",
+            "== composition of the recovered misses (the headline) ==",
+            _format_composition(sweep.composition),
+            "",
+            "== where the recovered trades sat on the gate's own lookbacks ==",
+            _format_profile(sweep.profile),
+            "",
+            "== outcome quality of the recovered trades ==",
+            _format_outcomes(sweep.outcomes),
+            "",
+            "== the gate widths ==",
+            _format_variants(sweep),
+            "",
+            "== field inflation, priced as #141 prices the cluster gate ==",
+            _format_inflation(sweep),
+            "",
+            "Scope: US 2019–2022, a once-in-a-decade momentum regime. No figure here "
+            "is an IDX\nexpectation.",
+        ]
+    )
+
+
+# -- machine-readable results -------------------------------------------------
+
+
+def _outcome_dict(o: OutcomeQuality) -> dict:
+    return {
+        "label": o.label,
+        "n": o.n,
+        "n_with_r": o.n_with_r,
+        "mean_r": o.mean_r,
+        "median_r": o.median_r,
+        "trimmed_mean_r": o.trimmed_mean_r,
+        "win_rate": o.win_rate,
+        "big_win_rate": o.big_win_rate,
+        "top_trade_r_share": o.top_trade_r_share,
+        "mean_mfe_pct": o.mean_mfe,
+    }
+
+
+def _recall_dict(r: StageRecall) -> dict:
+    return {
+        "passed": r.passed,
+        "total": r.total,
+        "recall": r.recall,
+        "passed_ex_continuation": r.passed_ex_continuation,
+        "total_ex_continuation": r.total_ex_continuation,
+        "recall_ex_continuation": r.recall_ex_continuation,
+    }
+
+
+def _inflation_dict(inflation: Inflation | None) -> dict | None:
+    """One width's cost, or ``None`` for the baseline, which adds nothing to itself."""
+    if inflation is None:
+        return None
+    return {
+        "added_detections": inflation.added_detections,
+        "recovered_entries": inflation.recovered_entries,
+        "surfaced_entries": inflation.surfaced_entries,
+        "added_detections_per_recovered_entry": inflation.per_recovered_entry,
+        "added_detections_per_surfaced_entry": inflation.per_surfaced_entry,
+    }
+
+
+def sweep_to_dict(sweep: GateSweep) -> dict:
+    """A JSON-serialisable dict of every figure the sweep reports."""
+    comp = sweep.composition
+    return {
+        "market": sweep.market,
+        "sessions": sweep.sessions,
+        "first_session": sweep.first_session.isoformat() if sweep.first_session else None,
+        "last_session": sweep.last_session.isoformat() if sweep.last_session else None,
+        "replayable_trades": sweep.replayable_trades,
+        "blind_spot_count": sweep.blind_spot_count,
+        "detection_recall": _recall_dict(sweep.detection_recall),
+        "composition": {
+            "total": comp.total,
+            "stale_only_12m": comp.stale_only,
+            "burst_only_1w": comp.burst_only,
+            "both_excluded": comp.both_excluded,
+            "also_gated": comp.also_gated,
+            "excluded_only": comp.excluded_only,
+            "continuation": comp.continuation,
+        },
+        "recovered_profile": [
+            {
+                "label": g.label,
+                "n": g.n,
+                "dead_on_gated_lookbacks": g.dead_on_gated,
+                "within_reach_of_the_gate": g.within_reach,
+                "median_percentiles": dict(g.median_percentiles),
+            }
+            for g in sweep.profile
+        ],
+        "outcomes": [_outcome_dict(o) for o in sweep.outcomes],
+        "variants": [
+            {
+                "name": m.variant.name,
+                "lookbacks": list(m.variant.lookbacks),
+                "added_lookbacks": list(m.variant.added),
+                "gate_population_share": m.gate_population_share,
+                "decile_recall": _recall_dict(m.decile_recall),
+                "surfaced_recall": _recall_dict(m.surfaced_recall),
+                "field_detections": m.field_detections,
+                "field_detections_on_trade_sessions": m.field_detections_on_trade_sessions,
+                "detections_per_surfaced_entry": m.detections_per_surfaced_entry,
+                "added_detections_total": m.added_detections_total,
+                "added_detections_stale": m.added_detections_stale,
+                "added_stale_share": m.added_stale_share,
+                "board_displacement": m.board_displacement,
+                "picks_in_field": m.picks_in_field,
+                "picks_on_board": m.picks_on_board,
+                "inflation": _inflation_dict(sweep.inflation.get(m.variant.name)),
+            }
+            for m in sweep.variants
+        ],
+        "precision_note": (
+            "Field inflation is a volume measure, never a false-positive rate: the "
+            "reference set records no setup he declined, so there is no control group "
+            "(findings §7, §9)."
+        ),
+    }
+
+
+# -- the runnable measurement -------------------------------------------------
+
+
+def run_gate_sweep(
+    store: Store,
+    market: str = REPLAY_MARKET,
+    *,
+    trades: list[ExecutedTrade],
+    blind_spot_tickers: Iterable[str] = (),
+    burn_in: int = BURN_IN_SESSIONS,
+    sessions: Sequence[date] | None = None,
+    variants: Sequence[GateVariant] = GATE_VARIANTS,
+    progress: Callable[[int, int, date], None] | None = None,
+) -> GateSweep:
+    """Run the whole #149 measurement over one read-only pass of the replay store.
+
+    Reconstructs the forward pass (universe from the store, ranks in memory),
+    detects once over the union of every swept gate, walks the funnel over the same
+    pass so the decile verdicts and the sweep read the identical field, and prices
+    each width against the as-measured one.
+    """
+    store = CachingStore.wrap(store)
+    classified = classify(trades, store, market=market)
+    calendar = store.sessions(market)
+    measured = list(sessions) if sessions is not None else calendar[burn_in:]
+    union = tuple(lb for lb in LOOKBACKS if any(lb in v.lookbacks for v in variants))
+
+    swept = build_sweep_sessions(
+        store, market, measured, lookbacks=union, progress=progress
+    )
+    blind_spots = set(blind_spot_tickers)
+    chain = session_fields(swept, len(blind_spots))
+    funnel = build_funnel_report(
+        classified, calendar, chain, store, market, blind_spot_tickers=blind_spots
+    )
+    by_identity = {(t.ticker, t.entry_date): t for t in trades}
+    return sweep_gates(
+        swept,
+        funnel.rows,
+        by_identity,
+        market=market,
+        variants=variants,
+        blind_spot_count=len(blind_spots),
+    )
+
+
+def _sweep_progress(stream) -> Callable[[int, int, date], None]:
+    """The study's throttled progress printer, bound to this sweep's one phase."""
+    report = progress_printer(stream)
+    return lambda i, total, session: report("sweep", i, total, session)
+
+
+def write_report(sweep: GateSweep, path: str | Path) -> None:
+    """Write the human-readable sweep report to ``path``."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(format_report(sweep) + "\n")
+
+
+def write_results(sweep: GateSweep, path: str | Path) -> None:
+    """Write the machine-readable sweep results to ``path`` (stable, 2-space JSON)."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(sweep_to_dict(sweep), indent=2) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Price the detection gate's width against the replay store (#149).
+
+        python -m replay.gate_sweep --store data/replay.duckdb \\
+            --out-report references/detection_gate_sweep.txt \\
+            --out-json references/detection_gate_sweep.json
+
+    Read-only: the pass reconstructs universe membership from the rows the replay
+    store already holds and recomputes ranks in memory, writing nothing back.
+    Progress and an ETA print to stderr while it runs.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the replay store")
+    parser.add_argument("--reference", default=str(DEFAULT_REFERENCE_JSON),
+                        help="path to the executed-trade reference JSON")
+    parser.add_argument("--blind-spots", default=str(DEFAULT_BLIND_SPOT_OUT),
+                        help="path to the committed blind-spot ticker list")
+    parser.add_argument("--market", default=REPLAY_MARKET)
+    parser.add_argument("--burn-in", type=int, default=BURN_IN_SESSIONS,
+                        help="burn-in sessions before the first measured session")
+    parser.add_argument("--out-report", default="references/detection_gate_sweep.txt",
+                        help="where to write the human-readable report")
+    parser.add_argument("--out-json", default="references/detection_gate_sweep.json",
+                        help="where to write the machine-readable results")
+    args = parser.parse_args(argv)
+
+    trades = load_trades(args.reference)
+    blind_spots = json.loads(Path(args.blind_spots).read_text())
+    store = Store.open(args.store)
+    try:
+        sweep = run_gate_sweep(
+            store,
+            args.market,
+            trades=trades,
+            blind_spot_tickers=blind_spots,
+            burn_in=args.burn_in,
+            progress=_sweep_progress(sys.stderr),
+        )
+    finally:
+        store.close()
+
+    write_report(sweep, args.out_report)
+    write_results(sweep, args.out_json)
+    print(format_report(sweep))
+    print(f"\nwrote {args.out_report}")
+    print(f"wrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/replay/study.py
+++ b/backend/replay/study.py
@@ -23,7 +23,7 @@ four (issue #131).
 killed at 60 minutes precisely because it had printed nothing — a silent long run
 is indistinguishable from a hung one. So the chain and the detection pass both call
 back per session, and the CLI prints a throttled line with a running count and an
-ETA (:func:`_progress_printer`). A failure surfaces as an exception rather than a
+ETA (:func:`progress_printer`). A failure surfaces as an exception rather than a
 hang.
 
 **Two outputs.** The human-readable reports (:func:`format_study`) are the four
@@ -447,7 +447,7 @@ def _fmt_eta(seconds: float) -> str:
     return f"{m}m{s:02d}s"
 
 
-def _progress_printer(stream: TextIO, *, every_seconds: float = 5.0) -> Progress:
+def progress_printer(stream: TextIO, *, every_seconds: float = 5.0) -> Progress:
     """A throttled progress callback that prints a count and an ETA to ``stream``.
 
     Prints at most once every ``every_seconds`` per phase (and always the final
@@ -519,7 +519,7 @@ def main(argv: list[str] | None = None) -> int:
             args.market,
             trades=trades,
             burn_in=args.burn_in,
-            progress=_progress_printer(sys.stderr),
+            progress=progress_printer(sys.stderr),
         )
     finally:
         store.close()

--- a/backend/screener/detection.py
+++ b/backend/screener/detection.py
@@ -32,9 +32,11 @@ Gates (a name is a detection iff all hold):
   that is *graded* by the rubric, and only a name genuinely in motion is rejected
   here (ADR 0004).
 - **Catch-up** — price is back at the 10/20 MA (step 2).
-- **Decile** — top decile in **any of 1m/3m/6m**, off the rank table
-  (:func:`detection_gate`). 1w is a momentum burst, not §3.1's big prior move;
-  12m is stale enough that a name that topped out months ago still carries it.
+- **Decile** — top decile in **any of 1m/3m/6m/12m**, off the rank table
+  (:func:`detection_gate`). Only ``1w`` is excluded: a name top-decile in the last
+  week alone is a momentum burst, not §3.1's big prior move. ``12m`` was excluded
+  on a staleness argument until #149 measured it and found the staleness did not
+  occur (ADR 0003, amendment).
 
 ``line_ok`` is **not** a gate — it becomes a sort tiebreak downstream. A name
 failing it is still emitted as a detection (spec §4.5).
@@ -57,6 +59,7 @@ from bisect import bisect_right
 from dataclasses import dataclass
 from datetime import date
 from statistics import median
+from typing import Sequence
 
 from .bars import Bar
 from .indicators import adr as _adr
@@ -154,8 +157,20 @@ DRYUP_LOOKBACK = 50
 SMA_SUPPORT = 20
 RISING_LAG = 5
 
-# The decile gate reads only 3 of the 5 ranking windows (spec §4.5 gates).
-DETECTION_LOOKBACKS = ("1m", "3m", "6m")
+# The decile gate reads 4 of the 5 ranking windows (spec §4.5 gates, ADR 0003 as
+# amended by #149). `1w` is the one exclusion that survived measurement: a name
+# top-decile only in `1w` is a momentum burst, not §3.1's big prior move, and the
+# sweep found 35.0% of the field it adds sits below the field median on every other
+# gated window — the highest stale share of any width, bought at 4.63x the funnel's
+# own cost per entry surfaced, for 22 of Kullamägi's entries that won 4.5% of the
+# time and never once reached 3R.
+#
+# `12m` was excluded on the same reasoning and did not survive it. It was assumed to
+# admit names that topped out months ago and have done nothing since; measured, 1 of
+# the 49 entries it recovers is dead on 1m/3m/6m and the group's median 6m percentile
+# is 0.798 — names sitting just under the cut, not stale ones. See
+# `docs/adr/0003-the-decile-gate.md` (amendment) and `replay.gate_sweep`.
+DETECTION_LOOKBACKS = ("1m", "3m", "6m", "12m")
 
 # Stamped on every detection row; bump when the detector's output changes so
 # rows from different logic are never silently compared (spec §7.2 / A1).
@@ -164,7 +179,16 @@ DETECTION_LOOKBACKS = ("1m", "3m", "6m")
 # v1 session's — the funnel's denominators, the detected-count anchor and every
 # field-derived share move with it. That is exactly the comparison this stamp
 # exists to stop happening silently.
-DETECTOR_VERSION = 2
+# v3 (#149): DETECTION_LOOKBACKS admitted `12m`, so a v3 session's rows are again
+# drawn from a different population — a wider one. Every *row* is byte-identical to
+# what v2 would have emitted for the same name: the gate is applied by
+# :func:`screener.pipeline.rebuild_detections`, outside :func:`detect`, and no
+# geometry moved. But the stamp is a claim about the **population**, not about one
+# row's fields — that is the reasoning v2's own note above sets down — and this
+# change moves the population by 2.6 points of universe. Comparing a v2 session's
+# field size, or any share derived from it, against a v3 session's is the silent
+# error this exists to prevent.
+DETECTOR_VERSION = 3
 
 
 @dataclass(frozen=True)
@@ -576,14 +600,32 @@ def detect(symbol: str, bars: list[Bar], as_of: date) -> Detection | None:
     )
 
 
-def detection_gate(rows: list[Rank]) -> set[str]:
-    """Names top-decile in **any of 1m/3m/6m** — the detection precondition.
+def detection_gate(
+    rows: list[Rank], *, lookbacks: Sequence[str] = DETECTION_LOOKBACKS
+) -> set[str]:
+    """Names top-decile in **any of 1m/3m/6m/12m** — the detection precondition.
 
-    A subset of the general union gate: 1w (a momentum burst) and 12m (stale) are
-    excluded, so a name that topped out months ago no longer qualifies on staleness
-    alone (spec §4.5 gates)."""
+    A subset of the general union gate: ``1w`` is excluded, so a name that has only
+    run for a week does not qualify on a momentum burst alone (spec §4.5 gates).
+
+    ``12m`` sat in that exclusion too, on the reasoning that a name topping out
+    months ago would qualify on staleness alone. #149 measured that population
+    rather than assuming it: of the 49 executed trades ``12m`` recovers, **one** is
+    below the field median on every other gated window, and the group's median 6m
+    percentile is 0.798 — a name still near the cut, which is what a base looks
+    like. Only 14.1% of the field ``12m`` adds is stale by the same test, against
+    35.0% for ``1w``. The window that reads as stale in prose was the less stale of
+    the two in measurement, so it was admitted and ``1w`` was not
+    (``docs/adr/0003-the-decile-gate.md``, amendment; :mod:`replay.gate_sweep`).
+
+    ``lookbacks`` defaults to :data:`DETECTION_LOOKBACKS` — the live gate, and the
+    only set the app ever runs. It is a parameter so a study can *price* an
+    alternative width (:mod:`replay.gate_sweep`, #149) by handing one in, rather
+    than mutating the module constant for the length of a measurement. Nothing in
+    :mod:`screener` passes it."""
+    wanted = set(lookbacks)
     return {
         r.symbol
         for r in rows
-        if r.lookback in DETECTION_LOOKBACKS and r.percentile >= TOP_DECILE
+        if r.lookback in wanted and r.percentile >= TOP_DECILE
     }

--- a/backend/screener/pipeline.py
+++ b/backend/screener/pipeline.py
@@ -221,7 +221,7 @@ def rebuild_detections(
 
     Detection runs against **every universe member every night**, not only recent
     movers (spec §4.5): the loop visits each member and the **decile gate** —
-    top decile in any of 1m/3m/6m, off the rank table — decides eligibility, not
+    top decile in any of 1m/3m/6m/12m, off the rank table — decides eligibility, not
     a "did it move today" pre-filter. Each gated member is handed its clean bars
     and detected; the cluster and catch-up gates live inside :func:`detect`.
 

--- a/backend/tests/test_detection.py
+++ b/backend/tests/test_detection.py
@@ -19,6 +19,7 @@ from datetime import date, timedelta
 
 from screener.bars import Bar
 from screener.detection import (
+    DETECTION_LOOKBACKS,
     DETECTOR_VERSION,
     K_MAX,
     K_MIN,
@@ -305,17 +306,21 @@ def test_dryup_is_base_volume_over_the_preceding_fifty_bars():
     assert abs(_dryup(vol, 50, 59) - 0.4) < 1e-9
 
 
-# -- the decile gate reads only 1m / 3m / 6m ----------------------------------
+# -- the decile gate excludes 1w, and only 1w ---------------------------------
+#
+# `12m` sat in the exclusion too until #149 measured what it actually admits and
+# found the staleness the exclusion assumed did not occur; `1w` measured as the
+# genuine momentum-burst window and stayed out (ADR 0003, amendment).
 
 
-def test_detection_gate_reads_only_1m_3m_6m():
+def test_detection_gate_excludes_1w_and_nothing_else():
     rows = [
         Rank("BURST", "1w", percentile=0.99, raw_return=0.5),   # 1w excluded
-        Rank("STALE", "12m", percentile=0.99, raw_return=2.0),  # 12m excluded
+        Rank("LONG", "12m", percentile=0.99, raw_return=2.0),   # 12m counts (#149)
         Rank("REAL", "3m", percentile=0.95, raw_return=0.8),    # counts
         Rank("MID", "3m", percentile=0.50, raw_return=0.1),
     ]
-    assert detection_gate(rows) == {"REAL"}
+    assert detection_gate(rows) == {"REAL", "LONG"}
 
 
 def test_detection_gate_is_inclusive_at_the_threshold():
@@ -324,3 +329,41 @@ def test_detection_gate_is_inclusive_at_the_threshold():
         Rank("BELOW", "6m", percentile=TOP_DECILE - 1e-9, raw_return=0.2),
     ]
     assert detection_gate(rows) == {"AT"}
+
+
+# -- the gate's lookback set is injectable for measurement (#149) --------------
+#
+# Widening the gate 3->5 has to be *priced* before it is adopted, and pricing it
+# means running the whole replay under a lookback set the live app does not use.
+# The set is therefore a defaulted argument rather than a read of the module
+# constant, so a sweep never has to mutate the live value to measure an
+# alternative to it (#149).
+
+
+def test_detection_gate_defaults_to_the_module_lookbacks():
+    """Called with no lookbacks, the gate is exactly DETECTION_LOOKBACKS — the
+    live behaviour, unchanged."""
+    rows = [
+        Rank("BURST", "1w", percentile=0.99, raw_return=0.5),
+        Rank("REAL", "3m", percentile=0.95, raw_return=0.8),
+    ]
+    assert detection_gate(rows) == detection_gate(rows, lookbacks=DETECTION_LOOKBACKS)
+    assert detection_gate(rows) == {"REAL"}
+    assert "1w" not in DETECTION_LOOKBACKS
+
+
+def test_detection_gate_takes_an_injected_lookback_set():
+    """A caller measuring an alternative gate hands the lookbacks in; the live
+    constant is untouched by the call."""
+    rows = [
+        Rank("BURST", "1w", percentile=0.99, raw_return=0.5),
+        Rank("STALE", "12m", percentile=0.99, raw_return=2.0),
+        Rank("REAL", "3m", percentile=0.95, raw_return=0.8),
+    ]
+    widened = ("1m", "3m", "6m", "1w", "12m")
+    assert detection_gate(rows, lookbacks=widened) == {"BURST", "STALE", "REAL"}
+    assert detection_gate(rows, lookbacks=("12m",)) == {"STALE"}
+    # Narrower than the live gate, too — the sweep baselines against the width the
+    # gate ran at before #149 moved it.
+    assert detection_gate(rows, lookbacks=("1m", "3m", "6m")) == {"REAL"}
+    assert DETECTION_LOOKBACKS == ("1m", "3m", "6m", "12m")

--- a/backend/tests/test_detection_pipeline.py
+++ b/backend/tests/test_detection_pipeline.py
@@ -2,7 +2,7 @@
 
 ``rebuild_detections`` reads the session's published universe, the rank table and
 each member's clean bars off the store, applies the decile gate (top decile in
-any of 1m/3m/6m), detects each gated member, and appends the detection rows.
+any of 1m/3m/6m/12m), detects each gated member, and appends the detection rows.
 
 Detection runs against **every universe member every night**, not only recent
 movers: the gate decides eligibility, and a gated member that is not sitting in a
@@ -85,7 +85,7 @@ def test_rebuild_detections_emits_only_gated_members_with_a_base(store: Store):
 
 
 def test_an_ungated_universe_detects_nothing(store: Store):
-    # Every member sits in a base, but none is top decile in 1m/3m/6m — so the
+    # Every member sits in a base, but none is top decile in any gated window — so the
     # decile gate, read off the rank table, admits nobody and nothing is emitted.
     store.append_bars("IDX", "AAA", _bars(_base_series()))
     store.append_bars("IDX", "BBB", _bars(_base_series()))

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -100,7 +100,8 @@ from replay.contrast import (
 from replay.caching_store import CachingStore
 from replay.store import WINDOW_END, WINDOW_START, build_replay_store
 from screener.bars import Bar
-from screener.detection import Detection, detect
+from screener.detection import Detection, detect, detection_gate
+from screener.ranks import Rank
 from screener.store import Store
 
 
@@ -936,11 +937,11 @@ def test_funnel_decile_output_carries_blind_spot_coverage(store: Store):
 # -- #133: the funnel row carries the per-lookback decile detail ------------
 #
 # `FunnelRow` used to throw away the margin of a decile miss: the row knew only
-# the flattened three-union verdict, so whether he ranked 11th percentile or 40th,
+# the flattened gate verdict, so whether he ranked 11th percentile or 40th,
 # and which lookback he was strong in, were both discarded at the gate. #133 needs
 # those, so the row now carries the per-lookback eval-session percentiles and the
 # per-lookback top-decile verdicts, plus the five-union verdict — the second gate
-# the three-union is compared against. The verdicts still go through the app's own
+# the detection gate is compared against. The verdicts still go through the app's own
 # gate functions (`detection_gate`, `decile_gate`), never a second hand-rolled path.
 
 
@@ -969,7 +970,7 @@ def test_funnel_row_carries_per_lookback_percentiles_and_verdicts(store: Store):
     assert set(lag.decile_verdicts) == set(lag.eval_percentiles)
     assert all(0.0 <= p <= 1.0 for p in lag.eval_percentiles.values())
     # LAG is dead across every lookback -> no lookback is a top-decile verdict, and
-    # it fails both the three-union and the five-union gate.
+    # it fails both the detection gate and the five-union gate.
     assert not any(lag.decile_verdicts.values())
     assert lag.decile_pass is False
     assert lag.decile_pass_five is False
@@ -982,10 +983,10 @@ def test_funnel_row_carries_per_lookback_percentiles_and_verdicts(store: Store):
 
 
 def test_funnel_decile_verdicts_go_through_the_app_gate_functions(store: Store):
-    """The row's three-union verdict is the app's ``detection_gate`` and its
-    five-union verdict is the app's ``decile_gate`` — never a second hand-rolled
-    path (the trap #133 calls out). A five-union pass is a superset of the
-    three-union pass, so a three-union pass implies a five-union pass."""
+    """The row's gate verdict is the app's ``detection_gate`` and its five-union
+    verdict is the app's ``decile_gate`` — never a second hand-rolled path (the trap
+    #133 calls out). The five-union gate is a superset of the detection gate at any
+    width, so a detection-gate pass implies a five-union pass."""
     dates = _daily(date(2020, 1, 1), 40)
     store.append_bars("US", "HI", _bars_from_hlc(dates, _rising_hlc(40)))
     store.append_bars("US", "LAG", _bars_from_hlc(dates, _flat_hlc(40)))
@@ -1003,7 +1004,7 @@ def test_funnel_decile_verdicts_go_through_the_app_gate_functions(store: Store):
 def test_funnel_report_decomposes_the_decile_miss(store: Store):
     """The report decomposes every replayable trade's decile miss into three
     mutually exclusive, exhaustive buckets — coverage gap (absent from the field),
-    recovered-by-5 (fails the three-union gate but clears the five-union one), and
+    recovered-by-5 (fails the detection gate but clears the five-union one), and
     outside-any-union (fails even the five-union) — across all replayable trades
     (#133)."""
     from replay.funnel import DecileDecomposition, decompose_decile_misses
@@ -2241,3 +2242,417 @@ def test_field_detects_on_a_session_whose_stored_ranks_were_pruned(store: Store)
     (field,) = build_field_sessions(store, "US", chain)
 
     assert [d.symbol for d in field.detections] == ["BASE"]
+
+# -- #149: pricing the detection gate's width --------------------------------
+#
+# ADR 0003 leaves `DETECTION_LOOKBACKS = ("1m", "3m", "6m")` -> the five-lookback
+# set as its leading candidate and explicitly does not authorise the edit. The
+# widening re-admits the two lookbacks `detection_gate` excludes on purpose — `1w`
+# (a momentum burst) and `12m` (stale) — so what decides it is not the headline 75
+# but *which* lookback admits each of them. These tests pin the decomposition, the
+# volume price, and the two properties that keep the measurement honest: every gate
+# goes through the app's own `detection_gate`, and the live constant is never
+# mutated to measure an alternative to it.
+
+
+def _with_outcome(record: dict, *, r: float, mfe: float) -> dict:
+    """``record`` with its primary exit's R and MFE set — the two figures the
+    outcome-quality group averages."""
+    return {**record, "rr10sma": r, "mfe10smaPct": mfe}
+
+
+def _funnel_row(
+    ticker: str,
+    *,
+    session: date,
+    present: bool = True,
+    pass3: bool = False,
+    pass5: bool = True,
+    detection: bool = True,
+    continuation: bool = False,
+    entry: date | None = None,
+):
+    from replay.funnel import FunnelRow
+
+    return FunnelRow(
+        ticker=ticker,
+        entry_date=entry or (session + timedelta(days=1)),
+        eval_session=session,
+        liquidity_pass=True,
+        decile_present=present,
+        decile_pass=pass3,
+        decile_pass_five=pass5,
+        eval_percentiles={},
+        decile_verdicts={},
+        detection_pass=detection,
+        failed_condition=None,
+        first_failing_stage=None if pass3 and detection else STAGE_DECILE,
+        entry_session_break=False,
+        continuation=continuation,
+        median_dollar_volume=50_000_000.0,
+        range_3bar_adr=None,
+        sessions_since_prior_entry=None,
+    )
+
+
+def test_a_variants_gate_is_the_apps_gate_under_that_width():
+    """A variant's gate is the union of its lookbacks' top deciles, and that union
+    is *exactly* what the app's own `detection_gate` returns for the same width —
+    asserted rather than assumed, so the sweep can never drift into a second
+    definition of "top decile" (#149)."""
+    from replay.gate_sweep import GATE_VARIANTS, gate_membership, variant_gate
+
+    rows = [
+        Rank("BURST", "1w", percentile=0.99, raw_return=0.5),
+        Rank("STALE", "12m", percentile=0.97, raw_return=2.0),
+        Rank("NOW", "3m", percentile=0.95, raw_return=0.8),
+        Rank("MID", "6m", percentile=0.40, raw_return=0.1),
+    ]
+    membership = gate_membership(rows)
+
+    for variant in GATE_VARIANTS:
+        assert variant_gate(membership, variant) == detection_gate(
+            rows, lookbacks=variant.lookbacks
+        )
+    # …and the widths are what they claim: the live one admits neither excluded name.
+    assert variant_gate(membership, GATE_VARIANTS[0]) == {"NOW"}
+    assert variant_gate(membership, GATE_VARIANTS[-1]) == {"NOW", "BURST", "STALE"}
+
+
+def test_recovered_misses_are_split_by_which_lookback_admits_them():
+    """The ticket's headline: the trades a 3->5 widening recovers, decomposed into
+    `12m`-only (the stale qualifier the §4.5 exclusion exists to prevent), `1w`-only
+    (the momentum burst), both, and also-admitted-by-a-gated-lookback (#149)."""
+    from replay.gate_sweep import decompose_recovered
+
+    session = date(2021, 3, 1)
+    rows = [
+        _funnel_row("STALE", session=session),
+        _funnel_row("STALE2", session=session, continuation=True),
+        _funnel_row("BURST", session=session),
+        _funnel_row("BOTH", session=session),
+        # Not recovered: already clears the live gate, so not a miss at all.
+        _funnel_row("PASSER", session=session, pass3=True),
+        # Not recovered: absent from the field (a coverage gap), and outside every union.
+        _funnel_row("GONE", session=session, present=False, pass5=False),
+        _funnel_row("MISS", session=session, pass5=False),
+    ]
+    membership = {
+        session: {
+            "1m": set(), "3m": set(), "6m": {"PASSER"},
+            "1w": {"BURST", "BOTH"},
+            "12m": {"STALE", "STALE2", "BOTH"},
+        }
+    }
+
+    comp = decompose_recovered(rows, membership)
+
+    assert comp.total == 4
+    assert comp.stale_only == 2
+    assert comp.burst_only == 1
+    assert comp.both_excluded == 1
+    assert comp.also_gated == 0
+    assert comp.continuation == 1
+    # The four buckets partition the recovered trades, and none of them is reached
+    # through a lookback the gate already unions.
+    assert (
+        comp.stale_only + comp.burst_only + comp.both_excluded + comp.also_gated
+        == comp.total
+    )
+    assert comp.excluded_only == comp.total
+
+
+def test_a_trade_the_gate_already_admits_is_not_a_recovered_trade():
+    """`also_existing` is zero *by construction*: a name top-decile in a lookback the
+    gate already unions clears the gate, so it was never a miss for a widening to
+    recover. The bucket is carried and reported anyway, so "every recovered trade
+    arrives through an excluded lookback" is visible in the output rather than
+    assumed by the reader (#149)."""
+    from replay.gate_sweep import decompose_recovered, recovered_rows
+
+    session = date(2021, 3, 1)
+    rows = [_funnel_row("ODD", session=session)]
+    membership = {session: {"3m": {"ODD"}, "12m": {"ODD"}}}
+
+    assert recovered_rows(rows, membership) == []
+    comp = decompose_recovered(rows, membership)
+    assert comp.total == 0
+    assert comp.also_gated == 0
+
+
+def test_outcome_quality_reports_the_recovered_groups_realised_r():
+    """A recall gain is reported against the *quality* of what it recovers: mean and
+    median R and the win rate, over the trades behind the rows. A row whose trade
+    carries no outcome stays in ``n`` and out of the averages, so the group is never
+    quietly shrunk to the rows that happen to have a result (#149)."""
+    from replay.gate_sweep import outcome_quality
+
+    session = date(2021, 3, 1)
+    rows = [
+        _funnel_row("WIN", session=session, entry=date(2021, 3, 2)),
+        _funnel_row("LOSS", session=session, entry=date(2021, 3, 2)),
+        _funnel_row("NOOUT", session=session, entry=date(2021, 3, 2)),
+    ]
+    trades = {
+        (t.ticker, t.entry_date): t
+        for t in parse_trades(
+            [
+                _with_outcome(_trade_record("WIN", "2021-03-02"), r=4.0, mfe=30.0),
+                _with_outcome(_trade_record("LOSS", "2021-03-02"), r=-1.0, mfe=2.0),
+            ]
+        )
+    }
+
+    quality = outcome_quality("recovered", rows, trades)
+
+    assert quality.n == 3          # every row in the group
+    assert quality.n_with_r == 2   # only the two carrying an outcome
+    assert quality.mean_r == 1.5
+    assert quality.median_r == 1.5
+    assert quality.win_rate == 0.5
+    assert quality.mean_mfe == 16.0
+    # R is fat-tailed, so the mean is carried beside figures that survive one
+    # outlier: the top 5% (here, one of two) is trimmed off before re-meaning, the
+    # 3R tail is counted, and the best trade's share of the group's R is stated.
+    assert quality.trimmed_mean_r == -1.0
+    assert quality.big_win_rate == 0.5
+    assert quality.top_trade_r_share == pytest.approx(4.0 / 3.0)
+
+
+def _sweep_session(session: date, ranks: list[Rank], symbols: list[str]):
+    """One prepared sweep session: a hand-authored rank table and one detection per
+    name in ``symbols``, all identical so star order falls back to the ticker."""
+    from replay.gate_sweep import SweepSession, gate_membership
+
+    return SweepSession(
+        session=session,
+        members=sorted({r.symbol for r in ranks}),
+        ranks=ranks,
+        membership=gate_membership(ranks),
+        detections=[
+            dataclasses.replace(_det(symbol, cluster_k=5), session=session)
+            for symbol in symbols
+        ],
+    )
+
+
+def _widening_pass():
+    """Two sessions where each excluded lookback admits exactly one extra name:
+    NOW clears the live gate, STALE is top-decile only in 12m, BURST only in 1w,
+    and DEAD is top-decile nowhere. All but DEAD sit in a base."""
+    sessions = [date(2021, 3, 1), date(2021, 3, 2)]
+    out = []
+    for session in sessions:
+        ranks = [
+            Rank("NOW", "3m", percentile=0.95, raw_return=0.8),
+            Rank("STALE", "12m", percentile=0.97, raw_return=2.0),
+            Rank("BURST", "1w", percentile=0.99, raw_return=0.5),
+            Rank("DEAD", "3m", percentile=0.10, raw_return=0.0),
+        ]
+        out.append(_sweep_session(session, ranks, ["NOW", "STALE", "BURST"]))
+    return out
+
+
+def test_the_widened_gate_is_priced_in_added_detections_per_recovered_entry():
+    """#141's basis, mirrored for the decile gate: the widening's price is the extra
+    field volume it emits per real entry it recovers. Precision is unmeasurable, so
+    this is a *volume* ratio and never a false-positive rate (#149)."""
+    from replay.gate_sweep import GATE_VARIANTS, sweep_gates
+
+    swept = _widening_pass()
+    rows = [
+        _funnel_row("NOW", session=swept[0].session, pass3=True),
+        _funnel_row("STALE", session=swept[0].session),
+    ]
+
+    sweep = sweep_gates(swept, rows, {}, board_size=2)
+
+    base, five = sweep.variants[0], sweep.variants[-1]
+    # The live gate admits one name a session; the five-lookback union admits three.
+    assert base.field_detections == 2
+    assert five.field_detections == 6
+    # It recovers exactly the one trade admitted by 12m…
+    assert base.decile_recall.passed == 1
+    assert five.decile_recall.passed == 2
+    # …so the price is four extra detections for one recovered entry.
+    inflation = sweep.inflation[five.variant.name]
+    assert inflation.added_detections == 4
+    assert inflation.recovered_entries == 1
+    assert inflation.per_recovered_entry == 4.0
+    # The narrower widenings are priced separately, each on its own evidence.
+    assert {v.variant.name for v in sweep.variants} == {
+        v.name for v in GATE_VARIANTS
+    }
+    assert sweep.inflation["+12m (stale)"].recovered_entries == 1
+    assert sweep.inflation["+1w (burst)"].recovered_entries == 0
+
+
+def test_the_widened_gate_displaces_names_from_the_board():
+    """Board displacement: with a two-name board, the names a wider gate admits take
+    places the live gate's names held. Counted over every measured session (#149)."""
+    from replay.gate_sweep import sweep_gates
+
+    swept = _widening_pass()
+    sweep = sweep_gates(swept, [], {}, board_size=2)
+
+    base, five = sweep.variants[0], sweep.variants[-1]
+    # The live gate can only fill one of the two board places (one name is gated).
+    assert base.board_displacement == 0
+    # Under the five-union gate the board fills to two, and BURST — admitted only by
+    # 1w — takes the second place on both sessions.
+    assert five.board_displacement == 2
+
+
+def test_his_picks_in_field_and_top_thirty_counts_move_with_the_gate():
+    """What the widening does to his own entries' placement: a pick admitted only by
+    an excluded lookback appears in the field, and can reach the board (#149)."""
+    from replay.gate_sweep import sweep_gates
+
+    swept = _widening_pass()
+    rows = [_funnel_row("STALE", session=swept[0].session)]
+
+    sweep = sweep_gates(swept, rows, {}, board_size=3)
+
+    base, five = sweep.variants[0], sweep.variants[-1]
+    assert (base.picks_in_field, base.picks_on_board) == (0, 0)
+    assert (five.picks_in_field, five.picks_on_board) == (1, 1)
+
+
+def test_the_sweep_never_mutates_the_live_gate_width(store: Store):
+    """The measurement's first acceptance criterion: the gate's lookbacks are handed
+    in as a parameter, never assigned. Running the whole sweep leaves the live
+    constant exactly where it was (#149)."""
+    from screener import detection as detection_module
+    from replay.gate_sweep import sweep_gates
+
+    before = detection_module.DETECTION_LOOKBACKS
+    sweep_gates(_widening_pass(), [], {}, board_size=2)
+    assert detection_module.DETECTION_LOOKBACKS == before
+
+
+def test_the_sweep_baselines_against_the_width_it_measured_not_the_live_one():
+    """The sweep is the evidence that decided the live width, so its baseline is
+    pinned to the width the gate ran at when the question was asked. A baseline that
+    tracked `DETECTION_LOOKBACKS` would change the moment the verdict was adopted,
+    and the report could no longer be re-run to audit itself (#149)."""
+    from replay.gate_sweep import BASELINE_VARIANT, GATE_AS_MEASURED, GATE_VARIANTS
+
+    assert GATE_AS_MEASURED == ("1m", "3m", "6m")
+    assert BASELINE_VARIANT.lookbacks == GATE_AS_MEASURED
+    # Every swept width is the as-measured gate plus something, so `added` names
+    # exactly what that width re-admits.
+    for variant in GATE_VARIANTS:
+        assert set(GATE_AS_MEASURED) <= set(variant.lookbacks)
+        assert set(variant.added) == set(variant.lookbacks) - set(GATE_AS_MEASURED)
+
+
+def test_the_sweep_pass_reads_the_store_without_writing_to_it(store: Store):
+    """The pass reconstructs the forward chain from the universe rows the replay
+    store already holds and recomputes the ranks in memory — the chain's own reuse
+    path, with nothing written back. A measurement must not leave the store it
+    measured in a different state (#149)."""
+    from replay.gate_sweep import build_sweep_sessions
+
+    dates = _daily(date(2020, 1, 1), 40)
+    store.append_bars("US", "HI", _bars_from_hlc(dates, _rising_hlc(40)))
+    store.append_bars("US", "LAG", _bars_from_hlc(dates, _flat_hlc(40)))
+    chain = replay_chain(store, "US", burn_in=0)
+    sessions = [sf.session for sf in chain[-3:]]
+    counts_before = _row_counts(store)
+
+    swept = build_sweep_sessions(
+        store, "US", sessions, lookbacks=("1m", "3m", "6m", "1w", "12m")
+    )
+
+    assert [s.session for s in swept] == sessions
+    # The reconstructed pass is the chain's: the same members and the same ranks.
+    for prepared, sf in zip(swept, chain[-3:]):
+        assert prepared.members == sf.members
+        assert prepared.ranks == sf.ranks
+    assert _row_counts(store) == counts_before
+
+
+def _row_counts(store: Store) -> dict[str, int]:
+    """Row counts for every derived table — the store's state, before and after."""
+    tables = ("runs", "universe", "ranks", "detections")
+    return {
+        t: store._con.execute(f"SELECT count(*) FROM {t}").fetchone()[0]
+        for t in tables
+    }
+
+
+def test_the_recovered_groups_are_profiled_against_the_gates_own_lookbacks():
+    """"Admitted by 12m" is not the same claim as "topped out months ago and has
+    done nothing since" — and only the second is what the §4.5 exclusion was written
+    against. Each admitting-lookback group therefore carries where its trades sat on
+    the lookbacks the gate already unions: below the field median on all three (the
+    stale qualifier, counted) against within reach of the cut (#149)."""
+    from replay.gate_sweep import FIELD_MEDIAN, NEAR_DECILE, profile_recovered
+
+    session = date(2021, 3, 1)
+
+    def _with_percentiles(ticker, pcts):
+        return dataclasses.replace(
+            _funnel_row(ticker, session=session), eval_percentiles=pcts
+        )
+
+    rows = [
+        # Genuinely stale: top-decile on 12m, mid-pack or worse on every gated one.
+        _with_percentiles("STALE", {"1m": 0.20, "3m": 0.30, "6m": 0.45, "12m": 0.96}),
+        # Admitted by 12m, but 6m had it just under the cut — not a stale qualifier.
+        _with_percentiles("NEAR", {"1m": 0.50, "3m": 0.70, "6m": 0.88, "12m": 0.95}),
+        _with_percentiles("BURST", {"1w": 0.97, "1m": 0.10, "3m": 0.05, "6m": 0.10}),
+    ]
+    membership = {
+        session: {"12m": {"STALE", "NEAR"}, "1w": {"BURST"}}
+    }
+
+    groups = {g.label: g for g in profile_recovered(rows, membership)}
+
+    stale, burst = groups["12m only"], groups["1w only"]
+    assert (stale.n, stale.dead_on_gated, stale.within_reach) == (2, 1, 1)
+    assert (burst.n, burst.dead_on_gated, burst.within_reach) == (1, 1, 0)
+    # The medians are the group's own, per lookback, off the margins #133 recorded.
+    assert stale.median_percentiles["6m"] == 0.665
+    # The two cuts are what they say they are.
+    assert FIELD_MEDIAN == 0.50 and NEAR_DECILE == 0.80
+
+
+def test_the_added_field_is_measured_for_staleness_not_only_his_trades():
+    """§4.5's worry is about what the gate *admits*, not only about which of his
+    trades a widening recovers — a widening can leave the recovered entries looking
+    healthy while flooding the list with names that topped out long ago. So each
+    width reports the share of the detections it adds that sit below the field median
+    on every lookback the live gate unions (#149)."""
+    from replay.gate_sweep import GateVariant, sweep_gates
+
+    session = date(2021, 3, 1)
+    ranks = [
+        Rank("NOW", "3m", percentile=0.95, raw_return=0.8),
+        # Admitted by 12m and genuinely dead on the gated lookbacks.
+        Rank("STALE", "12m", percentile=0.97, raw_return=2.0),
+        Rank("STALE", "3m", percentile=0.20, raw_return=0.0),
+        # Admitted by 12m but still near the cut on 6m — not stale.
+        Rank("NEAR", "12m", percentile=0.96, raw_return=1.5),
+        Rank("NEAR", "6m", percentile=0.88, raw_return=0.9),
+    ]
+    swept = [_sweep_session(session, ranks, ["NOW", "STALE", "NEAR"])]
+
+    sweep = sweep_gates(
+        swept, [], {},
+        variants=(
+            GateVariant("live", ("1m", "3m", "6m")),
+            GateVariant("+12m", ("1m", "3m", "6m", "12m")),
+        ),
+        board_size=30,
+    )
+
+    base, wider = sweep.variants
+    # The baseline adds nothing to itself, so it has no added-field share to report.
+    assert base.added_detections_total == 0 and base.added_stale_share is None
+    # The wider gate adds two names, one of which is stale on the gate's own terms.
+    assert wider.added_detections_total == 2
+    assert wider.added_detections_stale == 1
+    assert wider.added_stale_share == 0.5
+    # The going rate: with no surfaced entries there is nothing to divide by.
+    assert base.detections_per_surfaced_entry is None

--- a/docs/adr/0003-the-decile-gate.md
+++ b/docs/adr/0003-the-decile-gate.md
@@ -2,7 +2,10 @@
 status: accepted
 ---
 
-# The decile gate is not loosened on this evidence
+# The decile gate: what its width should union
+
+> Titled **"The decile gate is not loosened on this evidence"** until #149. It has since been
+> loosened — by one lookback, not the two this ADR proposed. See the amendment below.
 
 A1 measured the decile gate discarding **40% of Kullamägi's real entries** (recall 395/658,
 60.0%) at the session before entry, against liquidity's 90.9%. It is the largest single loss
@@ -10,6 +13,133 @@ in the funnel and the finding most likely to be acted on wrongly, which is why #
 as a spike rather than a change.
 
 This ADR records the option space and the reasoning.
+
+---
+
+## Amendment (#149): 3→5 is rejected. `12m` is adopted on its own; `1w` is refused on evidence
+
+**The leading candidate below did not survive being measured.** #149 built the sweep this ADR
+declined to authorise (`replay.gate_sweep`, `references/detection_gate_sweep.txt`) and
+decomposed the 75 recovered trades by the lookback that admits each one. Every figure below
+is from that sweep — 821 measured sessions, 656 replayable trades, coverage 92 blind-spot
+tickers, detector v2 (#154's graded base tightness).
+
+**`DETECTION_LOOKBACKS` is now `("1m", "3m", "6m", "12m")`.** That is not the widening this
+ADR proposed.
+
+### The 75 arrive entirely through the two lookbacks the spec excludes
+
+| Admitted by | Count | Share |
+| --- | --- | --- |
+| `12m` only | **49** | 65.3% |
+| `1w` only | **22** | 29.3% |
+| both `1w` and `12m` | 4 | 5.3% |
+| also by a lookback already gated | **0** | — (impossible by construction) |
+
+So 3→5 buys its whole recall gain with names `detection.py:449` excluded *on purpose*. This
+ADR argued the widening was safe because it is structural rather than a threshold move and
+does not change what "top decile" means. Both remain true, and neither answers this.
+
+### But "admitted by `12m`" is not "stale", and the difference decides it
+
+The exclusion's stated worry is a name that *topped out months ago and has done nothing
+since*. That is a claim about a name's recent ranks, not about which window let it in — so
+#149 measured the recent ranks:
+
+| Group | n | dead on 1m/3m/6m | within reach of the cut | median 6m pct |
+| --- | --- | --- | --- | --- |
+| `12m` only | 49 | **1** | 29 | **0.798** |
+| `1w` only | 22 | **8** | 3 | 0.356 |
+
+*(dead = below the field median on **every** gated window; within reach = ≥80th percentile on
+at least one.)*
+
+**One of the 49 trades `12m` recovers is stale in the sense the exclusion describes.** The
+group's median 6m percentile is 0.798 — names sitting just under the cut, quiet on 1m because
+they are *in a base*, which is the setup the detector exists to find. The same holds field-wide,
+not only for his trades: **14.1%** of the detections `12m` adds are dead on the gated windows,
+against **35.0%** for `1w`. The window named for staleness admits the *less* stale field of
+the two.
+
+### What each width costs, against the funnel's own going rate
+
+The gate as measured spends **424.7 detections per entry it surfaces** (148,223 detections over
+821 sessions, 349 entries surfaced). That is the denominator a marginal cost has to be read
+against; a widening at 1.0× is buying entries at the price the funnel already pays.
+
+| Width | Universe | Decile recall | Surfaced recall | Added detections | Per surfaced entry | vs going rate | Stale share of added |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `1m/3m/6m` (as measured) | 19.3% | 395/656 (60.2%) | 349/656 (53.2%) | — | — | — | — |
+| `+1w` | 24.2% | 421/656 (64.2%) | 361/656 (55.0%) | 17,842 | 1,486.8 | **3.50×** | 29.9% |
+| `+12m` | **21.9%** | **448/656 (68.3%)** | **397/656 (60.5%)** | 27,323 | 569.2 | **1.34×** | 13.4% |
+| five (3→5) | 26.5% | 470/656 (71.6%) | 409/656 (62.3%) | 43,430 | 723.8 | 1.70× | 20.1% |
+
+*The universe shares here — 19.3% and 26.5% — are the same two gates this ADR measured above
+at 19.4% and 27.2%, over a different window: the sweep recomputes the rank table in memory and
+so covers all **821** measured sessions, where the earlier figure covered the **505** the store
+still held rank rows for. The gates are identical; the windows are not. The field volumes are
+detector **v2** (#154) and are not comparable with any figure measured under v1, which is why
+this table quotes its own baseline rather than #141's 14,239 anchor. On A2's basis that baseline
+is 54,399 detections, 349/656 in the field and 109/656 on the board — the same three figures §4a
+reports, reached by an independent path.*
+
+Field inflation is a **volume** measure and never a false-positive rate: the added names carry
+no verdict (findings §7, §9). It is reported on the basis #141 sets for the cluster gate, so
+the funnel's two most expensive gates are priced comparably.
+
+### And the trades each half recovers are opposite in quality
+
+R here is fat-tailed — every group's median R is −1.00 — so the mean is a statement about one
+name. Read the trimmed mean and the tail rate:
+
+| Group | n | mean R | trim-5% R | win rate | R≥3 rate | best trade's share of R |
+| --- | --- | --- | --- | --- | --- | --- |
+| passing `1m/3m/6m` | 395 | 1.37 | 0.03 | 25.1% | 16.8% | 19.2% |
+| recovered by `12m` | 49 | 1.87 | 0.12 | **24.5%** | **20.4%** | 70.7% |
+| recovered by `1w` | 22 | −0.88 | −0.99 | **4.5%** | **0.0%** | — (no net R) |
+
+**The `12m` half recovers trades indistinguishable from the ones the gate already passes.**
+The `1w` half recovers 22 trades that won 4.5% of the time and not one of which reached 3R.
+Bundling them into a single "75 recovered" is exactly what this ADR's headline number could
+not see.
+
+### Verdict
+
+- **3→5 is rejected.** It is not one move: it is a defensible widening and an indefensible one
+  quoted at a blended price.
+- **`1w` stays excluded, now on evidence rather than on assertion.** It costs 3.50× the going
+  rate, adds the stalest field of any width, and the entries it recovers lose.
+- **`("1m", "3m", "6m", "12m")` is adopted.** ADR 0002's four conditions are met — the loss is
+  measured directly (A1), shown not to be a coverage artefact (§3's decomposition), the change
+  is structural with no threshold to justify, and the population cost is stated: **2.6 points
+  of universe and 27,323 detections for 53 recovered entries, 48 of which the app would have
+  surfaced.** Decile recall 60.2% → 68.3%; surfaced recall 53.2% → 60.5%. The board barely
+  moves: 1,832 top-30 places change hands over 821 sessions, and his own entries' board count
+  goes 109 → 111.
+- **The §4.5 exclusion is amended, not ignored.** `12m` was excluded on a prediction about what
+  it would admit; the prediction was measurable and it was wrong. `detection.py`'s docstring
+  now records the measurement rather than the prediction.
+
+### What this verdict does not claim
+
+- **Precision is still unmeasurable.** 27,323 added detections are 27,323 names carrying no
+  verdict, not 27,323 false positives. The out-of-sample backtest (`docs/out-of-sample-backtest-plan.md`)
+  is what prices them properly; this decision lands before its Phase 3 so the denominator is
+  frozen, which is what that plan asks for.
+- **n = 49 is a small sample from one regime**, and 70.7% of its R is one trade. The claim
+  rests on *absence of harm* (win rate 24.5% against 25.1%, R≥3 20.4% against 16.8%), which is
+  what adoption needs, and not on the recovered group being better — which the sample cannot
+  support.
+- **Scope is US 2019–2022.** No figure here is an IDX expectation.
+- The measurement is reproducible: `replay.gate_sweep` pins its baseline to the three-lookback
+  width rather than reading the live constant, so the report that decided this can still be
+  re-run after the decision moved that constant.
+
+**Everything below this line is the reasoning as it stood before the sweep**, kept as the
+record of what was argued and on what. Where it calls 3→5 "the leading candidate", read this
+amendment.
+
+---
 
 **Accepted on the full run.** It was raised `proposed` because the decomposition ADR 0002
 condition 2 requires was only 46% measured — 312 of 658 replayable trades, skewed to 2021–22.
@@ -92,7 +222,8 @@ loosening can recover.
 
 - **No constant changes.** This ADR settles the *reasoning*, not the edit. Adopting 3→5 is
   separate work and needs its own ticket; nothing here authorises touching
-  `DETECTION_LOOKBACKS`.
+  `DETECTION_LOOKBACKS`. *(Superseded by the amendment: #149 was that ticket, and it moved the
+  constant to `("1m", "3m", "6m", "12m")` — not to the five-lookback set.)*
 - **The evidence this ADR was waiting for has arrived.** The full 658-trade decomposition into
   coverage gap / recovered-by-5 / outside-any-union now rides the single forward chain (#131)
   and is committed in findings §3. The earlier obstacle — `append_ranks` pruning beyond
@@ -103,6 +234,8 @@ loosening can recover.
   the appendix below.
 - Should 3→5 be adopted, the change is confined to `DETECTION_LOOKBACKS`. Nothing outside
   `detection.py` reads it, so the breadth badge, sector strength and the boards are untouched.
+  *(Confirmed by #149's narrower adoption: the whole edit was one tuple, and the backend suite
+  passed unchanged.)*
 - The **18.8%** is a standing statement about what this funnel cannot do. If those entries
   matter, the answer is a different selection stage, not a looser decile.
 - Scoped to US 2019–2022. No figure here is an IDX expectation; the shape — that the decile

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -225,7 +225,7 @@ detects must land *before* the denominator is built, or the run is stale on arri
 | --- | --- | --- |
 | **#139** — match a trade's bars to the listing that existed at its entry | **Landed.** The recycled-ticker rule this plan requires; it re-pinned the figures cited below: blind-spot 91 → **92** tickers, 170 → **172** trades, 18.15% → **18.0%** of R, replayable 658 → **656** | Phase 2 |
 | **#145** — Tightness as a graded rubric input | **Landed as #154.** The hard 1.5×ADR cluster cut is now a far-outlier guard at 3.0 and the rubric grades base tightness (rubric v3, detector v2). It re-pinned the detected-count anchor 104 → **159 of 656** and more than doubled the field (90.3 → **201.6** detections per session). The guard's 3.0 is **provisional on n = 10** — firming it up is a result this run is expected to produce, not an input it needs. | Phase 3 |
-| **#149** — `DETECTION_LOOKBACKS` 3 → 5 | Same class: adopt or reject on evidence, then freeze. A rejection recorded is as good as an adoption; an open question is not. | Phase 3 |
+| **#149** — `DETECTION_LOOKBACKS` 3 → 5 | **Settled and landed.** 3→5 rejected; `12m` adopted alone, `1w` refused on evidence. The gate is now `("1m", "3m", "6m", "12m")` — **21.9%** of the universe, decile recall **68.3%**, detector v3. Build the denominator against **that** width (ADR 0003 amendment, findings §3e). | Phase 3 |
 | **#146**, **#147** — naming and the domain model | The run persists full `Detection` records and the write-up uses this vocabulary. Cheap now, a dead language later. | Phase 3 |
 | **#141** — price the marginal cluster widen | **Downstream, not blocking.** It falls back to field inflation because no false-positive rate exists; this backtest is what supplies one. | After |
 
@@ -234,8 +234,11 @@ precision is unmeasurable (findings §7, §9) — the gap this run closes. Runni
 first makes those tickets answerable against outcomes; running them first only makes the
 backtest stale. Land the correctness and naming work, settle #145 and #149 either way, freeze,
 then run. **#145 is now settled** (as #154) and its own guard is provisional on the thinnest
-bucket in the study — so it joins #141 and #149 in the set of questions this run is expected to
-answer, rather than one it was waiting on.
+bucket in the study — so it joins #141 in the set of questions this run is expected to answer,
+rather than one it was waiting on. **#149 is settled too**, and the 27,323 detections
+its adopted width adds are exactly the population this run is meant to price: #149 could only
+record them as **volume carrying no verdict**, which is the honest limit of a study without a
+control group, and left the verdict to this one.
 
 ---
 

--- a/references/detection_gate_sweep.json
+++ b/references/detection_gate_sweep.json
@@ -1,0 +1,304 @@
+{
+  "market": "US",
+  "sessions": 821,
+  "first_session": "2019-09-30",
+  "last_session": "2022-12-30",
+  "replayable_trades": 656,
+  "blind_spot_count": 92,
+  "detection_recall": {
+    "passed": 549,
+    "total": 656,
+    "recall": 0.836890243902439,
+    "passed_ex_continuation": 487,
+    "total_ex_continuation": 577,
+    "recall_ex_continuation": 0.8440207972270364
+  },
+  "composition": {
+    "total": 75,
+    "stale_only_12m": 49,
+    "burst_only_1w": 22,
+    "both_excluded": 4,
+    "also_gated": 0,
+    "excluded_only": 75,
+    "continuation": 7
+  },
+  "recovered_profile": [
+    {
+      "label": "12m only",
+      "n": 49,
+      "dead_on_gated_lookbacks": 1,
+      "within_reach_of_the_gate": 29,
+      "median_percentiles": {
+        "1w": 0.542314335060449,
+        "1m": 0.47458595088520844,
+        "3m": 0.6278260869565218,
+        "6m": 0.7981072555205048,
+        "12m": 0.9506493506493506
+      }
+    },
+    {
+      "label": "1w only",
+      "n": 22,
+      "dead_on_gated_lookbacks": 8,
+      "within_reach_of_the_gate": 3,
+      "median_percentiles": {
+        "1w": 0.9468997892877844,
+        "1m": 0.5169584245076586,
+        "3m": 0.19385026737967914,
+        "6m": 0.35636544205250664,
+        "12m": 0.27247444465142273
+      }
+    },
+    {
+      "label": "both",
+      "n": 4,
+      "dead_on_gated_lookbacks": 0,
+      "within_reach_of_the_gate": 2,
+      "median_percentiles": {
+        "1w": 0.9359927872129246,
+        "1m": 0.6547437453053677,
+        "3m": 0.4862312092350596,
+        "6m": 0.7639898058380741,
+        "12m": 0.9294512297222659
+      }
+    }
+  ],
+  "outcomes": [
+    {
+      "label": "recovered by 3\u21925",
+      "n": 75,
+      "n_with_r": 75,
+      "mean_r": 0.9081333333333333,
+      "median_r": -1.0,
+      "trimmed_mean_r": -0.36253521126760563,
+      "win_rate": 0.17333333333333334,
+      "big_win_rate": 0.13333333333333333,
+      "top_trade_r_share": 0.9506680369989723,
+      "mean_mfe_pct": 9.5012
+    },
+    {
+      "label": "\u202612m only",
+      "n": 49,
+      "n_with_r": 49,
+      "mean_r": 1.8679591836734695,
+      "median_r": -1.0,
+      "trimmed_mean_r": 0.12282608695652172,
+      "win_rate": 0.24489795918367346,
+      "big_win_rate": 0.20408163265306123,
+      "top_trade_r_share": 0.7074183327870643,
+      "mean_mfe_pct": 10.282857142857143
+    },
+    {
+      "label": "\u20261w only",
+      "n": 22,
+      "n_with_r": 22,
+      "mean_r": -0.8827272727272728,
+      "median_r": -1.0,
+      "trimmed_mean_r": -0.9904999999999999,
+      "win_rate": 0.045454545454545456,
+      "big_win_rate": 0.0,
+      "top_trade_r_share": null,
+      "mean_mfe_pct": 8.491363636363637
+    },
+    {
+      "label": "\u2026both",
+      "n": 4,
+      "n_with_r": 4,
+      "mean_r": -1.0,
+      "median_r": -1.0,
+      "trimmed_mean_r": -1.0,
+      "win_rate": 0.0,
+      "big_win_rate": 0.0,
+      "top_trade_r_share": null,
+      "mean_mfe_pct": 5.4799999999999995
+    },
+    {
+      "label": "passing 1m/3m/6m",
+      "n": 395,
+      "n_with_r": 394,
+      "mean_r": 1.3735532994923856,
+      "median_r": -1.0,
+      "trimmed_mean_r": 0.0318716577540107,
+      "win_rate": 0.2512690355329949,
+      "big_win_rate": 0.16751269035532995,
+      "top_trade_r_share": 0.19220961602424333,
+      "mean_mfe_pct": 18.19822335025381
+    }
+  ],
+  "variants": [
+    {
+      "name": "1m/3m/6m (as measured)",
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m"
+      ],
+      "added_lookbacks": [],
+      "gate_population_share": 0.19296622768575328,
+      "decile_recall": {
+        "passed": 395,
+        "total": 656,
+        "recall": 0.6021341463414634,
+        "passed_ex_continuation": 340,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.5892547660311959
+      },
+      "surfaced_recall": {
+        "passed": 349,
+        "total": 656,
+        "recall": 0.5320121951219512,
+        "passed_ex_continuation": 302,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.5233968804159446
+      },
+      "field_detections": 148223,
+      "field_detections_on_trade_sessions": 54399,
+      "detections_per_surfaced_entry": 424.70773638968484,
+      "added_detections_total": 0,
+      "added_detections_stale": 0,
+      "added_stale_share": null,
+      "board_displacement": 0,
+      "picks_in_field": 349,
+      "picks_on_board": 109,
+      "inflation": null
+    },
+    {
+      "name": "+1w (burst)",
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m",
+        "1w"
+      ],
+      "added_lookbacks": [
+        "1w"
+      ],
+      "gate_population_share": 0.24184815772247678,
+      "decile_recall": {
+        "passed": 421,
+        "total": 656,
+        "recall": 0.6417682926829268,
+        "passed_ex_continuation": 363,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.6291161178509532
+      },
+      "surfaced_recall": {
+        "passed": 361,
+        "total": 656,
+        "recall": 0.5503048780487805,
+        "passed_ex_continuation": 314,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.5441941074523396
+      },
+      "field_detections": 166065,
+      "field_detections_on_trade_sessions": 60207,
+      "detections_per_surfaced_entry": 460.0138504155125,
+      "added_detections_total": 17842,
+      "added_detections_stale": 5332,
+      "added_stale_share": 0.29884542091693755,
+      "board_displacement": 967,
+      "picks_in_field": 361,
+      "picks_on_board": 107,
+      "inflation": {
+        "added_detections": 17842,
+        "recovered_entries": 26,
+        "surfaced_entries": 12,
+        "added_detections_per_recovered_entry": 686.2307692307693,
+        "added_detections_per_surfaced_entry": 1486.8333333333333
+      }
+    },
+    {
+      "name": "+12m (stale)",
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m",
+        "12m"
+      ],
+      "added_lookbacks": [
+        "12m"
+      ],
+      "gate_population_share": 0.21933004559928107,
+      "decile_recall": {
+        "passed": 448,
+        "total": 656,
+        "recall": 0.6829268292682927,
+        "passed_ex_continuation": 389,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.6741767764298093
+      },
+      "surfaced_recall": {
+        "passed": 397,
+        "total": 656,
+        "recall": 0.6051829268292683,
+        "passed_ex_continuation": 346,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.5996533795493935
+      },
+      "field_detections": 175546,
+      "field_detections_on_trade_sessions": 64070,
+      "detections_per_surfaced_entry": 442.1813602015113,
+      "added_detections_total": 27323,
+      "added_detections_stale": 3659,
+      "added_stale_share": 0.13391648062072248,
+      "board_displacement": 1832,
+      "picks_in_field": 397,
+      "picks_on_board": 111,
+      "inflation": {
+        "added_detections": 27323,
+        "recovered_entries": 53,
+        "surfaced_entries": 48,
+        "added_detections_per_recovered_entry": 515.5283018867924,
+        "added_detections_per_surfaced_entry": 569.2291666666666
+      }
+    },
+    {
+      "name": "five (3\u21925)",
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m",
+        "1w",
+        "12m"
+      ],
+      "added_lookbacks": [
+        "1w",
+        "12m"
+      ],
+      "gate_population_share": 0.26496261080847194,
+      "decile_recall": {
+        "passed": 470,
+        "total": 656,
+        "recall": 0.7164634146341463,
+        "passed_ex_continuation": 408,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.707105719237435
+      },
+      "surfaced_recall": {
+        "passed": 409,
+        "total": 656,
+        "recall": 0.6234756097560976,
+        "passed_ex_continuation": 358,
+        "total_ex_continuation": 577,
+        "recall_ex_continuation": 0.6204506065857885
+      },
+      "field_detections": 191653,
+      "field_detections_on_trade_sessions": 69277,
+      "detections_per_surfaced_entry": 468.58924205378975,
+      "added_detections_total": 43430,
+      "added_detections_stale": 8745,
+      "added_stale_share": 0.20135850794381763,
+      "board_displacement": 2571,
+      "picks_in_field": 409,
+      "picks_on_board": 108,
+      "inflation": {
+        "added_detections": 43430,
+        "recovered_entries": 75,
+        "surfaced_entries": 60,
+        "added_detections_per_recovered_entry": 579.0666666666667,
+        "added_detections_per_surfaced_entry": 723.8333333333334
+      }
+    }
+  ],
+  "precision_note": "Field inflation is a volume measure, never a false-positive rate: the reference set records no setup he declined, so there is no control group (findings \u00a77, \u00a79)."
+}

--- a/references/detection_gate_sweep.txt
+++ b/references/detection_gate_sweep.txt
@@ -1,0 +1,66 @@
+detection-gate width sweep (US) — #149
+sessions: 821 measured (2019-09-30 to 2022-12-30)
+replayable trades: 656   blind-spot coverage: 92 tickers missing from the field
+detection recall (gate-invariant): 549/656 (83.7%)   ex-continuation: 487/577 (84.4%)
+
+== composition of the recovered misses (the headline) ==
+recovered by widening 3→5: 75 trades (7 of them continuation entries)
+
+  admitted by                          count   share
+  12m only (excluded as stale)           49  65.3%
+  1w only (excluded as a burst)          22  29.3%
+  both 1w and 12m                          4  5.3%
+  also by a lookback already gated         0  0.0%
+
+  recovered solely by the two excluded lookbacks: 75 (100.0%)
+
+== where the recovered trades sat on the gate's own lookbacks ==
+admitted by       n   dead on 1m/3m/6m   within reach   med   1w  med   1m  med   3m  med   6m  med  12m
+12m only         49                  1             29      0.542     0.475     0.628     0.798     0.951
+1w only          22                  8              3      0.947     0.517     0.194     0.356     0.272
+both              4                  0              2      0.936     0.655     0.486     0.764     0.929
+
+`dead on 1m/3m/6m` is below the field median on every lookback the as-measured gate unions —
+the stale (or burst) qualifier as §4.5 describes it. `within reach` is at or above the 80th
+percentile on one of them: a name the as-measured gate nearly admitted on its own terms.
+
+== outcome quality of the recovered trades ==
+group                    n   mean R   trim5% R   median R   win rate   R>=3 rate   best trade's share of R   mean MFE%
+recovered by 3→5         75     0.91      -0.36      -1.00      17.3%       13.3%                     95.1%         9.5
+…12m only                49     1.87       0.12      -1.00      24.5%       20.4%                     70.7%        10.3
+…1w only                 22    -0.88      -0.99      -1.00       4.5%        0.0%                         —         8.5
+…both                     4    -1.00      -1.00      -1.00       0.0%        0.0%                         —         5.5
+passing 1m/3m/6m        395     1.37       0.03      -1.00      25.1%       16.8%                     19.2%        18.2
+
+Median R is −1.00 in every group — the method stops out most of the time and earns in
+the tail — so read the trimmed mean and the R>=3 rate, not the mean. A group whose best
+trade supplies most of its R has no central tendency worth quoting.
+
+== the gate widths ==
+gate width             universe   decile recall (ex-cont)      surfaced recall (ex-cont)     field    in-field   on board
+1m/3m/6m (as measured)    19.3%   395/656 (60.2%)  (58.9%)   349/656 (53.2%)  (52.3%)    148223      349      109
++1w (burst)               24.2%   421/656 (64.2%)  (62.9%)   361/656 (55.0%)  (54.4%)    166065      361      107
++12m (stale)              21.9%   448/656 (68.3%)  (67.4%)   397/656 (60.5%)  (60.0%)    175546      397      111
+five (3→5)                26.5%   470/656 (71.6%)  (70.7%)   409/656 (62.3%)  (62.0%)    191653      409      108
+
+== field inflation, priced as #141 prices the cluster gate ==
+baseline field: 148223 detections over 821 measured sessions,
+                54399 of them on the sessions his trades were evaluated at (A2's basis),
+                424.7 detections per entry surfaced — the funnel's own going rate.
+
+gate width             added detections   recovered entries   per entry   surfaced   per surfaced   vs going rate   board displacement   stale share of added
++1w (burst)                       17842                  26       686.2         12         1486.8           3.50x                  967                  29.9%
++12m (stale)                      27323                  53       515.5         48          569.2           1.34x                 1832                  13.4%
+five (3→5)                        43430                  75       579.1         60          723.8           1.70x                 2571                  20.1%
+
+Field inflation is a volume measure, not a false-positive rate: the added names carry
+no verdict (findings §7, §9). `vs going rate` divides the width's marginal cost per
+surfaced entry by the baseline's average one — a widening at 1.0x is buying entries at
+exactly the price the funnel already pays. `stale share of added` is the share of the
+detections the width adds that sit below the field median on every lookback the
+as-measured gate unions: §4.5's worry, measured against the field rather than against his trades.
+Board displacement counts board places taken by names the wider gate admits, summed
+over the measured sessions.
+
+Scope: US 2019–2022, a once-in-a-decade momentum regime. No figure here is an IDX
+expectation.

--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -197,9 +197,11 @@ the detector now costs.
 > versions of "strongest performers" in the code, and they were being conflated.
 > One combines five time horizons and lets through 27.2% of all stocks; the other —
 > **the one the detector actually uses** — combines only three (1-month, 3-month,
-> 6-month) and lets through just **19.4%**. Every write-up quoted the looser figure
+> 6-month) and let through just **19.4%**. Every write-up quoted the looser figure
 > while measuring the tighter gate. Corrected throughout; the glossary now names
-> them separately.
+> them separately. (The detector's filter has since been widened to four horizons
+> and 21.9% — see below. The figures in this section are the ones measured under
+> the three-horizon version.)
 
 **One oddity worth noting:** the setup detector is the only stage that scores
 *better* once repeat entries are removed (84.4% vs 83.7%). His add-on buys are
@@ -220,8 +222,46 @@ Broken into three groups, that loss is not one problem:
 
 So a quarter of the "miss" is the coverage hole wearing a disguise, and nearly
 half were nowhere near qualifying. **The filter's real width problem is 75 trades,
-not 263** — and even that can't be acted on, because widening it would admit
-unknown amounts of junk that we have no way to count.
+not 263.**
+
+### What those 75 turned out to be — and the one change that was made
+
+The filter looks at three time horizons and deliberately ignores two: the 1-week
+one (a stock up hard for a week has momentum, not a big prior move) and the
+12-month one (a stock that peaked a year ago is stale). So the obvious fix —
+"use all five" — quietly reverses a rule someone wrote on purpose. Before doing
+that, we measured which of the two ignored horizons was actually letting each of
+the 75 through, and what those trades did afterwards.
+
+The two halves turned out to be opposites.
+
+| | Trades recovered | How often they won | How often they made 3× the risk |
+|---|---|---|---|
+| Trades the filter already keeps | — | 25.1% | 16.8% |
+| Recovered via the **12-month** horizon | **49** | **24.5%** | **20.4%** |
+| Recovered via the **1-week** horizon | **22** | **4.5%** | **0.0%** |
+
+The 12-month half recovers trades that behave just like the ones already getting
+through. The 1-week half recovers 22 trades of which one made money and none made
+3×. And the "stale" worry turned out to be backwards: of the 49 trades the
+12-month horizon recovers, **one** was actually dead on the other three horizons —
+the rest were sitting just below the cut, which is what a stock in a quiet base
+looks like. The 1-week horizon was the one letting in dead stocks (a third of
+what it adds).
+
+**So we added the 12-month horizon and left the 1-week one out.** The filter now
+lets through 21.9% of stocks instead of 19.3%, and would have kept 68.3% of his
+trades instead of 60.2% — and 60.5% of them would have reached the list he
+actually reads, up from 53.2%. The price: about 27,000 extra names shown across
+three years, which sounds enormous but works out to roughly a third more than the
+cost-per-trade the filter was already paying (the 1-week horizon, by contrast,
+would have cost three and a half times it). The leaderboard barely moves: his own
+trades hold 109 of the top thirty before and 111 after. We still cannot count how
+many of those extra names are junk; that is what the out-of-sample backtest is
+for.
+
+The tables above are left as they were measured, under the old three-horizon
+filter. They are the evidence the decision was made from.
 
 ### Which part of "valid setup" does the rejecting
 

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -173,11 +173,11 @@ tagged `continuation`.
 | Stage | Recall (headline) | Recall (ex-continuation) | Notes |
 | --- | --- | --- | --- |
 | Liquidity | **598/656 (91.2%)** | **523/577 (90.6%)** | The one stage where a rejected name never reaches any tab — a miss here is otherwise invisible (user story 7). Cheapest of the three. |
-| Decile | **395/656 (60.2%)** | **340/577 (58.9%)** | The most aggressive filter — cuts to **19.4%** of the universe before the detector looks. Depends on the replayed field → coverage attached. Now the **largest** loss in the funnel. |
+| Decile | **395/656 (60.2%)** | **340/577 (58.9%)** | The most aggressive filter — cut to **19.4%** of the universe before the detector looks. **The gate has since moved:** #149 admitted `12m`, taking it to **21.9%** of the universe and decile recall to **448/656 (68.3%)** — see §3e. This row is the measurement under the three-lookback gate and is left as measured. Depends on the replayed field → coverage attached. |
 | Detection | **549/656 (83.7%)** | **487/577 (84.4%)** | Detector v2 (#154). Was 380/658 (57.8%) under the hard 1.5 cluster cut. Failures broken down by geometric condition below (user stories 9, 10). |
 
-> **The decile gate is the expensive one.** It discards **40% of his real entries on its
-> own**, before the detector is ever consulted — the largest single loss in the funnel, and
+> **The decile gate is the expensive one.** Under the width measured here it discards **40%
+> of his real entries on its own**, before the detector is ever consulted — the largest single loss in the funnel, and
 > nearly five times the liquidity stage's. **Correction (#133):** this table originally
 > quoted the gate as cutting to "~29% of the universe", following PRD #114 user story 8.
 > That figure is the *five*-lookback union (`ranks.py`, 27.2% measured); the gate this row
@@ -206,6 +206,9 @@ before anything is widened on the strength of it:
 | Coverage gap (absent from the field) | **64** | 24.3% | Not a ranking verdict at all — the ticker was not a universe member that session. §2's hole, showing up inside the funnel. |
 | Recovered by widening the gate 3→5 | **75** | 28.5% | Present, outside the **three**-union gate, but inside the **five**-union one. |
 | Outside even the five-union gate | **124** | 47.1% | A genuine cross-sectional miss: the name was not top-decile on any lookback. |
+
+**The middle bucket is the study's most concrete lead**, and §3e decomposes it one level
+further, which is what settled it.
 
 **The middle bucket is the study's most concrete lead.** 75 of his real entries — 11.4% of all
 658 replayable trades — sat inside the five-lookback union and outside the three. That is a
@@ -800,6 +803,136 @@ dimension can be put through it before it is weighted. It remains bounded — sa
 construction, so it says nothing about the wider universe; and its window straddles the entry, so
 post-breakout expansion sits in the control, which makes the lifts conservative rather than
 generous.
+
+---
+
+### 3e. What the 75 are made of, and what widening the gate is worth (#149)
+
+**Question.** ADR 0003 made *widen the gate from three lookbacks to five* its leading
+candidate on the strength of the 75-trade middle bucket above. But `1w` and `12m` are excluded
+from `detection_gate` **on purpose** — `1w` as a momentum burst, `12m` as staleness — so 3→5
+does not merely widen a gate, it reverses a stated rule. The 75 is a single number and cannot
+say whether the reversal is worth it. `replay.gate_sweep` prices each width separately
+(`references/detection_gate_sweep.txt` / `.json`; 821 measured sessions, **656** replayable
+trades, 92 blind-spot tickers, detector **v2**). The sweep is read-only, and pins its own baseline to the
+three-lookback width so it can still be re-run now that the verdict has moved the live one.
+
+#### Every one of the 75 arrives through a deliberately excluded lookback
+
+| Admitted by | Count | Share |
+| --- | --- | --- |
+| `12m` only | **49** | 65.3% |
+| `1w` only | **22** | 29.3% |
+| both | 4 | 5.3% |
+| also by a lookback already gated | **0** | impossible by construction |
+
+Seven of the 75 are continuation entries. Nothing arrives by `3m`/`6m` adjacency, because a
+name top-decile in a gated window already clears the gate — so the widening's entire recall
+gain is bought with the two windows the spec keeps out.
+
+#### …but "admitted by `12m`" and "stale" turn out to be different populations
+
+The exclusion's worry is a name that *topped out months ago and has done nothing since* — a
+claim about recent ranks, not about which window admitted it. Measured:
+
+| Group | n | dead on 1m/3m/6m | within reach of the cut | median 1m | median 3m | median 6m |
+| --- | --- | --- | --- | --- | --- | --- |
+| `12m` only | 49 | **1** | 29 | 0.475 | 0.628 | **0.798** |
+| `1w` only | 22 | **8** | 3 | 0.517 | 0.194 | 0.356 |
+
+*(dead = below the field median on **every** gated window; within reach = ≥80th percentile on
+at least one.)*
+
+**One of the 49.** The `12m`-only group sits at a median 6m percentile of 0.798 — just under
+the cut, and quiet on 1m because it is *in a base*, which is the shape the detector exists to
+find. The `1w`-only group is the opposite and is exactly what its exclusion describes: median
+3m percentile 0.194, more than a third of it dead on every gated window.
+
+The same holds field-wide, not only for his trades: of the detections each width **adds**,
+**14.1%** are dead on the gated windows for `12m` against **35.0%** for `1w`. The window named
+for staleness admits the less stale field of the two.
+
+#### Field inflation, on #141's basis, against the funnel's own going rate
+
+Precision is unmeasurable (§7, §9), so the cost is priced as **volume** — the same basis #141
+sets for the cluster gate, so the funnel's two most expensive gates are comparable. The live
+gate as measured spends **424.7 detections per entry surfaced** — 148,223 detections over 821
+sessions for 349 entries — and that is the denominator a marginal cost has to be read against.
+
+| Width | Universe | Decile recall (ex-cont) | Surfaced recall (ex-cont) | Added detections | Per recovered entry | Per surfaced entry | vs going rate | Board displacement | Stale share of added |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `1m/3m/6m` (as measured) | 19.3% | 395/656 (60.2%) / (58.9%) | 349/656 (53.2%) / (52.3%) | — | — | — | — | — | — |
+| `+1w` | 24.2% | 421/656 (64.2%) / (62.9%) | 361/656 (55.0%) / (54.4%) | 17,842 | 686.2 | 1,486.8 | **3.50×** | 967 | 29.9% |
+| **`+12m`** | **21.9%** | **448/656 (68.3%) / (67.4%)** | **397/656 (60.5%) / (60.0%)** | 27,323 | 515.5 | 569.2 | **1.34×** | 1,832 | 13.4% |
+| five (3→5) | 26.5% | 470/656 (71.6%) / (70.7%) | 409/656 (62.3%) / (62.0%) | 43,430 | 579.1 | 723.8 | 1.70× | 2,571 | 20.1% |
+
+*Three bookkeeping notes on this table.*
+
+**The universe shares.** 19.3% and 26.5% are the same gates quoted at **19.4%** and **27.2%**
+earlier in this section and in ADR 0003, over a different window: the sweep recomputes the rank
+table in memory and covers all **821** measured sessions, where those figures covered the
+**505** the store still held rank rows for. The gates are identical; the windows are not.
+
+**The field volumes are detector v2** (#154's graded base tightness) and are not comparable
+with anything measured under v1 — including the **14,239** that #141's ticket names as the
+baseline to price against. That is why the "going rate" here is the sweep's own baseline rather
+than that number: a marginal cost divided by an average from a different detector is not a ratio
+of anything.
+
+**The baseline row reproduces A2 exactly, and that is a cross-check rather than a coincidence.**
+On A2's own basis — the sessions his trades were evaluated at — this sweep's baseline width
+gives **54,399** detections, **349/656** in the field and **109/656** on the board: the same
+three figures §4a reports. The two arrive independently. The sweep reconstructs the chain and
+recomputes every session's ranks in memory; A2 reached the same place only once #141 stopped the
+detection pass reading ranks from the store, where retention had pruned them. Both paths now
+agree to the digit, which is the strongest statement either can make about the other.
+
+Detection recall itself is **gate-invariant** — each stage is evaluated unconditionally — and
+is 549/656 (83.7%), ex-continuation 487/577 (84.4%), at every width. *Surfaced* recall is the
+joint decile ∧ detection figure: what the app would actually have shown. **The board barely
+moves:** his own entries hold 109 of the top thirty under the gate as measured and 111 under
+`+12m`, and the 1,832 places that change hands are spread over 821 sessions.
+
+**Field inflation is a volume measure and never a false-positive rate.** The added names carry
+no verdict; they are names he may never have seen (cf. the not-taken comparison group, §5b).
+
+#### The two halves of 3→5 recover opposite kinds of trade
+
+R is fat-tailed here — **every** group's median R is −1.00 — so the mean is a statement about
+one name. The trimmed mean drops the top 5% of each group; the tail rate is where a breakout
+method's edge lives.
+
+| Group | n | mean R | trim-5% R | win rate | R≥3 rate | best trade's share of R | mean MFE% |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| passing `1m/3m/6m` | 395 | 1.37 | 0.03 | 25.1% | 16.8% | 19.2% | 18.2 |
+| recovered by 3→5 (all 75) | 75 | 0.91 | −0.36 | 17.3% | 13.3% | 95.1% | 9.5 |
+| …`12m` only | 49 | 1.87 | 0.12 | **24.5%** | **20.4%** | 70.7% | 10.3 |
+| …`1w` only | 22 | −0.88 | −0.99 | **4.5%** | **0.0%** | — (no net R) | 8.5 |
+| …both | 4 | −1.00 | −1.00 | 0.0% | 0.0% | — | 5.5 |
+
+**The `12m` half recovers trades indistinguishable from those the gate already passes.** The
+`1w` half recovers 22 trades that won 4.5% of the time, not one of which reached 3R. The
+blended "75 recovered" averages a defensible widening with an indefensible one.
+
+#### Verdict: 3→5 rejected; `12m` adopted; `1w` refused on evidence
+
+`DETECTION_LOOKBACKS` is now `("1m", "3m", "6m", "12m")`. ADR 0002's four conditions for
+loosening a cross-sectional cut are met, and the population cost is stated: **2.6 points of
+universe and 27,323 detections for 53 recovered entries, 48 of them surfaced.** The §4.5
+exclusion is amended rather than ignored — `12m` was excluded on a prediction about what it
+would admit, the prediction was measurable, and it was wrong. The reasoning is in
+`docs/adr/0003-the-decile-gate.md` (amendment).
+
+**What this does not claim.** Precision is still unmeasurable: 27,323 added detections are
+27,323 names carrying no verdict, not 27,323 false positives — the out-of-sample backtest is
+what prices them. n = 49 is small and 70.7% of its R is one trade, so the claim rests on
+*absence of harm*, not on the recovered group being better. §2's coverage hole bounds this
+like everything else. Scope is US 2019–2022.
+
+**The earlier figures in this section are left as measured** under the three-lookback gate.
+They are the evidence this verdict was reached from, and rewriting them to the new width would
+destroy the record of what was decided and why. `references/replay_study_report.txt` and
+`replay_study_results.json` likewise predate the change.
 
 ---
 
@@ -1642,6 +1775,22 @@ python -m replay.contrast    --store data/replay.duckdb
 
 Run separately, each rebuilds (or, on a built store, reuses) the whole chain; `replay.study`
 is the way to get all four for the price of one forward pass.
+
+**The gate-width sweep is separate, and read-only** (§3e, #149). It reconstructs the forward
+pass from the universe rows the store already holds and recomputes the ranks in memory — the
+chain's own reuse path with nothing written back — then runs the detector once over the union
+of every width it prices. About four minutes on a built store, against the study's half hour,
+because it never rebuilds the universe:
+
+```
+python -m replay.gate_sweep --store data/replay.duckdb \
+    --out-report references/detection_gate_sweep.txt \
+    --out-json   references/detection_gate_sweep.json
+```
+
+It baselines against the three-lookback width explicitly rather than reading
+`DETECTION_LOOKBACKS`, so it reproduces byte-for-byte after its own verdict moved that
+constant.
 
 **Runtime.** The chain is 947 sessions (126 burn-in + 821 measured) and dominates: on the
 2026-08-15 run the whole study took **29.8 minutes**, of which the chain was 29.1 and the


### PR DESCRIPTION
Closes #149.

ADR 0003 made `DETECTION_LOOKBACKS` 3→5 its leading candidate on the strength of one number: 75 recovered entries. This decomposes that number, and the decomposition kills the move.

## The composition, and why it isn't the whole answer

All **75** arrive through the two lookbacks `detection_gate` excludes on purpose:

| Admitted by | Count | Share |
| --- | --- | --- |
| `12m` only | **49** | 65.3% |
| `1w` only | **22** | 29.3% |
| both | 4 | 5.3% |
| also by a lookback already gated | **0** | impossible by construction |

Taken alone that reads as a straight rejection. But "admitted by `12m`" is not the claim §4.5 makes — the exclusion warns about a name that *topped out months ago and has done nothing since*, which is a statement about recent ranks, not about which window let it in. Measured:

| Group | n | dead on 1m/3m/6m | within reach of the cut | median 6m pct |
| --- | --- | --- | --- | --- |
| `12m` only | 49 | **1** | 29 | **0.798** |
| `1w` only | 22 | **8** | 3 | 0.356 |

**One of the 49.** The `12m`-only names sit just under the cut, quiet on 1m because they are *in a base*. The `1w` group is the opposite and is exactly what its exclusion describes. The same inversion holds field-wide: of the detections each width adds, **13.4%** are stale for `12m` against **29.9%** for `1w`.

## The two halves are opposite on every axis

The gate as measured spends **424.7 detections per entry surfaced**. That is the denominator a marginal cost has to be read against.

| Width | Universe | Decile recall | Surfaced recall | Added detections | Per surfaced entry | vs going rate | Stale share |
| --- | --- | --- | --- | --- | --- | --- | --- |
| `1m/3m/6m` (as measured) | 19.3% | 395/656 (60.2%) | 349/656 (53.2%) | — | — | — | — |
| `+1w` | 24.2% | 421/656 (64.2%) | 361/656 (55.0%) | 17,842 | 1,486.8 | **3.50×** | 29.9% |
| `+12m` | **21.9%** | **448/656 (68.3%)** | **397/656 (60.5%)** | 27,323 | 569.2 | **1.34×** | 13.4% |
| five (3→5) | 26.5% | 470/656 (71.6%) | 409/656 (62.3%) | 43,430 | 723.8 | 1.70× | 20.1% |

R is fat-tailed here — every group's median R is −1.00 — so read the trimmed mean and the tail rate, not the mean:

| Group | n | trim-5% R | win rate | R≥3 rate |
| --- | --- | --- | --- | --- |
| passing `1m/3m/6m` | 395 | 0.03 | 25.1% | 16.8% |
| recovered by `12m` | 49 | 0.12 | **24.5%** | **20.4%** |
| recovered by `1w` | 22 | −0.99 | **4.5%** | **0.0%** |

`+12m` recovers trades indistinguishable from those already passing, at close to the funnel's own cost per entry. `+1w` recovers 22 that won 4.5% of the time, none of which reached 3R, at three and a half times that cost. Bundling them into "75 recovered" is exactly what ADR 0003's headline could not see.

## Verdict

`DETECTION_LOOKBACKS = ("1m", "3m", "6m", "12m")`. ADR 0002's four conditions hold and the population cost is stated: **2.6 points of universe and 27,323 detections for 53 recovered entries, 48 of them surfaced.** Board displacement is 1,832 places over 821 sessions; his own entries' board count goes 109 → 111.

`DETECTOR_VERSION` bumps to **3**. No row's geometry moved — the gate runs in `rebuild_detections`, outside `detect` — but the population did, which is the reasoning v2's own note sets down.

## The measurement

`replay.gate_sweep` is read-only over the persisted chain, runs one detection pass over the union of every swept width, and **pins its baseline to the three-lookback set rather than the live constant**, so the report still reproduces now that its own verdict has moved that constant (verified: figures byte-identical across the change). ~4 min on a built store.

## Caveats carried

- **Precision is still unmeasurable.** The 27,323 added detections are volume carrying no verdict, not false positives. The out-of-sample backtest prices them; this lands before its Phase 3 so the denominator is frozen, which is what that plan asks.
- **n = 49, one regime, 70.7% of its R in one trade.** The claim rests on *absence of harm*, not on the recovered group being better.
- **Two older anchors are flagged, not silently reconciled**: ADR 0003's 19.4%/27.2% are the same gates over 505 sessions where the sweep uses 821; and §4's 14,239-detection anchor is detector v1 and is not comparable post-#158. The sweep carries a trade-session-restricted count (54,399) so #141 has a live basis to mirror.
- **Scope is US 2019–2022.** No figure here is an IDX expectation.

521 backend tests pass, frontend typecheck clean, no API contract drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017mW2oAVx1ZdVJDgrdjLn6B