### PR TITLE
Keep `Prior move` at ×1, and record why (#160/#161)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -226,9 +226,21 @@ restated anywhere else.
 
 **Constant dimension**:
 A score dimension true for every detection by construction, so it shifts every score equally
-and can never move the sort. `Prior move` is one, and is kept for what it documents, not for
-what it discriminates — a defence ADR 0005 (`proposed`) argues against, which would make it
-the first candidate for **retirement** if that ADR is accepted.
+and can never move the sort. `Prior move` is the only one, measured at pooled spread 0.000 in
+findings §5b and again in §5d, on a field 171% larger.
+
+**It stays at ×1, and is retired only when something takes its slot** (#160/#161). ADR 0005
+(`proposed`) calls keeping it "documentation bought at the price of a point", but that presumes
+the point is **scarce** — and it is not: the ceiling is the sum of the weights, not a budget, so
+a ninth dimension can be added without retiring the eighth and retiring this one frees nothing.
+The measurement is not in doubt; what fails is the case for acting on it alone. Because the
+dimension hits on every row its weight lands on every score, so zeroing *or* deleting it moves
+the scale identically — ceiling 9 → 8, stars 0.5–4.5 → 0.0–4.0 — which re-bases every frozen
+digest, `HERO_MIN` and acceptance B9 **while reordering nothing**. It is also the only breakdown
+row recording that the name cleared the decile gate ADR 0003 is about, so retiring it before
+that metadata exists loses information outright.
+_Avoid_: reading §5b's 0.000 as a standing instruction to retire it; the spread says the
+dimension cannot discriminate, not that removing it is free.
 
 **Candidate dimension**:
 A dimension **under measurement**, not in the rubric: computed on every detection in the

--- a/backend/screener/score.py
+++ b/backend/screener/score.py
@@ -29,6 +29,21 @@ one ticketed as #135:
 - Tightness stays ×2 (+20.8pp, second-strongest); Prior move / MA support /
   Volume / Sector stay ×1, having no ordinal basis to move (see the table below).
 
+**``Prior move`` stays ×1 despite measuring nothing** (#160/#161). It is a
+**constant dimension** — 100.0% in both the taken and the not-taken group, pooled
+spread 0.000 in findings §5b and again in §5d — so it cannot move the sort under
+any field, and ADR 0005 argues a dimension like that is retired rather than kept.
+The argument was tested standalone when ``RS line``, the candidate proposed for
+its slot, was measured and refused; it does not survive on its own. Its premise is
+that the point is *scarce*, and the ceiling here is the sum of the weights rather
+than a budget — a ninth dimension can be added without retiring the eighth, so
+retiring this one frees nothing. Against that: because it hits on every row,
+zeroing or deleting it moves the scale identically (ceiling 9 → 8, stars 0.5–4.5 →
+0.0–4.0), re-basing every frozen digest and acceptance B9 while **reordering
+nothing**, and it is the only breakdown row recording that the name cleared the
+decile gate ADR 0003 is about. So it is retired when something takes its slot, not
+before. The measurement is on the record and costs nothing to wait on.
+
 The eight dimensions and their **published** thresholds — one set serves both
 markets (spec §4.7; the eye is harsher on IDX, but that is the population, not the
 calibration; a weight *ordering* is shape not magnitude, so §8 permits it


### PR DESCRIPTION
Records the decision taken after #160 refused `RS line`, the candidate proposed for `Prior move`'s slot. **Docstring and glossary only** — no weight, threshold or behaviour change, and the weights table is byte-identical.

## Why it stays

ADR 0005 calls keeping a constant dimension *"documentation bought at the price of a point"*. That presumes the point is **scarce**, and it is not — `score.py` already says the ceiling is *"not a tunable but the sum of the weights below"*. A ninth dimension can be added without retiring the eighth, so retiring this one frees nothing that was constrained. With `RS line` in hand the premise never had to hold alone; standalone it does, and it does not.

The cost, meanwhile, is real:

| | keep ×1 (today) | `Prior move` ×0 | delete the row |
|---|---|---|---|
| Ceiling | 9 | 8 | 8 |
| Star range | 0.5–4.5 | **0.0–4.0** | **0.0–4.0** |

Because the dimension hits on every row, zeroing and deleting move the scale identically. Either re-bases every frozen digest, `HERO_MIN` and acceptance B9 — **while reordering nothing**, since a constant cannot move the sort. And it is the only breakdown row recording that the name cleared the decile gate ADR 0003 is entirely about, so retiring it before that metadata exists loses information outright.

**Retired when something takes its slot, not on the spread measurement alone.** The measurement is on the record (§5b and §5d, both 0.000) and costs nothing to wait on.

Recorded in both places a reader would start from, because the previous wording pointed the other way and the next reader would otherwise re-propose the retirement.

## Left for the author

ADR 0005's retirement limb was drafted alongside the replacement and has never been read against the no-replacement case. Flagged on #161 rather than edited here — it is a change to the ADR's reasoning, not a typo.

542 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDb7qXfLQ397vgGK9LNKmP