### PR TITLE
Separate the detector change from the retention fix, and re-pin the anchors (#165)

### DIFF
--- a/backend/replay/discrimination_grid.py
+++ b/backend/replay/discrimination_grid.py
@@ -117,11 +117,30 @@ DISCRIMINATION_STARS = 3.5
 # one is the cross-run comparison the stamp exists to prevent.
 PUBLISHED_RUBRIC = 1
 
-# The two fields, named so a cell's provenance is legible without a comment.
-# ``truncated`` is the field as it stood when §4 was measured — the sessions the
-# rank retention had already pruned contributed nothing (#164).
-FIELD_TRUNCATED = "truncated"
-FIELD_WHOLE = "whole"
+
+@dataclass(frozen=True)
+class FieldSource:
+    """One of the two fields a cell is measured against, as the rule that builds it.
+
+    ``retained_only`` is the whole difference: the truncated field is the whole
+    field restricted to the sessions the store still holds ranks for, because a
+    pruned session gated against an empty rank table and dropped every member
+    (#164). Carried as a type rather than a string so the rule travels with the
+    name — the same reason the gate's width is a
+    :class:`replay.gate_sweep.GateVariant` and not a tuple of lookbacks.
+    """
+
+    name: str
+    retained_only: bool
+
+    def keeps(self, session: date, retained: set[date]) -> bool:
+        """Whether this field carries ``session`` at all."""
+        return session in retained if self.retained_only else True
+
+
+# The field as it stood when §4 was measured, and the field as it actually was.
+FIELD_TRUNCATED = FieldSource("truncated", retained_only=True)
+FIELD_WHOLE = FieldSource("whole", retained_only=False)
 FIELD_SOURCES = (FIELD_TRUNCATED, FIELD_WHOLE)
 
 
@@ -154,7 +173,7 @@ DETECTORS: Mapping[int, DetectorSpec] = {
         version=1,
         cluster_cut=1.5,
         lookbacks=GATE_AS_MEASURED,
-        note="hard 1.5xADR cluster cut, pre-#154",
+        note="hard 1.5×ADR cluster cut, pre-#154",
     ),
     2: DetectorSpec(
         version=2,
@@ -229,7 +248,7 @@ class CellMeasurement:
     """
 
     detector: DetectorSpec
-    field_source: str
+    field_source: FieldSource
     measured_sessions: int
     sessions_with_detections: int
     field_detections: int
@@ -288,7 +307,7 @@ class CellMeasurement:
 def _cell_fields(
     swept: Sequence[SweepSession],
     spec: DetectorSpec,
-    field_source: str,
+    field_source: FieldSource,
     *,
     entries: Mapping[date, set[str]],
     stored_rank_sessions: set[date],
@@ -307,7 +326,7 @@ def _cell_fields(
     """
     out: list[FieldSession] = []
     for s in swept:
-        if field_source == FIELD_TRUNCATED and s.session not in stored_rank_sessions:
+        if not field_source.keeps(s.session, stored_rank_sessions):
             continue
         gated = variant_gate(s.membership, _gate_of(spec))
         detections = under_detector(
@@ -345,7 +364,7 @@ def _gate_of(spec: DetectorSpec) -> GateVariant:
 def measure_cell(
     swept: Sequence[SweepSession],
     spec: DetectorSpec,
-    field_source: str,
+    field_source: FieldSource,
     *,
     replayable: Sequence[ExecutedTrade],
     calendar: Sequence[date],
@@ -392,6 +411,66 @@ def measure_cell(
 
 
 @dataclass(frozen=True)
+class PrunedComparison:
+    """His picks against the field on the sessions the retention deleted.
+
+    ``sessions`` is how many measured sessions the bug emptied. The four counts are
+    the ≥3.5★ hits and the totals on those sessions alone, picks and field, so both
+    shares are checkable arithmetic on the artefact rather than a quoted percentage.
+    """
+
+    sessions: int
+    picks_at_stars: int
+    picks_total: int
+    field_at_stars: int
+    field_total: int
+
+    @property
+    def picks_share(self) -> float | None:
+        return self.picks_at_stars / self.picks_total if self.picks_total else None
+
+    @property
+    def field_share(self) -> float | None:
+        return self.field_at_stars / self.field_total if self.field_total else None
+
+    @property
+    def edge(self) -> float | None:
+        """Picks minus field on the deleted sessions, in percentage points."""
+        if self.picks_share is None or self.field_share is None:
+            return None
+        return (self.picks_share - self.field_share) * 100
+
+
+def _at_stars(dist: StarDistribution) -> int:
+    """How many scores in ``dist`` sit at or above :data:`DISCRIMINATION_STARS`."""
+    return sum(n for s, n in dist.counts.items() if s >= DISCRIMINATION_STARS)
+
+
+def pruned_comparison(
+    truncated: CellMeasurement,
+    whole: CellMeasurement,
+    version: int = PUBLISHED_RUBRIC,
+) -> PrunedComparison | None:
+    """The deleted sessions' own contribution, as the difference of two cells.
+
+    Sound because the two cells differ in exactly one thing: which sessions carry a
+    field. Their star distributions are over the same detections scored the same
+    way, so subtracting the smaller from the larger leaves the pruned sessions and
+    nothing else.
+    """
+    lo, hi = truncated.rubric(version), whole.rubric(version)
+    if lo is None or hi is None:
+        return None
+    return PrunedComparison(
+        sessions=whole.sessions_with_detections - truncated.sessions_with_detections,
+        picks_at_stars=_at_stars(hi.picks) - _at_stars(lo.picks),
+        picks_total=hi.picks.total - lo.picks.total,
+        field_at_stars=_at_stars(hi.field) - _at_stars(lo.field),
+        field_total=hi.field.total - lo.field.total,
+    )
+
+
+@dataclass(frozen=True)
 class DiscriminationGrid:
     """Every cell, plus the two one-variable steps the whole exercise is for.
 
@@ -406,7 +485,7 @@ class DiscriminationGrid:
     board_size: int
     blind_spot_count: int
 
-    def cell(self, version: int, field_source: str) -> CellMeasurement | None:
+    def cell(self, version: int, field_source: FieldSource) -> CellMeasurement | None:
         """The cell at one (detector version, field) pair, if it was measured."""
         return next(
             (
@@ -430,6 +509,22 @@ class DiscriminationGrid:
     ) -> tuple[CellMeasurement | None, CellMeasurement | None]:
         """The detector restructure alone, on the whole field."""
         return self.cell(1, FIELD_WHOLE), self.cell(2, FIELD_WHOLE)
+
+    @property
+    def deleted_sessions(self) -> "PrunedComparison | None":
+        """What the sessions the bug deleted actually held.
+
+        The retention step says the field's ≥3.5★ share moves and his picks' does
+        not; this says *why*, and it is the load-bearing half of that reading, so it
+        is measured and emitted rather than left to be derived by subtraction at
+        each retelling. Computed as the whole cell minus the truncated one at the
+        detector §4 published under — the two cells differ in nothing else, so the
+        difference is exactly the pruned sessions' own contribution.
+        """
+        before, after = self.retention_step
+        if before is None or after is None:
+            return None
+        return pruned_comparison(before, after)
 
 
 def build_grid(
@@ -533,10 +628,10 @@ def _num(value: float | None) -> str:
 
 
 def _cell_label(cell: CellMeasurement) -> str:
-    return f"detector v{cell.detector.version}, {cell.field_source} field"
+    return f"detector v{cell.detector.version}, {cell.field_source.name} field"
 
 
-def _format_cell(cell: CellMeasurement) -> list[str]:
+def _format_cell(cell: CellMeasurement, board_size: int) -> list[str]:
     """One cell in full: how much field existed, and what the pair reads on it."""
     lines = [
         f"{_cell_label(cell)}  [{cell.detector.note}]",
@@ -560,7 +655,7 @@ def _format_cell(cell: CellMeasurement) -> list[str]:
             f"  picks >= {DISCRIMINATION_STARS}* {_pct(picks)}"
             f"   field {_pct(field)}"
             f"   edge {_pp(cell.edge(scored.rubric_version))}"
-            f"   top {BOARD_SIZE} {scored.top_thirty}/{cell.placed}"
+            f"   top {board_size} {scored.top_thirty}/{cell.placed}"
         )
     return lines
 
@@ -600,13 +695,35 @@ def format_report(grid: DiscriminationGrid) -> str:
         "",
     ]
     for cell in grid.cells:
-        lines += _format_cell(cell) + [""]
+        lines += _format_cell(cell, grid.board_size) + [""]
     lines += ["== the two one-variable steps ==", ""]
     lines += _format_step("the retention fix alone (#164)", grid.retention_step) + [""]
     lines += _format_step(
         "the detector restructure alone (#154)", grid.restructure_step
-    )
+    ) + [""]
+    lines += _format_pruned(grid.deleted_sessions)
     return "\n".join(lines)
+
+
+def _format_pruned(pruned: PrunedComparison | None) -> list[str]:
+    """What the deleted sessions held — the retention step's mechanism, measured."""
+    if pruned is None:
+        return ["== what the deleted sessions held ==", "", "  not measured"]
+    return [
+        "== what the deleted sessions held ==",
+        "",
+        f"  the {pruned.sessions} sessions the retention emptied, at rubric "
+        f"v{PUBLISHED_RUBRIC}, detector v1:",
+        f"  picks >= {DISCRIMINATION_STARS}*: {pruned.picks_at_stars}"
+        f"/{pruned.picks_total} = {_pct(pruned.picks_share)}",
+        f"  field >= {DISCRIMINATION_STARS}*: {pruned.field_at_stars}"
+        f"/{pruned.field_total} = {_pct(pruned.field_share)}",
+        f"  edge on the deleted sessions: {_pp(pruned.edge)}",
+        "",
+        "  The bug deleted the sessions where the field was strongest relative to",
+        "  his picks, so cutting both sides on the same sessions still biased the",
+        "  comparison — and biased it in the rubric's favour.",
+    ]
 
 
 def _distribution_dict(dist: StarDistribution) -> dict:
@@ -620,28 +737,30 @@ def _distribution_dict(dist: StarDistribution) -> dict:
 def _cell_dict(cell: CellMeasurement) -> dict:
     picks, field = cell.discrimination()
     return {
-        "detectorVersion": cell.detector.version,
-        "detectorNote": cell.detector.note,
-        "clusterCut": cell.detector.cluster_cut,
+        "detector_version": cell.detector.version,
+        "detector_note": cell.detector.note,
+        "cluster_cut": cell.detector.cluster_cut,
         "lookbacks": list(cell.detector.lookbacks),
-        "fieldSource": cell.field_source,
-        "measuredSessions": cell.measured_sessions,
-        "sessionsWithDetections": cell.sessions_with_detections,
-        "fieldDetections": cell.field_detections,
-        "detectionsPerSession": cell.detections_per_session,
-        "detectionsPerContributingSession": cell.detections_per_contributing_session,
+        "field_source": cell.field_source.name,
+        "measured_sessions": cell.measured_sessions,
+        "sessions_with_detections": cell.sessions_with_detections,
+        "field_detections": cell.field_detections,
+        "detections_per_session": cell.detections_per_session,
+        "detections_per_contributing_session": (
+            cell.detections_per_contributing_session
+        ),
         "placed": cell.placed,
-        "inField": cell.in_field,
-        "evalFieldDetections": cell.eval_field_detections,
-        "discriminationStars": DISCRIMINATION_STARS,
-        "publishedRubric": PUBLISHED_RUBRIC,
-        "picksShare": picks,
-        "fieldShare": field,
-        "edgePp": cell.edge(),
-        "byRubric": [
+        "in_field": cell.in_field,
+        "eval_field_detections": cell.eval_field_detections,
+        "discrimination_stars": DISCRIMINATION_STARS,
+        "published_rubric": PUBLISHED_RUBRIC,
+        "picks_share": picks,
+        "field_share": field,
+        "edge_pp": cell.edge(),
+        "by_rubric": [
             {
-                "rubricVersion": r.rubric_version,
-                "topThirty": r.top_thirty,
+                "rubric_version": r.rubric_version,
+                "top_thirty": r.top_thirty,
                 "picks": _distribution_dict(r.picks),
                 "field": _distribution_dict(r.field),
             }
@@ -650,25 +769,46 @@ def _cell_dict(cell: CellMeasurement) -> dict:
     }
 
 
-def grid_to_dict(grid: DiscriminationGrid) -> dict:
-    """The machine-readable grid: every cell and both steps."""
-    def step(pair):
-        before, after = pair
-        return {
-            "before": _cell_label(before) if before else None,
-            "after": _cell_label(after) if after else None,
-            "edgeBeforePp": before.edge() if before else None,
-            "edgeAfterPp": after.edge() if after else None,
-        }
-
+def _step_dict(
+    pair: tuple[CellMeasurement | None, CellMeasurement | None],
+) -> dict:
+    """One one-variable step, as the two cells it runs between and what moved."""
+    before, after = pair
     return {
-        "boardSize": grid.board_size,
-        "blindSpotCount": grid.blind_spot_count,
+        "before": _cell_label(before) if before else None,
+        "after": _cell_label(after) if after else None,
+        "edge_before_pp": before.edge() if before else None,
+        "edge_after_pp": after.edge() if after else None,
+    }
+
+
+def _pruned_dict(pruned: PrunedComparison | None) -> dict | None:
+    """The deleted sessions' own contribution, counts first so the shares check out."""
+    if pruned is None:
+        return None
+    return {
+        "sessions": pruned.sessions,
+        "picks_at_stars": pruned.picks_at_stars,
+        "picks_total": pruned.picks_total,
+        "picks_share": pruned.picks_share,
+        "field_at_stars": pruned.field_at_stars,
+        "field_total": pruned.field_total,
+        "field_share": pruned.field_share,
+        "edge_pp": pruned.edge,
+    }
+
+
+def grid_to_dict(grid: DiscriminationGrid) -> dict:
+    """The machine-readable grid: every cell, both steps, and the deleted sessions."""
+    return {
+        "board_size": grid.board_size,
+        "blind_spot_count": grid.blind_spot_count,
         "cells": [_cell_dict(c) for c in grid.cells],
         "steps": {
-            "retentionFix": step(grid.retention_step),
-            "detectorRestructure": step(grid.restructure_step),
+            "retention_fix": _step_dict(grid.retention_step),
+            "detector_restructure": _step_dict(grid.restructure_step),
         },
+        "deleted_sessions": _pruned_dict(grid.deleted_sessions),
     }
 
 

--- a/backend/replay/discrimination_grid.py
+++ b/backend/replay/discrimination_grid.py
@@ -1,0 +1,745 @@
+"""Does the rubric discriminate his picks from the field? — re-measured with the
+detector change held apart from the retention fix (#165).
+
+§4's most consequential result is a **negative** one: his picks reach ≥3.5 stars
+**17.3%** of the time against the field's **17.8%**, so the rubric does not rank
+what he chose above what he didn't. #164 then found that the field that pair was
+measured over was **truncated** — the replayed detection pass gated on
+``Store.ranks``, which the two-year retention prunes as the chain advances, so 316
+of the 821 measured sessions contributed nothing at all. Re-scored on the whole
+field under the same rubric, the pair reads **14.6% / 12.6%** — an edge *in his
+favour* where the published pair has him fractionally behind.
+
+**Neither number corrects the other, because two variables moved between them.**
+The detector went v1 → v2 with #154 (the hard 1.5×ADR cluster cut became the
+far-outlier guard at 3.0), and the field truncation was fixed. A pair that moves
+when two things change attributes its movement to neither. #164 said so and
+flagged §4/§5's discrimination figures as pending re-derivation rather than
+restating them; this module is that re-derivation.
+
+**The grid.** The pair is re-measured at each detector version against each field,
+so exactly one variable moves between any two cells read against each other:
+
+===============  ==================  =====================================
+detector         field               what the cell is
+===============  ==================  =====================================
+v1 (pre-#154)    truncated           **as published** — reproduces 17.3/17.8
+v1 (pre-#154)    whole               **the retention fix alone**
+v2 (#154)        truncated           **the restructure alone**
+v2 (#154)        whole               fix and restructure together
+v3 (#149)        whole               the **live** detector
+===============  ==================  =====================================
+
+Four of those five cells have a committed figure to reproduce, so the grid is
+checked against the record rather than merely computed: §4's own pair and its
+104 / 14,239 counts, #158's 159 / 29,096 / 45, #164's 349 / 54,399 / 109, and
+#164's own v1-on-the-whole-field diagnostic of 242 / 27,116. The fifth is the
+first measurement of `in_field` under the width #149 adopted.
+
+**One detection pass, five cells, nothing written.** Two facts make that possible.
+
+*The v1 field is a filter on the v2 field.* :func:`screener.detection._find_cluster`
+records the identity: the restructure *added* names and moved none, so a name that
+cleared the old 1.5×ADR cut emits a byte-identical row under v2. Reconstructing
+v1's field is therefore striking every row whose trailing 3-bar range sits past
+1.5, not a second detection pass — and the reconstruction is checkable, because
+the committed store still holds the 45,600 ``detector_version = 1`` rows that pass
+emitted.
+
+*The truncated field is the whole field restricted to the retained sessions.* A
+pruned session gated against an **empty** rank table, so it dropped every member
+and contributed nothing — the truncation removed whole sessions rather than
+thinning them. The retained set is read off the store, read-only, and handed in as
+a parameter.
+
+The gate width likewise rides on the detector version rather than being read off
+:data:`~screener.detection.DETECTION_LOOKBACKS`, for the reason
+:data:`replay.gate_sweep.GATE_AS_MEASURED` sets down: a measurement whose baseline
+drifts with the constant it is arguing about cannot be re-run to audit itself.
+
+**Read-only.** Like :mod:`replay.gate_sweep`, the forward pass is reconstructed
+from the universe rows the replay store already holds with the ranks recomputed in
+memory (:func:`replay.gate_sweep.build_sweep_sessions`) — the chain's own reuse
+path with nothing written back. Nothing here touches the live store, and no live
+constant is assigned.
+
+**What the grid cannot say.** It re-measures the pair; it does not repair the
+field. The §2 survivorship hole is permanent (#129, closed won't-do), so every
+cell here is still measured against a field missing 29% of its tickers, and the
+bound §4 states rides on all of them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, Sequence
+
+from screener.detection import Detection
+from screener.store import Store
+
+from .caching_store import CachingStore
+from .chain import BURN_IN_SESSIONS, REPLAY_MARKET
+from .field import FieldSession, build_field
+from .gate_sweep import (
+    GATE_AS_MEASURED,
+    GateVariant,
+    SweepSession,
+    build_sweep_sessions,
+    variant_gate,
+)
+from .placement import (
+    BOARD_SIZE,
+    RubricStarDistributions,
+    StarDistribution,
+    build_placement_report,
+)
+from .reference import (
+    DEFAULT_BLIND_SPOT_OUT,
+    DEFAULT_REFERENCE_JSON,
+    ExecutedTrade,
+    classify,
+    load_trades,
+)
+from .study import progress_printer
+
+# The star threshold §4's pair is quoted at. The result is *about* the top of the
+# scale — the end the board actually shows — so the grid emits the share at or
+# above it rather than a histogram to be re-totalled by hand at each reading.
+DISCRIMINATION_STARS = 3.5
+
+# The rubric the published pair was measured under. Every star figure carries its
+# rubric stamp (#138); quoting a share against 17.3 / 17.8 without matching this
+# one is the cross-run comparison the stamp exists to prevent.
+PUBLISHED_RUBRIC = 1
+
+# The two fields, named so a cell's provenance is legible without a comment.
+# ``truncated`` is the field as it stood when §4 was measured — the sessions the
+# rank retention had already pruned contributed nothing (#164).
+FIELD_TRUNCATED = "truncated"
+FIELD_WHOLE = "whole"
+FIELD_SOURCES = (FIELD_TRUNCATED, FIELD_WHOLE)
+
+
+@dataclass(frozen=True)
+class DetectorSpec:
+    """One detector version as the two things that decide its **population**.
+
+    ``cluster_cut`` is the trailing-3-bar-range bound a name has to sit inside to
+    be a detection at all — 1.5 under v1's hard cut, 3.0 under v2's far-outlier
+    guard. ``lookbacks`` is the decile gate's width, which #149 moved for v3.
+
+    **Pinned per version, never read off the live constants.** Both values are
+    what the version *ran at*, so this module keeps producing the same grid after
+    a later ticket moves either one — the reproducibility discipline
+    :data:`replay.gate_sweep.GATE_AS_MEASURED` sets down. ``note`` is the ticket
+    that set the version, carried onto the report so no cell is quoted without it.
+    """
+
+    version: int
+    cluster_cut: float
+    lookbacks: tuple[str, ...]
+    note: str
+
+
+# The three stamped populations, keyed by their :data:`~screener.detection.DETECTOR_VERSION`.
+# v1 → v2 moves the cluster rule alone; v2 → v3 moves the gate alone. That is what
+# makes each pair of cells a one-variable step.
+DETECTORS: Mapping[int, DetectorSpec] = {
+    1: DetectorSpec(
+        version=1,
+        cluster_cut=1.5,
+        lookbacks=GATE_AS_MEASURED,
+        note="hard 1.5xADR cluster cut, pre-#154",
+    ),
+    2: DetectorSpec(
+        version=2,
+        cluster_cut=3.0,
+        lookbacks=GATE_AS_MEASURED,
+        note="far-outlier guard at 3.0 (#145/#154)",
+    ),
+    3: DetectorSpec(
+        version=3,
+        cluster_cut=3.0,
+        lookbacks=GATE_AS_MEASURED + ("12m",),
+        note="guard at 3.0, gate admits 12m (#149)",
+    ),
+}
+
+# The cells, in reading order: the published pair first, then the one-variable
+# step that isolates the retention fix, then the two that isolate the restructure,
+# then the live detector. Ordered rather than crossed so the report reads as the
+# argument it is making.
+GRID: tuple[tuple[int, str], ...] = (
+    (1, FIELD_TRUNCATED),
+    (1, FIELD_WHOLE),
+    (2, FIELD_TRUNCATED),
+    (2, FIELD_WHOLE),
+    (3, FIELD_WHOLE),
+)
+
+
+def under_detector(
+    detections: Iterable[Detection], spec: DetectorSpec
+) -> list[Detection]:
+    """The rows ``spec``'s detector would have emitted, out of a v2/v3 pass.
+
+    A filter, not a re-detection, and that rests on an identity rather than an
+    approximation: :func:`screener.detection._find_cluster` grades what it used to
+    gate, so a name inside the old 1.5×ADR cut keeps the same ``k``, trigger and
+    span under the guard. Striking the rows past ``cluster_cut`` therefore
+    reconstructs the older population exactly.
+
+    The gate width is applied separately (:func:`variant_gate`), because it decides
+    which members reach the detector rather than what the detector emits.
+    """
+    return [d for d in detections if d.range_3bar_adr <= spec.cluster_cut]
+
+
+def share_at_or_above(dist: StarDistribution, stars: float) -> float | None:
+    """The share of a distribution at or above ``stars`` — §4's pair, as one number.
+
+    ``None`` on an empty distribution: a share of nothing is not zero, and a cell
+    with no picks in the field must not read as a cell whose picks all scored low.
+    """
+    if dist.total == 0:
+        return None
+    return sum(n for s, n in dist.counts.items() if s >= stars) / dist.total
+
+
+@dataclass(frozen=True)
+class CellMeasurement:
+    """One cell of the grid: one detector version against one field.
+
+    ``field_detections`` is the whole field over every measured session and
+    ``eval_field_detections`` only the field on his evaluation sessions — the
+    denominator §4's field share is taken over. ``measured_sessions`` is the window
+    both fields were measured across, so ``detections_per_session`` is read against
+    the window rather than against the sessions that survived: the truncation was a
+    hole in the field, not a shorter run, and dividing by the survivors is exactly
+    how the superseded 90.3 figure came about.
+
+    ``by_rubric`` carries the picks/field distributions under every rubric version,
+    stamped, so a cell can be read against a committed pair only under the rubric
+    that pair was quoted with.
+    """
+
+    detector: DetectorSpec
+    field_source: str
+    measured_sessions: int
+    sessions_with_detections: int
+    field_detections: int
+    placed: int
+    in_field: int
+    eval_field_detections: int
+    by_rubric: list[RubricStarDistributions]
+
+    @property
+    def detections_per_session(self) -> float | None:
+        """Field volume per **measured** session — the honest per-session figure."""
+        if self.measured_sessions == 0:
+            return None
+        return self.field_detections / self.measured_sessions
+
+    @property
+    def detections_per_contributing_session(self) -> float | None:
+        """Field volume per session that contributed a field at all.
+
+        The denominator the superseded 90.3 and 201.6 were taken over — the 505
+        sessions the retention left ranks for. Carried beside the honest figure
+        rather than instead of it, so a reading of this grid can be checked against
+        findings §3b and §5d, which state that denominator explicitly, without
+        either figure being mistaken for the other.
+        """
+        if self.sessions_with_detections == 0:
+            return None
+        return self.field_detections / self.sessions_with_detections
+
+    def rubric(self, version: int) -> RubricStarDistributions | None:
+        """This cell's distributions under one rubric version, or ``None``."""
+        return next(
+            (r for r in self.by_rubric if r.rubric_version == version), None
+        )
+
+    def discrimination(
+        self, version: int = PUBLISHED_RUBRIC
+    ) -> tuple[float | None, float | None]:
+        """§4's pair under ``version``: his picks' share, then the field's."""
+        scored = self.rubric(version)
+        if scored is None:
+            return None, None
+        return (
+            share_at_or_above(scored.picks, DISCRIMINATION_STARS),
+            share_at_or_above(scored.field, DISCRIMINATION_STARS),
+        )
+
+    def edge(self, version: int = PUBLISHED_RUBRIC) -> float | None:
+        """Picks minus field at ≥3.5★, in percentage points — the sign §4 turns on."""
+        picks, field = self.discrimination(version)
+        if picks is None or field is None:
+            return None
+        return (picks - field) * 100
+
+
+def _cell_fields(
+    swept: Sequence[SweepSession],
+    spec: DetectorSpec,
+    field_source: str,
+    *,
+    entries: Mapping[date, set[str]],
+    stored_rank_sessions: set[date],
+    blind_spot_count: int,
+) -> list[FieldSession]:
+    """This cell's field, session by session.
+
+    A truncated cell skips a session the retention had pruned outright rather than
+    scoring an empty one: that is what the bug did, and an empty
+    :class:`FieldSession` would otherwise read as a session that detected nothing.
+
+    The RS-line candidate dimension is not computed here. It is never scored and
+    the star order is identical with or without it (:func:`replay.field.build_field`),
+    so supplying it would cost a second symbol's bars per session and change no
+    figure this grid reports.
+    """
+    out: list[FieldSession] = []
+    for s in swept:
+        if field_source == FIELD_TRUNCATED and s.session not in stored_rank_sessions:
+            continue
+        gated = variant_gate(s.membership, _gate_of(spec))
+        detections = under_detector(
+            [d for d in s.detections if d.symbol in gated], spec
+        )
+        entered = entries.get(s.session, set())
+        out.append(
+            FieldSession(
+                session=s.session,
+                burn_in=False,
+                members=s.members,
+                detections=build_field(
+                    detections,
+                    s.ranks,
+                    entered=entered,
+                    any_entry=bool(entered),
+                    lookbacks=spec.lookbacks,
+                ),
+                blind_spot_count=blind_spot_count,
+            )
+        )
+    return out
+
+
+def _gate_of(spec: DetectorSpec) -> GateVariant:
+    """A detector version's gate, as the sweep's own width type.
+
+    Reusing :class:`replay.gate_sweep.GateVariant` rather than re-unioning the
+    deciles here keeps one definition of "the gate at this width" in the codebase —
+    the sweep's, which runs the app's own :func:`screener.detection.detection_gate`.
+    """
+    return GateVariant(name=f"detector v{spec.version}", lookbacks=spec.lookbacks)
+
+
+def measure_cell(
+    swept: Sequence[SweepSession],
+    spec: DetectorSpec,
+    field_source: str,
+    *,
+    replayable: Sequence[ExecutedTrade],
+    calendar: Sequence[date],
+    stored_rank_sessions: set[date],
+    blind_spot_count: int,
+) -> CellMeasurement:
+    """Measure one cell: build its field, then place every replayable trade in it.
+
+    The placement is the study's own (:func:`replay.placement.build_placement_report`),
+    so a cell's `in_field`, board and star distributions are computed by the code
+    that produced the committed figures rather than by a second implementation of
+    them — which is what lets four of the five cells be checked against the record.
+    """
+    entries: dict[date, set[str]] = {}
+    for t in replayable:
+        entries.setdefault(t.entry_date, set()).add(t.ticker)
+
+    fields = _cell_fields(
+        swept,
+        spec,
+        field_source,
+        entries=entries,
+        stored_rank_sessions=stored_rank_sessions,
+        blind_spot_count=blind_spot_count,
+    )
+    placement = build_placement_report(
+        list(replayable), list(calendar), fields, blind_spot_count
+    )
+    published = next(
+        (r for r in placement.by_rubric if r.rubric_version == PUBLISHED_RUBRIC),
+        None,
+    )
+    return CellMeasurement(
+        detector=spec,
+        field_source=field_source,
+        measured_sessions=len(swept),
+        sessions_with_detections=sum(1 for f in fields if f.detections),
+        field_detections=sum(len(f.detections) for f in fields),
+        placed=len(placement.placements),
+        in_field=placement.in_field_count,
+        eval_field_detections=published.field.total if published else 0,
+        by_rubric=list(placement.by_rubric),
+    )
+
+
+@dataclass(frozen=True)
+class DiscriminationGrid:
+    """Every cell, plus the two one-variable steps the whole exercise is for.
+
+    ``retention_step`` is (v1 truncated → v1 whole): the retention fix alone, with
+    the detector held at the version §4 published under. ``restructure_step`` is
+    (v1 whole → v2 whole): the detector change alone, on the whole field. Read
+    together they decompose the move from 17.3/17.8 to 14.6/12.6 that #164 could
+    only report as confounded.
+    """
+
+    cells: list[CellMeasurement]
+    board_size: int
+    blind_spot_count: int
+
+    def cell(self, version: int, field_source: str) -> CellMeasurement | None:
+        """The cell at one (detector version, field) pair, if it was measured."""
+        return next(
+            (
+                c
+                for c in self.cells
+                if c.detector.version == version and c.field_source == field_source
+            ),
+            None,
+        )
+
+    @property
+    def retention_step(
+        self,
+    ) -> tuple[CellMeasurement | None, CellMeasurement | None]:
+        """The retention fix alone, at the detector §4 published under."""
+        return self.cell(1, FIELD_TRUNCATED), self.cell(1, FIELD_WHOLE)
+
+    @property
+    def restructure_step(
+        self,
+    ) -> tuple[CellMeasurement | None, CellMeasurement | None]:
+        """The detector restructure alone, on the whole field."""
+        return self.cell(1, FIELD_WHOLE), self.cell(2, FIELD_WHOLE)
+
+
+def build_grid(
+    swept: Sequence[SweepSession],
+    *,
+    replayable: Sequence[ExecutedTrade],
+    calendar: Sequence[date],
+    stored_rank_sessions: set[date],
+    blind_spot_count: int,
+    grid: Sequence[tuple[int, str]] = GRID,
+) -> DiscriminationGrid:
+    """Measure every cell of ``grid`` over one prepared pass."""
+    return DiscriminationGrid(
+        cells=[
+            measure_cell(
+                swept,
+                DETECTORS[version],
+                field_source,
+                replayable=replayable,
+                calendar=calendar,
+                stored_rank_sessions=stored_rank_sessions,
+                blind_spot_count=blind_spot_count,
+            )
+            for version, field_source in grid
+        ],
+        board_size=BOARD_SIZE,
+        blind_spot_count=blind_spot_count,
+    )
+
+
+def sessions_with_stored_ranks(
+    store: Store, market: str, sessions: Iterable[date]
+) -> set[date]:
+    """The measured sessions the store still holds a rank table for.
+
+    Read-only, and the whole of what "truncated" means: the replayed detection pass
+    gated on these rows, so a session absent here gated against an empty table and
+    contributed no field at all (#164). Derived from the store rather than from a
+    cutoff date, because the retention boundary is a property of the chain that ran,
+    not of the calendar.
+    """
+    return {s for s in sessions if store.ranks(market, s)}
+
+
+def run_grid(
+    store: Store,
+    market: str = REPLAY_MARKET,
+    *,
+    trades: list[ExecutedTrade],
+    blind_spot_tickers: Iterable[str] = (),
+    burn_in: int = BURN_IN_SESSIONS,
+    sessions: Sequence[date] | None = None,
+    grid: Sequence[tuple[int, str]] = GRID,
+    progress: Callable[[int, int, date], None] | None = None,
+) -> DiscriminationGrid:
+    """Run the whole #165 re-derivation over one read-only pass of the replay store.
+
+    Reconstructs the forward pass (universe from the store, ranks in memory),
+    detects once over the union of every version's gate, then derives each cell by
+    filtering that one pass. The store is never written to and no live constant is
+    assigned.
+    """
+    store = CachingStore.wrap(store)
+    classified = classify(trades, store, market=market)
+    replayable = [c.trade for c in classified if c.replayable]
+    calendar = store.sessions(market)
+    measured = list(sessions) if sessions is not None else calendar[burn_in:]
+
+    union = tuple(
+        dict.fromkeys(
+            lb for version, _ in grid for lb in DETECTORS[version].lookbacks
+        )
+    )
+    swept = build_sweep_sessions(
+        store, market, measured, lookbacks=union, progress=progress
+    )
+    blind_spots = set(blind_spot_tickers)
+    return build_grid(
+        swept,
+        replayable=replayable,
+        calendar=calendar,
+        stored_rank_sessions=sessions_with_stored_ranks(store, market, measured),
+        blind_spot_count=len(blind_spots),
+        grid=grid,
+    )
+
+
+# -- reporting ----------------------------------------------------------------
+
+
+def _pct(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.2f}%"
+
+
+def _pp(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:+.2f}pp"
+
+
+def _num(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.1f}"
+
+
+def _cell_label(cell: CellMeasurement) -> str:
+    return f"detector v{cell.detector.version}, {cell.field_source} field"
+
+
+def _format_cell(cell: CellMeasurement) -> list[str]:
+    """One cell in full: how much field existed, and what the pair reads on it."""
+    lines = [
+        f"{_cell_label(cell)}  [{cell.detector.note}]",
+        f"  gate:                 {'/'.join(cell.detector.lookbacks)}",
+        f"  sessions with a field: {cell.sessions_with_detections}"
+        f"/{cell.measured_sessions}",
+        f"  field detections:      {cell.field_detections}"
+        f"  ({_num(cell.detections_per_session)} per measured session,"
+        f" {_num(cell.detections_per_contributing_session)} per contributing one)",
+        f"  in_field:              {cell.in_field}/{cell.placed}",
+        f"  field on his eval sessions: {cell.eval_field_detections}",
+    ]
+    # Every rubric version, so the cell can be read against a committed pair under
+    # the rubric that pair was stamped with — and so the live rubric's reading of
+    # this field is on the artefact rather than only in the JSON.
+    for scored in sorted(cell.by_rubric, key=lambda r: r.rubric_version):
+        picks, field = cell.discrimination(scored.rubric_version)
+        published = " (§4's rubric)" if scored.rubric_version == PUBLISHED_RUBRIC else ""
+        lines.append(
+            f"  rubric v{scored.rubric_version}{published}:"
+            f"  picks >= {DISCRIMINATION_STARS}* {_pct(picks)}"
+            f"   field {_pct(field)}"
+            f"   edge {_pp(cell.edge(scored.rubric_version))}"
+            f"   top {BOARD_SIZE} {scored.top_thirty}/{cell.placed}"
+        )
+    return lines
+
+
+def _format_step(
+    label: str,
+    step: tuple[CellMeasurement | None, CellMeasurement | None],
+) -> list[str]:
+    """One one-variable step, stated as what it moved and by how much."""
+    before, after = step
+    if before is None or after is None:
+        return [f"{label}: not measured"]
+    return [
+        f"{label}",
+        f"  {_cell_label(before)}  ->  {_cell_label(after)}",
+        f"  picks >= {DISCRIMINATION_STARS}*: {_pct(before.discrimination()[0])}"
+        f"  ->  {_pct(after.discrimination()[0])}",
+        f"  field >= {DISCRIMINATION_STARS}*: {_pct(before.discrimination()[1])}"
+        f"  ->  {_pct(after.discrimination()[1])}",
+        f"  edge:              {_pp(before.edge())}  ->  {_pp(after.edge())}",
+        f"  field detections:  {before.field_detections}"
+        f"  ->  {after.field_detections}",
+    ]
+
+
+def format_report(grid: DiscriminationGrid) -> str:
+    """The grid, then the two one-variable steps it exists to separate."""
+    lines = [
+        "Discrimination grid — the detector change held apart from the retention "
+        "fix (#165)",
+        f"scope: US 2019-2022; blind-spot tickers missing from the field: "
+        f"{grid.blind_spot_count}",
+        f"the pair is quoted under rubric v{PUBLISHED_RUBRIC}, the rubric §4's "
+        f"17.3% / 17.8% was measured with",
+        "",
+        "== cells ==",
+        "",
+    ]
+    for cell in grid.cells:
+        lines += _format_cell(cell) + [""]
+    lines += ["== the two one-variable steps ==", ""]
+    lines += _format_step("the retention fix alone (#164)", grid.retention_step) + [""]
+    lines += _format_step(
+        "the detector restructure alone (#154)", grid.restructure_step
+    )
+    return "\n".join(lines)
+
+
+def _distribution_dict(dist: StarDistribution) -> dict:
+    return {
+        "counts": {str(star): n for star, n in sorted(dist.counts.items())},
+        "total": dist.total,
+        "share_at_or_above": share_at_or_above(dist, DISCRIMINATION_STARS),
+    }
+
+
+def _cell_dict(cell: CellMeasurement) -> dict:
+    picks, field = cell.discrimination()
+    return {
+        "detectorVersion": cell.detector.version,
+        "detectorNote": cell.detector.note,
+        "clusterCut": cell.detector.cluster_cut,
+        "lookbacks": list(cell.detector.lookbacks),
+        "fieldSource": cell.field_source,
+        "measuredSessions": cell.measured_sessions,
+        "sessionsWithDetections": cell.sessions_with_detections,
+        "fieldDetections": cell.field_detections,
+        "detectionsPerSession": cell.detections_per_session,
+        "detectionsPerContributingSession": cell.detections_per_contributing_session,
+        "placed": cell.placed,
+        "inField": cell.in_field,
+        "evalFieldDetections": cell.eval_field_detections,
+        "discriminationStars": DISCRIMINATION_STARS,
+        "publishedRubric": PUBLISHED_RUBRIC,
+        "picksShare": picks,
+        "fieldShare": field,
+        "edgePp": cell.edge(),
+        "byRubric": [
+            {
+                "rubricVersion": r.rubric_version,
+                "topThirty": r.top_thirty,
+                "picks": _distribution_dict(r.picks),
+                "field": _distribution_dict(r.field),
+            }
+            for r in cell.by_rubric
+        ],
+    }
+
+
+def grid_to_dict(grid: DiscriminationGrid) -> dict:
+    """The machine-readable grid: every cell and both steps."""
+    def step(pair):
+        before, after = pair
+        return {
+            "before": _cell_label(before) if before else None,
+            "after": _cell_label(after) if after else None,
+            "edgeBeforePp": before.edge() if before else None,
+            "edgeAfterPp": after.edge() if after else None,
+        }
+
+    return {
+        "boardSize": grid.board_size,
+        "blindSpotCount": grid.blind_spot_count,
+        "cells": [_cell_dict(c) for c in grid.cells],
+        "steps": {
+            "retentionFix": step(grid.retention_step),
+            "detectorRestructure": step(grid.restructure_step),
+        },
+    }
+
+
+def write_report(grid: DiscriminationGrid, path: str | Path) -> None:
+    """Write the human-readable grid report to ``path``."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(format_report(grid) + "\n")
+
+
+def write_results(grid: DiscriminationGrid, path: str | Path) -> None:
+    """Write the machine-readable grid to ``path`` (stable, 2-space JSON)."""
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(grid_to_dict(grid), indent=2) + "\n")
+
+
+def _grid_progress(stream) -> Callable[[int, int, date], None]:
+    """The study's throttled progress printer, bound to this run's one phase."""
+    report = progress_printer(stream)
+    return lambda i, total, session: report("grid", i, total, session)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Re-derive §4's discrimination pair with the two changes separated (#165).
+
+        python -m replay.discrimination_grid --store data/replay.duckdb \\
+            --out-report references/discrimination_grid.txt \\
+            --out-json references/discrimination_grid.json
+
+    Read-only: the pass reconstructs universe membership from the rows the replay
+    store already holds and recomputes ranks in memory, writing nothing back.
+    Progress and an ETA print to stderr while it runs.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the replay store")
+    parser.add_argument("--reference", default=str(DEFAULT_REFERENCE_JSON),
+                        help="path to the executed-trade reference JSON")
+    parser.add_argument("--blind-spots", default=str(DEFAULT_BLIND_SPOT_OUT),
+                        help="path to the committed blind-spot ticker list")
+    parser.add_argument("--market", default=REPLAY_MARKET)
+    parser.add_argument("--burn-in", type=int, default=BURN_IN_SESSIONS,
+                        help="burn-in sessions before the first measured session")
+    parser.add_argument("--out-report", default="references/discrimination_grid.txt",
+                        help="where to write the human-readable report")
+    parser.add_argument("--out-json", default="references/discrimination_grid.json",
+                        help="where to write the machine-readable results")
+    args = parser.parse_args(argv)
+
+    trades = load_trades(args.reference)
+    blind_spots = json.loads(Path(args.blind_spots).read_text())
+    store = Store.open(args.store)
+    try:
+        grid = run_grid(
+            store,
+            args.market,
+            trades=trades,
+            blind_spot_tickers=blind_spots,
+            burn_in=args.burn_in,
+            progress=_grid_progress(sys.stderr),
+        )
+    finally:
+        store.close()
+
+    write_report(grid, args.out_report)
+    write_results(grid, args.out_json)
+    print(format_report(grid))
+    print(f"\nwrote {args.out_report}")
+    print(f"wrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -2808,15 +2808,16 @@ def test_the_truncated_field_drops_every_session_the_rank_retention_pruned():
         _grid_session(pruned, ranks, {"NOW": 1.0}),
         _grid_session(retained, ranks, {"NOW": 1.0}),
     ]
-    cell = lambda source: measure_cell(
-        swept,
-        DETECTORS[2],
-        source,
-        replayable=[],
-        calendar=[pruned, retained],
-        stored_rank_sessions={retained},
-        blind_spot_count=0,
-    )
+    def cell(source):
+        return measure_cell(
+            swept,
+            DETECTORS[2],
+            source,
+            replayable=[],
+            calendar=[pruned, retained],
+            stored_rank_sessions={retained},
+            blind_spot_count=0,
+        )
 
     whole, truncated = cell(FIELD_WHOLE), cell(FIELD_TRUNCATED)
 
@@ -2844,6 +2845,57 @@ def test_the_grid_reports_the_share_at_or_above_the_published_threshold():
         StarDistribution.from_stars([4.0, 3.5, 3.0, 2.0]), DISCRIMINATION_STARS
     ) == 0.5
     assert share_at_or_above(StarDistribution.from_stars([]), 3.5) is None
+
+
+def test_the_deleted_sessions_are_measured_not_derived_by_subtraction_downstream():
+    """The retention step's *mechanism* — the field was strongest exactly where the
+    bug deleted it — is what turns "the null hardens" from an assertion into an
+    explanation, so the grid measures the deleted sessions' own contribution and
+    emits the counts. A share quoted in prose that no committed artefact carries is
+    the same unreproducible figure this whole study exists to avoid."""
+    from replay.discrimination_grid import (
+        DETECTORS,
+        FIELD_WHOLE,
+        CellMeasurement,
+        PrunedComparison,
+        pruned_comparison,
+    )
+    from replay.placement import RubricStarDistributions, StarDistribution
+
+    def cell(picks, field, sessions):
+        return CellMeasurement(
+            detector=DETECTORS[1],
+            field_source=FIELD_WHOLE,
+            measured_sessions=10,
+            sessions_with_detections=sessions,
+            field_detections=0,
+            placed=0,
+            in_field=0,
+            eval_field_detections=0,
+            by_rubric=[
+                RubricStarDistributions(
+                    rubric_version=1,
+                    picks=StarDistribution.from_stars(picks),
+                    field=StarDistribution.from_stars(field),
+                )
+            ],
+        )
+
+    # The truncated cell is a strict subset of the whole one — same detections,
+    # same scoring, fewer sessions — so the difference is the deleted sessions.
+    truncated = cell(picks=[4.0, 2.0], field=[3.5, 1.0], sessions=4)
+    whole = cell(picks=[4.0, 2.0, 2.5], field=[3.5, 1.0, 4.0, 3.5], sessions=10)
+
+    pruned = pruned_comparison(truncated, whole)
+
+    assert isinstance(pruned, PrunedComparison)
+    assert pruned.sessions == 6
+    # One extra pick, scoring below the threshold; two extra field rows, both above.
+    assert (pruned.picks_at_stars, pruned.picks_total) == (0, 1)
+    assert (pruned.field_at_stars, pruned.field_total) == (2, 2)
+    assert pruned.picks_share == 0.0
+    assert pruned.field_share == 1.0
+    assert pruned.edge == -100.0
 
 
 def test_the_grid_never_mutates_the_live_detector_constants():

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -2722,3 +2722,140 @@ def test_build_field_defaults_the_candidate_dimension_to_absent():
     # Supplying it changes neither the order nor the scores.
     assert [d.symbol for d in without] == [d.symbol for d in with_rs]
     assert [d.score for d in without] == [d.score for d in with_rs]
+
+
+# -- the discrimination grid (#165): the detector change held apart from the
+#    retention fix -----------------------------------------------------------
+#
+# §4's published pair — picks 17.3% against field 17.8% at >= 3.5 stars — was
+# measured under detector v1 on the field the two-year rank retention had
+# truncated. #164 fixed the truncation, and the same rubric on the whole field
+# reads 14.6% / 12.6%. Two variables moved between those two pairs, so neither
+# corrects the other. The grid re-measures the pair at each detector version
+# against each field, so exactly one variable moves between adjacent cells.
+
+
+def _grid_session(session: date, ranks: list[Rank], ranges: dict[str, float]):
+    """One prepared sweep session whose detections differ only in their trailing
+    3-bar range — the quantity v1's hard cut gated and v2's guard grades."""
+    from replay.gate_sweep import SweepSession, gate_membership
+
+    return SweepSession(
+        session=session,
+        members=sorted({r.symbol for r in ranks}),
+        ranks=ranks,
+        membership=gate_membership(ranks),
+        detections=[
+            dataclasses.replace(
+                _det(symbol, cluster_k=5), session=session, range_3bar_adr=r
+            )
+            for symbol, r in sorted(ranges.items())
+        ],
+    )
+
+
+def test_the_v1_field_is_the_v2_field_with_the_names_past_the_hard_cut_struck():
+    """The one identity the grid stands on (#154, ``detection._find_cluster``): the
+    restructure *added* names and moved none, so a name that cleared the old
+    1.5xADR cut emits the same row under v2 as it did under v1. Reconstructing
+    v1's field is therefore a filter on v2's, not a second detection pass."""
+    from replay.discrimination_grid import DETECTORS, under_detector
+
+    dets = [
+        dataclasses.replace(_det("TIGHT", cluster_k=5), range_3bar_adr=1.2),
+        dataclasses.replace(_det("WIDE", cluster_k=3), range_3bar_adr=2.4),
+    ]
+
+    # v1's hard cut strikes the name past 1.5; v2's far-outlier guard keeps it.
+    assert [d.symbol for d in under_detector(dets, DETECTORS[1])] == ["TIGHT"]
+    assert [d.symbol for d in under_detector(dets, DETECTORS[2])] == [
+        "TIGHT",
+        "WIDE",
+    ]
+
+
+def test_a_detector_version_carries_its_own_gate_width_not_the_live_one():
+    """The stamp is a claim about the **population**, and #149 moved that population
+    by admitting ``12m`` — so a version's lookbacks ride on the version rather than
+    being read off the live constant, whose value this grid's own reading must not
+    drift with (the discipline ``gate_sweep.GATE_AS_MEASURED`` sets)."""
+    from replay.discrimination_grid import DETECTORS
+    from replay.gate_sweep import GATE_AS_MEASURED
+
+    assert DETECTORS[1].lookbacks == GATE_AS_MEASURED
+    assert DETECTORS[2].lookbacks == GATE_AS_MEASURED
+    assert DETECTORS[3].lookbacks == ("1m", "3m", "6m", "12m")
+    # v1 and v2 differ in the cluster rule alone; v2 and v3 in the gate alone.
+    assert DETECTORS[1].cluster_cut != DETECTORS[2].cluster_cut
+    assert DETECTORS[2].cluster_cut == DETECTORS[3].cluster_cut
+
+
+def test_the_truncated_field_drops_every_session_the_rank_retention_pruned():
+    """What the bug did, reproduced as a parameter rather than as a bug: a measured
+    session outside the retained window gated against an empty rank table and
+    contributed *nothing*, so the truncated field is the whole field restricted to
+    the sessions the store still holds ranks for (#164)."""
+    from replay.discrimination_grid import (
+        DETECTORS,
+        FIELD_TRUNCATED,
+        FIELD_WHOLE,
+        measure_cell,
+    )
+
+    ranks = [Rank("NOW", "3m", percentile=0.95, raw_return=0.8)]
+    pruned, retained = date(2020, 3, 2), date(2022, 3, 2)
+    swept = [
+        _grid_session(pruned, ranks, {"NOW": 1.0}),
+        _grid_session(retained, ranks, {"NOW": 1.0}),
+    ]
+    cell = lambda source: measure_cell(
+        swept,
+        DETECTORS[2],
+        source,
+        replayable=[],
+        calendar=[pruned, retained],
+        stored_rank_sessions={retained},
+        blind_spot_count=0,
+    )
+
+    whole, truncated = cell(FIELD_WHOLE), cell(FIELD_TRUNCATED)
+
+    assert (whole.sessions_with_detections, whole.field_detections) == (2, 2)
+    assert (truncated.sessions_with_detections, truncated.field_detections) == (1, 1)
+    # Both measured the same two sessions — the truncation is in the field, not in
+    # the window, so the per-session figure is read against the window either way.
+    assert whole.measured_sessions == truncated.measured_sessions == 2
+    assert truncated.detections_per_session == 0.5
+    # Both denominators are carried: dividing by the sessions that survived is how
+    # the superseded 90.3 came about, so it is reported beside the honest figure
+    # rather than in place of it.
+    assert truncated.detections_per_contributing_session == 1.0
+
+
+def test_the_grid_reports_the_share_at_or_above_the_published_threshold():
+    """§4's pair is one number a side — the share at >= 3.5 stars — so the grid
+    emits that share rather than leaving a histogram to be re-totalled by hand at
+    each reading. An empty distribution has no share, and says so."""
+    from replay.discrimination_grid import DISCRIMINATION_STARS, share_at_or_above
+    from replay.placement import StarDistribution
+
+    assert DISCRIMINATION_STARS == 3.5
+    assert share_at_or_above(
+        StarDistribution.from_stars([4.0, 3.5, 3.0, 2.0]), DISCRIMINATION_STARS
+    ) == 0.5
+    assert share_at_or_above(StarDistribution.from_stars([]), 3.5) is None
+
+
+def test_the_grid_never_mutates_the_live_detector_constants():
+    """Read-only in the same sense the gate sweep is: every version's cluster cut
+    and gate width are handed to the filter, never assigned to the live module."""
+    from screener import detection as detection_module
+    from replay.discrimination_grid import DETECTORS, under_detector
+
+    before = (detection_module.OUTLIER_MULT, detection_module.DETECTION_LOOKBACKS)
+    for spec in DETECTORS.values():
+        under_detector([_det("AAA", cluster_k=5)], spec)
+    assert (
+        detection_module.OUTLIER_MULT,
+        detection_module.DETECTION_LOOKBACKS,
+    ) == before

--- a/docs/adr/0004-replacing-a-threshold-with-a-graded-input.md
+++ b/docs/adr/0004-replacing-a-threshold-with-a-graded-input.md
@@ -90,7 +90,11 @@ inside ADR 0001's constraint as the weights do.
   `DETECTOR_VERSION` is 2, and rows from v1 and v2 are drawn from different populations — the
   stamp exists so that comparison cannot happen silently. Findings §3's detection row, §3's
   condition table and §4's `in_field` anchor (104 → **159 of 656**) are re-pinned from the
-  2026-08-22 re-run.
+  2026-08-22 re-run. **Amended (#165, 2026-08-25):** that `in_field` pair was measured on the
+  field the two-year rank retention had truncated (#164). On the whole chain the same
+  restructure moves it **242 → 349 of 656**, and the live detector v3 reads **397 of 656**
+  (findings §4b). The 104 → 159 above is left as the record of what this ADR was decided on;
+  it is not the pin to anchor against.
 - **Work moved from the gate to the sort key.** The names the guard admits are the ones the
   graded dimension scores low, so they arrive at the bottom of the list rather than beside his
   own setups. That is only a good trade if the sort key is trusted, which is why the grade is

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -148,8 +148,9 @@ instrument that could retire it, since it is the only planned measurement outsid
 - **The contrast this rule reads must be re-run under `DETECTOR_VERSION = 2`.** §5b's published
   table — 69 taken against 14,354 not-taken — was measured under detector v1. #154's graded
   tightness grew the detector's population by **+111.3 detections per session (+123%)**, and
-  while §3's detection row and §4's `in_field` anchor were re-pinned (104 → 159 of 656), §5b
-  was not. An ordinal position assigned against the v1 table would rank a v2-measured dimension
+  while §3's detection row and §4's `in_field` anchor were re-pinned (104 → 159 of 656 — since
+  amended to 242 → **349 of 656** on the whole field, and **397** under the live detector v3;
+  #165, findings §4b), §5b was not. An ordinal position assigned against the v1 table would rank a v2-measured dimension
   among v1-measured ones, which is the field-change-versus-rubric-change confound in a new
   costume. The admission rule therefore requires the contrast to be **measured under the
   detector the dimension will ship against**.

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -372,7 +372,7 @@ before reading any new figure:
 | Median 20-day ADR at entry eve | **6.08%** | Findings §3c |
 | Blind-spot tickers / trades, 2019–2022 | **92 / 172** (of 312 / 828) | Findings §2 |
 | Trades detected by the funnel (A1 detection recall) | **549 of 656 replayable** (83.7%; gate-invariant — the funnel evaluates every stage unconditionally, so #149's width does not move it. Detector v2/v3 geometry; the superseded pin under v1's hard cluster cut was 380 of 658) | Findings §3, §3b |
-| Trades that appeared in the replayed field (A2 `in_field`) | **397 of 656 replayable** (detector v3, the live gate; measured 2026-08-25 by `replay.discrimination_grid`. Superseded pins, each measured on a narrower population: 349 of 656 at detector v2, 159 and then 104 of 656 on the field the rank retention had truncated, and 104 of 658 before #139) | Findings §4b |
+| Trades that appeared in the replayed field (A2 `in_field`) | **349 of 656** at detector v2, and **397 of 656** at detector v3 (the live gate) — **anchor against the version the run is built at**. Both measured 2026-08-25 by `replay.discrimination_grid`; the v2 figure independently reproduces #164's committed run, the v3 figure is a **first measurement** and has no second one to agree with. Superseded pins, each measured on a narrower population: 159 and then 104 of 656 on the field the rank retention had truncated, and 104 of 658 before #139 | Findings §4b |
 
 These are the same reference set through a differently-built pipeline. Matching them says the
 new pipeline computes what the old one computed; a mismatch is a bug in the new store or the
@@ -387,6 +387,13 @@ count before it was measured on a field the two-year rank retention had silently
 of the 821 sessions. All three are re-pinned above, against the live detector, and every
 superseded pin is recorded beside them. An anchor quoted from a superseded pin fails for a
 reason that has nothing to do with the pipeline it is testing.
+
+**On the `in_field` row carrying two values.** It is stamped per detector version because the
+quantity *is* per detector version — the v2 → v3 gate widening admits 48 more of his trades to
+the field without any of them changing. Quoting one against a run built at the other is the
+same error the row itself used to make. The v3 value is the one a run built today anchors on,
+and it is flagged as a first measurement so a mismatch is investigated in both directions
+rather than charged straight to the new pipeline.
 
 **The two field rows are different anchors and were once conflated.** Until #165 this table
 carried one row labelled "trades detected by the funnel" whose *value* was A2's `in_field`. They

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -224,7 +224,7 @@ detects must land *before* the denominator is built, or the run is stale on arri
 | Ticket | Relation | Land by |
 | --- | --- | --- |
 | **#139** — match a trade's bars to the listing that existed at its entry | **Landed.** The recycled-ticker rule this plan requires; it re-pinned the figures cited below: blind-spot 91 → **92** tickers, 170 → **172** trades, 18.15% → **18.0%** of R, replayable 658 → **656** | Phase 2 |
-| **#145** — Tightness as a graded rubric input | **Landed as #154.** The hard 1.5×ADR cluster cut is now a far-outlier guard at 3.0 and the rubric grades base tightness (rubric v3, detector v2). It re-pinned the detected-count anchor 104 → **159 of 656** and more than doubled the field (90.3 → **201.6** detections per session). The guard's 3.0 is **provisional on n = 10** — firming it up is a result this run is expected to produce, not an input it needs. | Phase 3 |
+| **#145** — Tightness as a graded rubric input | **Landed as #154.** The hard 1.5×ADR cluster cut is now a far-outlier guard at 3.0 and the rubric grades base tightness (rubric v3, detector v2). It re-pinned the `in_field` anchor and more than doubled the field. **Both of its figures were re-measured on the whole field by #165**, because the pair it originally quoted (104 → 159 of 656; 90.3 → 201.6 detections per session) was measured on the field the rank retention had truncated — 90.3 is exactly 45,600 ÷ the 505 sessions that survived it. On the whole 821-session chain the restructure moves `in_field` 242 → **349 of 656** and the field **83.6 → 180.5** detections per measured session (findings §4b). The guard's 3.0 is **provisional on n = 10** — firming it up is a result this run is expected to produce, not an input it needs. | Phase 3 |
 | **#149** — `DETECTION_LOOKBACKS` 3 → 5 | **Settled and landed.** 3→5 rejected; `12m` adopted alone, `1w` refused on evidence. The gate is now `("1m", "3m", "6m", "12m")` — **21.9%** of the universe, decile recall **68.3%**, detector v3. Build the denominator against **that** width (ADR 0003 amendment, findings §3e). | Phase 3 |
 | **#146**, **#147** — naming and the domain model | The run persists full `Detection` records and the write-up uses this vocabulary. Cheap now, a dead language later. | Phase 3 |
 | **#141** — price the marginal cluster widen | **Downstream, not blocking.** It falls back to field inflation because no false-positive rate exists; this backtest is what supplies one. | After |
@@ -371,7 +371,8 @@ before reading any new figure:
 | Median trailing 5-bar range at his entries | **1.86 ADR** | Findings §3b, §3c |
 | Median 20-day ADR at entry eve | **6.08%** | Findings §3c |
 | Blind-spot tickers / trades, 2019–2022 | **92 / 172** (of 312 / 828) | Findings §2 |
-| Trades detected by the funnel | **159 of 656 replayable** (re-pinned by #154's far-outlier guard, measured 2026-08-22; the superseded pins were 104 of 658, then 104 of 656 after #139) | Findings §4 |
+| Trades detected by the funnel (A1 detection recall) | **549 of 656 replayable** (83.7%; gate-invariant — the funnel evaluates every stage unconditionally, so #149's width does not move it. Detector v2/v3 geometry; the superseded pin under v1's hard cluster cut was 380 of 658) | Findings §3, §3b |
+| Trades that appeared in the replayed field (A2 `in_field`) | **397 of 656 replayable** (detector v3, the live gate; measured 2026-08-25 by `replay.discrimination_grid`. Superseded pins, each measured on a narrower population: 349 of 656 at detector v2, 159 and then 104 of 656 on the field the rank retention had truncated, and 104 of 658 before #139) | Findings §4b |
 
 These are the same reference set through a differently-built pipeline. Matching them says the
 new pipeline computes what the old one computed; a mismatch is a bug in the new store or the
@@ -379,10 +380,21 @@ new chain, and every downstream number inherits it.
 
 **Two kinds of anchor, and only one of them is stable.** The first three are geometry measured
 from his bars: they hold whatever the detector does, so they anchor the *store and the
-indicators*. The last two depend on coverage and on the gates themselves — #139 re-pins them
-to 92 / 172 / 656, and the #145 restructure moved the detected count again — both are now
-re-pinned above and the restructure has landed, so these are the pins to anchor against. An anchor quoted from a superseded pin fails for a
+indicators*. The last three depend on coverage and on the gates themselves, and have moved
+repeatedly: #139 re-pinned the coverage row to 92 / 172 / 656, #154's far-outlier guard moved
+the detected count, #149's gate width moved it again, and #164 found that every field-derived
+count before it was measured on a field the two-year rank retention had silently emptied on 316
+of the 821 sessions. All three are re-pinned above, against the live detector, and every
+superseded pin is recorded beside them. An anchor quoted from a superseded pin fails for a
 reason that has nothing to do with the pipeline it is testing.
+
+**The two field rows are different anchors and were once conflated.** Until #165 this table
+carried one row labelled "trades detected by the funnel" whose *value* was A2's `in_field`. They
+are not the same quantity and do not move together: detection recall asks whether the detector
+would have fired on his name at all and is gate-invariant, while `in_field` asks whether the name
+reached that night's field and moves with every gate and coverage change. A rebuilt pipeline
+checked against the wrong one of the two fails an anchor it should pass — which is the specific
+failure this table exists to prevent, arriving through the table itself.
 
 Anchor against **arms B and C**, whose exits match the reference set's two simulated ones.
 Arm A has no counterpart there and is measured, never anchored.

--- a/references/discrimination_grid.json
+++ b/references/discrimination_grid.json
@@ -1,34 +1,34 @@
 {
-  "boardSize": 30,
-  "blindSpotCount": 92,
+  "board_size": 30,
+  "blind_spot_count": 92,
   "cells": [
     {
-      "detectorVersion": 1,
-      "detectorNote": "hard 1.5xADR cluster cut, pre-#154",
-      "clusterCut": 1.5,
+      "detector_version": 1,
+      "detector_note": "hard 1.5\u00d7ADR cluster cut, pre-#154",
+      "cluster_cut": 1.5,
       "lookbacks": [
         "1m",
         "3m",
         "6m"
       ],
-      "fieldSource": "truncated",
-      "measuredSessions": 821,
-      "sessionsWithDetections": 505,
-      "fieldDetections": 45600,
-      "detectionsPerSession": 55.54202192448234,
-      "detectionsPerContributingSession": 90.29702970297029,
+      "field_source": "truncated",
+      "measured_sessions": 821,
+      "sessions_with_detections": 505,
+      "field_detections": 45600,
+      "detections_per_session": 55.54202192448234,
+      "detections_per_contributing_session": 90.29702970297029,
       "placed": 656,
-      "inField": 104,
-      "evalFieldDetections": 14239,
-      "discriminationStars": 3.5,
-      "publishedRubric": 1,
-      "picksShare": 0.17307692307692307,
-      "fieldShare": 0.17824285413301497,
-      "edgePp": -0.5165931056091894,
-      "byRubric": [
+      "in_field": 104,
+      "eval_field_detections": 14239,
+      "discrimination_stars": 3.5,
+      "published_rubric": 1,
+      "picks_share": 0.17307692307692307,
+      "field_share": 0.17824285413301497,
+      "edge_pp": -0.5165931056091894,
+      "by_rubric": [
         {
-          "rubricVersion": 3,
-          "topThirty": 46,
+          "rubric_version": 3,
+          "top_thirty": 46,
           "picks": {
             "counts": {
               "1.0": 1,
@@ -57,8 +57,8 @@
           }
         },
         {
-          "rubricVersion": 2,
-          "topThirty": 45,
+          "rubric_version": 2,
+          "top_thirty": 45,
           "picks": {
             "counts": {
               "0.5": 3,
@@ -89,8 +89,8 @@
           }
         },
         {
-          "rubricVersion": 1,
-          "topThirty": 41,
+          "rubric_version": 1,
+          "top_thirty": 41,
           "picks": {
             "counts": {
               "0.5": 3,
@@ -125,32 +125,32 @@
       ]
     },
     {
-      "detectorVersion": 1,
-      "detectorNote": "hard 1.5xADR cluster cut, pre-#154",
-      "clusterCut": 1.5,
+      "detector_version": 1,
+      "detector_note": "hard 1.5\u00d7ADR cluster cut, pre-#154",
+      "cluster_cut": 1.5,
       "lookbacks": [
         "1m",
         "3m",
         "6m"
       ],
-      "fieldSource": "whole",
-      "measuredSessions": 821,
-      "sessionsWithDetections": 821,
-      "fieldDetections": 68654,
-      "detectionsPerSession": 83.62241169305724,
-      "detectionsPerContributingSession": 83.62241169305724,
+      "field_source": "whole",
+      "measured_sessions": 821,
+      "sessions_with_detections": 821,
+      "field_detections": 68654,
+      "detections_per_session": 83.62241169305724,
+      "detections_per_contributing_session": 83.62241169305724,
       "placed": 656,
-      "inField": 242,
-      "evalFieldDetections": 27116,
-      "discriminationStars": 3.5,
-      "publishedRubric": 1,
-      "picksShare": 0.17355371900826447,
-      "fieldShare": 0.19811181590205046,
-      "edgePp": -2.455809689378599,
-      "byRubric": [
+      "in_field": 242,
+      "eval_field_detections": 27116,
+      "discrimination_stars": 3.5,
+      "published_rubric": 1,
+      "picks_share": 0.17355371900826447,
+      "field_share": 0.19811181590205046,
+      "edge_pp": -2.455809689378599,
+      "by_rubric": [
         {
-          "rubricVersion": 3,
-          "topThirty": 114,
+          "rubric_version": 3,
+          "top_thirty": 114,
           "picks": {
             "counts": {
               "1.0": 1,
@@ -179,8 +179,8 @@
           }
         },
         {
-          "rubricVersion": 2,
-          "topThirty": 112,
+          "rubric_version": 2,
+          "top_thirty": 112,
           "picks": {
             "counts": {
               "0.5": 3,
@@ -211,8 +211,8 @@
           }
         },
         {
-          "rubricVersion": 1,
-          "topThirty": 95,
+          "rubric_version": 1,
+          "top_thirty": 95,
           "picks": {
             "counts": {
               "0.5": 3,
@@ -247,32 +247,32 @@
       ]
     },
     {
-      "detectorVersion": 2,
-      "detectorNote": "far-outlier guard at 3.0 (#145/#154)",
-      "clusterCut": 3.0,
+      "detector_version": 2,
+      "detector_note": "far-outlier guard at 3.0 (#145/#154)",
+      "cluster_cut": 3.0,
       "lookbacks": [
         "1m",
         "3m",
         "6m"
       ],
-      "fieldSource": "truncated",
-      "measuredSessions": 821,
-      "sessionsWithDetections": 505,
-      "fieldDetections": 101790,
-      "detectionsPerSession": 123.98294762484775,
-      "detectionsPerContributingSession": 201.56435643564356,
+      "field_source": "truncated",
+      "measured_sessions": 821,
+      "sessions_with_detections": 505,
+      "field_detections": 101790,
+      "detections_per_session": 123.98294762484775,
+      "detections_per_contributing_session": 201.56435643564356,
       "placed": 656,
-      "inField": 159,
-      "evalFieldDetections": 29096,
-      "discriminationStars": 3.5,
-      "publishedRubric": 1,
-      "picksShare": 0.1320754716981132,
-      "fieldShare": 0.11063376409128403,
-      "edgePp": 2.1441707606829175,
-      "byRubric": [
+      "in_field": 159,
+      "eval_field_detections": 29096,
+      "discrimination_stars": 3.5,
+      "published_rubric": 1,
+      "picks_share": 0.1320754716981132,
+      "field_share": 0.11063376409128403,
+      "edge_pp": 2.1441707606829175,
+      "by_rubric": [
         {
-          "rubricVersion": 3,
-          "topThirty": 45,
+          "rubric_version": 3,
+          "top_thirty": 45,
           "picks": {
             "counts": {
               "1.0": 3,
@@ -302,8 +302,8 @@
           }
         },
         {
-          "rubricVersion": 2,
-          "topThirty": 43,
+          "rubric_version": 2,
+          "top_thirty": 43,
           "picks": {
             "counts": {
               "0.5": 4,
@@ -334,8 +334,8 @@
           }
         },
         {
-          "rubricVersion": 1,
-          "topThirty": 31,
+          "rubric_version": 1,
+          "top_thirty": 31,
           "picks": {
             "counts": {
               "0.5": 4,
@@ -370,32 +370,32 @@
       ]
     },
     {
-      "detectorVersion": 2,
-      "detectorNote": "far-outlier guard at 3.0 (#145/#154)",
-      "clusterCut": 3.0,
+      "detector_version": 2,
+      "detector_note": "far-outlier guard at 3.0 (#145/#154)",
+      "cluster_cut": 3.0,
       "lookbacks": [
         "1m",
         "3m",
         "6m"
       ],
-      "fieldSource": "whole",
-      "measuredSessions": 821,
-      "sessionsWithDetections": 821,
-      "fieldDetections": 148223,
-      "detectionsPerSession": 180.53958587088917,
-      "detectionsPerContributingSession": 180.53958587088917,
+      "field_source": "whole",
+      "measured_sessions": 821,
+      "sessions_with_detections": 821,
+      "field_detections": 148223,
+      "detections_per_session": 180.53958587088917,
+      "detections_per_contributing_session": 180.53958587088917,
       "placed": 656,
-      "inField": 349,
-      "evalFieldDetections": 54399,
-      "discriminationStars": 3.5,
-      "publishedRubric": 1,
-      "picksShare": 0.14613180515759314,
-      "fieldShare": 0.12593981507012997,
-      "edgePp": 2.019199008746317,
-      "byRubric": [
+      "in_field": 349,
+      "eval_field_detections": 54399,
+      "discrimination_stars": 3.5,
+      "published_rubric": 1,
+      "picks_share": 0.14613180515759314,
+      "field_share": 0.12593981507012997,
+      "edge_pp": 2.019199008746317,
+      "by_rubric": [
         {
-          "rubricVersion": 3,
-          "topThirty": 110,
+          "rubric_version": 3,
+          "top_thirty": 110,
           "picks": {
             "counts": {
               "1.0": 4,
@@ -425,8 +425,8 @@
           }
         },
         {
-          "rubricVersion": 2,
-          "topThirty": 109,
+          "rubric_version": 2,
+          "top_thirty": 109,
           "picks": {
             "counts": {
               "0.5": 5,
@@ -457,8 +457,8 @@
           }
         },
         {
-          "rubricVersion": 1,
-          "topThirty": 78,
+          "rubric_version": 1,
+          "top_thirty": 78,
           "picks": {
             "counts": {
               "0.5": 5,
@@ -493,33 +493,33 @@
       ]
     },
     {
-      "detectorVersion": 3,
-      "detectorNote": "guard at 3.0, gate admits 12m (#149)",
-      "clusterCut": 3.0,
+      "detector_version": 3,
+      "detector_note": "guard at 3.0, gate admits 12m (#149)",
+      "cluster_cut": 3.0,
       "lookbacks": [
         "1m",
         "3m",
         "6m",
         "12m"
       ],
-      "fieldSource": "whole",
-      "measuredSessions": 821,
-      "sessionsWithDetections": 821,
-      "fieldDetections": 175546,
-      "detectionsPerSession": 213.81973203410476,
-      "detectionsPerContributingSession": 213.81973203410476,
+      "field_source": "whole",
+      "measured_sessions": 821,
+      "sessions_with_detections": 821,
+      "field_detections": 175546,
+      "detections_per_session": 213.81973203410476,
+      "detections_per_contributing_session": 213.81973203410476,
       "placed": 656,
-      "inField": 397,
-      "evalFieldDetections": 64070,
-      "discriminationStars": 3.5,
-      "publishedRubric": 1,
-      "picksShare": 0.13602015113350127,
-      "fieldShare": 0.11652879662868737,
-      "edgePp": 1.94913545048139,
-      "byRubric": [
+      "in_field": 397,
+      "eval_field_detections": 64070,
+      "discrimination_stars": 3.5,
+      "published_rubric": 1,
+      "picks_share": 0.13602015113350127,
+      "field_share": 0.11652879662868737,
+      "edge_pp": 1.94913545048139,
+      "by_rubric": [
         {
-          "rubricVersion": 3,
-          "topThirty": 103,
+          "rubric_version": 3,
+          "top_thirty": 103,
           "picks": {
             "counts": {
               "1.0": 6,
@@ -549,8 +549,8 @@
           }
         },
         {
-          "rubricVersion": 2,
-          "topThirty": 111,
+          "rubric_version": 2,
+          "top_thirty": 111,
           "picks": {
             "counts": {
               "0.5": 5,
@@ -581,8 +581,8 @@
           }
         },
         {
-          "rubricVersion": 1,
-          "topThirty": 73,
+          "rubric_version": 1,
+          "top_thirty": 73,
           "picks": {
             "counts": {
               "0.5": 5,
@@ -618,17 +618,27 @@
     }
   ],
   "steps": {
-    "retentionFix": {
+    "retention_fix": {
       "before": "detector v1, truncated field",
       "after": "detector v1, whole field",
-      "edgeBeforePp": -0.5165931056091894,
-      "edgeAfterPp": -2.455809689378599
+      "edge_before_pp": -0.5165931056091894,
+      "edge_after_pp": -2.455809689378599
     },
-    "detectorRestructure": {
+    "detector_restructure": {
       "before": "detector v1, whole field",
       "after": "detector v2, whole field",
-      "edgeBeforePp": -2.455809689378599,
-      "edgeAfterPp": 2.019199008746317
+      "edge_before_pp": -2.455809689378599,
+      "edge_after_pp": 2.019199008746317
     }
+  },
+  "deleted_sessions": {
+    "sessions": 316,
+    "picks_at_stars": 24,
+    "picks_total": 138,
+    "picks_share": 0.17391304347826086,
+    "field_at_stars": 2834,
+    "field_total": 12877,
+    "field_share": 0.22008231730993244,
+    "edge_pp": -4.616927383167157
   }
 }

--- a/references/discrimination_grid.json
+++ b/references/discrimination_grid.json
@@ -1,0 +1,634 @@
+{
+  "boardSize": 30,
+  "blindSpotCount": 92,
+  "cells": [
+    {
+      "detectorVersion": 1,
+      "detectorNote": "hard 1.5xADR cluster cut, pre-#154",
+      "clusterCut": 1.5,
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m"
+      ],
+      "fieldSource": "truncated",
+      "measuredSessions": 821,
+      "sessionsWithDetections": 505,
+      "fieldDetections": 45600,
+      "detectionsPerSession": 55.54202192448234,
+      "detectionsPerContributingSession": 90.29702970297029,
+      "placed": 656,
+      "inField": 104,
+      "evalFieldDetections": 14239,
+      "discriminationStars": 3.5,
+      "publishedRubric": 1,
+      "picksShare": 0.17307692307692307,
+      "fieldShare": 0.17824285413301497,
+      "edgePp": -0.5165931056091894,
+      "byRubric": [
+        {
+          "rubricVersion": 3,
+          "topThirty": 46,
+          "picks": {
+            "counts": {
+              "1.0": 1,
+              "1.5": 6,
+              "2.0": 15,
+              "2.5": 25,
+              "3.0": 41,
+              "3.5": 12,
+              "4.0": 4
+            },
+            "total": 104,
+            "share_at_or_above": 0.15384615384615385
+          },
+          "field": {
+            "counts": {
+              "1.0": 478,
+              "1.5": 1465,
+              "2.0": 3403,
+              "2.5": 4297,
+              "3.0": 3126,
+              "3.5": 1273,
+              "4.0": 197
+            },
+            "total": 14239,
+            "share_at_or_above": 0.10323758690919306
+          }
+        },
+        {
+          "rubricVersion": 2,
+          "topThirty": 45,
+          "picks": {
+            "counts": {
+              "0.5": 3,
+              "1.0": 4,
+              "1.5": 9,
+              "2.0": 15,
+              "2.5": 36,
+              "3.0": 22,
+              "3.5": 11,
+              "4.0": 4
+            },
+            "total": 104,
+            "share_at_or_above": 0.14423076923076922
+          },
+          "field": {
+            "counts": {
+              "0.5": 396,
+              "1.0": 1132,
+              "1.5": 2649,
+              "2.0": 3259,
+              "2.5": 3014,
+              "3.0": 2531,
+              "3.5": 916,
+              "4.0": 342
+            },
+            "total": 14239,
+            "share_at_or_above": 0.0883489009059625
+          }
+        },
+        {
+          "rubricVersion": 1,
+          "topThirty": 41,
+          "picks": {
+            "counts": {
+              "0.5": 3,
+              "1.0": 6,
+              "1.5": 10,
+              "2.0": 22,
+              "2.5": 25,
+              "3.0": 20,
+              "3.5": 9,
+              "4.0": 5,
+              "4.5": 4
+            },
+            "total": 104,
+            "share_at_or_above": 0.17307692307692307
+          },
+          "field": {
+            "counts": {
+              "0.5": 312,
+              "1.0": 1511,
+              "1.5": 2129,
+              "2.0": 2394,
+              "2.5": 2533,
+              "3.0": 2822,
+              "3.5": 1165,
+              "4.0": 1049,
+              "4.5": 324
+            },
+            "total": 14239,
+            "share_at_or_above": 0.17824285413301497
+          }
+        }
+      ]
+    },
+    {
+      "detectorVersion": 1,
+      "detectorNote": "hard 1.5xADR cluster cut, pre-#154",
+      "clusterCut": 1.5,
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m"
+      ],
+      "fieldSource": "whole",
+      "measuredSessions": 821,
+      "sessionsWithDetections": 821,
+      "fieldDetections": 68654,
+      "detectionsPerSession": 83.62241169305724,
+      "detectionsPerContributingSession": 83.62241169305724,
+      "placed": 656,
+      "inField": 242,
+      "evalFieldDetections": 27116,
+      "discriminationStars": 3.5,
+      "publishedRubric": 1,
+      "picksShare": 0.17355371900826447,
+      "fieldShare": 0.19811181590205046,
+      "edgePp": -2.455809689378599,
+      "byRubric": [
+        {
+          "rubricVersion": 3,
+          "topThirty": 114,
+          "picks": {
+            "counts": {
+              "1.0": 1,
+              "1.5": 12,
+              "2.0": 33,
+              "2.5": 64,
+              "3.0": 94,
+              "3.5": 30,
+              "4.0": 8
+            },
+            "total": 242,
+            "share_at_or_above": 0.15702479338842976
+          },
+          "field": {
+            "counts": {
+              "1.0": 826,
+              "1.5": 2648,
+              "2.0": 6063,
+              "2.5": 8072,
+              "3.0": 6226,
+              "3.5": 2765,
+              "4.0": 516
+            },
+            "total": 27116,
+            "share_at_or_above": 0.12099867237055613
+          }
+        },
+        {
+          "rubricVersion": 2,
+          "topThirty": 112,
+          "picks": {
+            "counts": {
+              "0.5": 3,
+              "1.0": 7,
+              "1.5": 21,
+              "2.0": 37,
+              "2.5": 78,
+              "3.0": 64,
+              "3.5": 24,
+              "4.0": 8
+            },
+            "total": 242,
+            "share_at_or_above": 0.1322314049586777
+          },
+          "field": {
+            "counts": {
+              "0.5": 669,
+              "1.0": 2083,
+              "1.5": 4615,
+              "2.0": 6275,
+              "2.5": 5659,
+              "3.0": 5029,
+              "3.5": 1985,
+              "4.0": 801
+            },
+            "total": 27116,
+            "share_at_or_above": 0.10274376751733294
+          }
+        },
+        {
+          "rubricVersion": 1,
+          "topThirty": 95,
+          "picks": {
+            "counts": {
+              "0.5": 3,
+              "1.0": 15,
+              "1.5": 24,
+              "2.0": 49,
+              "2.5": 57,
+              "3.0": 52,
+              "3.5": 21,
+              "4.0": 14,
+              "4.5": 7
+            },
+            "total": 242,
+            "share_at_or_above": 0.17355371900826447
+          },
+          "field": {
+            "counts": {
+              "0.5": 541,
+              "1.0": 2655,
+              "1.5": 3820,
+              "2.0": 4591,
+              "2.5": 4675,
+              "3.0": 5462,
+              "3.5": 2468,
+              "4.0": 2141,
+              "4.5": 763
+            },
+            "total": 27116,
+            "share_at_or_above": 0.19811181590205046
+          }
+        }
+      ]
+    },
+    {
+      "detectorVersion": 2,
+      "detectorNote": "far-outlier guard at 3.0 (#145/#154)",
+      "clusterCut": 3.0,
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m"
+      ],
+      "fieldSource": "truncated",
+      "measuredSessions": 821,
+      "sessionsWithDetections": 505,
+      "fieldDetections": 101790,
+      "detectionsPerSession": 123.98294762484775,
+      "detectionsPerContributingSession": 201.56435643564356,
+      "placed": 656,
+      "inField": 159,
+      "evalFieldDetections": 29096,
+      "discriminationStars": 3.5,
+      "publishedRubric": 1,
+      "picksShare": 0.1320754716981132,
+      "fieldShare": 0.11063376409128403,
+      "edgePp": 2.1441707606829175,
+      "byRubric": [
+        {
+          "rubricVersion": 3,
+          "topThirty": 45,
+          "picks": {
+            "counts": {
+              "1.0": 3,
+              "1.5": 12,
+              "2.0": 29,
+              "2.5": 43,
+              "3.0": 54,
+              "3.5": 14,
+              "4.0": 4
+            },
+            "total": 159,
+            "share_at_or_above": 0.11320754716981132
+          },
+          "field": {
+            "counts": {
+              "0.5": 403,
+              "1.0": 1892,
+              "1.5": 4675,
+              "2.0": 7554,
+              "2.5": 7858,
+              "3.0": 4750,
+              "3.5": 1767,
+              "4.0": 197
+            },
+            "total": 29096,
+            "share_at_or_above": 0.06750068737970855
+          }
+        },
+        {
+          "rubricVersion": 2,
+          "topThirty": 43,
+          "picks": {
+            "counts": {
+              "0.5": 4,
+              "1.0": 6,
+              "1.5": 22,
+              "2.0": 31,
+              "2.5": 56,
+              "3.0": 25,
+              "3.5": 11,
+              "4.0": 4
+            },
+            "total": 159,
+            "share_at_or_above": 0.09433962264150944
+          },
+          "field": {
+            "counts": {
+              "0.5": 1262,
+              "1.0": 3319,
+              "1.5": 7178,
+              "2.0": 7381,
+              "2.5": 5451,
+              "3.0": 3247,
+              "3.5": 916,
+              "4.0": 342
+            },
+            "total": 29096,
+            "share_at_or_above": 0.04323618366785813
+          }
+        },
+        {
+          "rubricVersion": 1,
+          "topThirty": 31,
+          "picks": {
+            "counts": {
+              "0.5": 4,
+              "1.0": 12,
+              "1.5": 20,
+              "2.0": 35,
+              "2.5": 32,
+              "3.0": 35,
+              "3.5": 12,
+              "4.0": 5,
+              "4.5": 4
+            },
+            "total": 159,
+            "share_at_or_above": 0.1320754716981132
+          },
+          "field": {
+            "counts": {
+              "0.5": 978,
+              "1.0": 3946,
+              "1.5": 5503,
+              "2.0": 4344,
+              "2.5": 5223,
+              "3.0": 5883,
+              "3.5": 1846,
+              "4.0": 1049,
+              "4.5": 324
+            },
+            "total": 29096,
+            "share_at_or_above": 0.11063376409128403
+          }
+        }
+      ]
+    },
+    {
+      "detectorVersion": 2,
+      "detectorNote": "far-outlier guard at 3.0 (#145/#154)",
+      "clusterCut": 3.0,
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m"
+      ],
+      "fieldSource": "whole",
+      "measuredSessions": 821,
+      "sessionsWithDetections": 821,
+      "fieldDetections": 148223,
+      "detectionsPerSession": 180.53958587088917,
+      "detectionsPerContributingSession": 180.53958587088917,
+      "placed": 656,
+      "inField": 349,
+      "evalFieldDetections": 54399,
+      "discriminationStars": 3.5,
+      "publishedRubric": 1,
+      "picksShare": 0.14613180515759314,
+      "fieldShare": 0.12593981507012997,
+      "edgePp": 2.019199008746317,
+      "byRubric": [
+        {
+          "rubricVersion": 3,
+          "topThirty": 110,
+          "picks": {
+            "counts": {
+              "1.0": 4,
+              "1.5": 21,
+              "2.0": 64,
+              "2.5": 98,
+              "3.0": 116,
+              "3.5": 38,
+              "4.0": 8
+            },
+            "total": 349,
+            "share_at_or_above": 0.1318051575931232
+          },
+          "field": {
+            "counts": {
+              "0.5": 739,
+              "1.0": 3468,
+              "1.5": 8450,
+              "2.0": 13322,
+              "2.5": 14710,
+              "3.0": 9338,
+              "3.5": 3856,
+              "4.0": 516
+            },
+            "total": 54399,
+            "share_at_or_above": 0.08036912443243442
+          }
+        },
+        {
+          "rubricVersion": 2,
+          "topThirty": 109,
+          "picks": {
+            "counts": {
+              "0.5": 5,
+              "1.0": 9,
+              "1.5": 48,
+              "2.0": 72,
+              "2.5": 110,
+              "3.0": 73,
+              "3.5": 24,
+              "4.0": 8
+            },
+            "total": 349,
+            "share_at_or_above": 0.09169054441260745
+          },
+          "field": {
+            "counts": {
+              "0.5": 2261,
+              "1.0": 6139,
+              "1.5": 12565,
+              "2.0": 13794,
+              "2.5": 10272,
+              "3.0": 6582,
+              "3.5": 1985,
+              "4.0": 801
+            },
+            "total": 54399,
+            "share_at_or_above": 0.051214176731189914
+          }
+        },
+        {
+          "rubricVersion": 1,
+          "topThirty": 78,
+          "picks": {
+            "counts": {
+              "0.5": 5,
+              "1.0": 27,
+              "1.5": 47,
+              "2.0": 73,
+              "2.5": 67,
+              "3.0": 79,
+              "3.5": 30,
+              "4.0": 14,
+              "4.5": 7
+            },
+            "total": 349,
+            "share_at_or_above": 0.14613180515759314
+          },
+          "field": {
+            "counts": {
+              "0.5": 1754,
+              "1.0": 7131,
+              "1.5": 9600,
+              "2.0": 8465,
+              "2.5": 9452,
+              "3.0": 11146,
+              "3.5": 3947,
+              "4.0": 2141,
+              "4.5": 763
+            },
+            "total": 54399,
+            "share_at_or_above": 0.12593981507012997
+          }
+        }
+      ]
+    },
+    {
+      "detectorVersion": 3,
+      "detectorNote": "guard at 3.0, gate admits 12m (#149)",
+      "clusterCut": 3.0,
+      "lookbacks": [
+        "1m",
+        "3m",
+        "6m",
+        "12m"
+      ],
+      "fieldSource": "whole",
+      "measuredSessions": 821,
+      "sessionsWithDetections": 821,
+      "fieldDetections": 175546,
+      "detectionsPerSession": 213.81973203410476,
+      "detectionsPerContributingSession": 213.81973203410476,
+      "placed": 656,
+      "inField": 397,
+      "evalFieldDetections": 64070,
+      "discriminationStars": 3.5,
+      "publishedRubric": 1,
+      "picksShare": 0.13602015113350127,
+      "fieldShare": 0.11652879662868737,
+      "edgePp": 1.94913545048139,
+      "byRubric": [
+        {
+          "rubricVersion": 3,
+          "topThirty": 103,
+          "picks": {
+            "counts": {
+              "1.0": 6,
+              "1.5": 29,
+              "2.0": 80,
+              "2.5": 111,
+              "3.0": 123,
+              "3.5": 40,
+              "4.0": 8
+            },
+            "total": 397,
+            "share_at_or_above": 0.12090680100755667
+          },
+          "field": {
+            "counts": {
+              "0.5": 991,
+              "1.0": 4621,
+              "1.5": 10456,
+              "2.0": 16032,
+              "2.5": 16978,
+              "3.0": 10243,
+              "3.5": 4191,
+              "4.0": 558
+            },
+            "total": 64070,
+            "share_at_or_above": 0.07412205400343375
+          }
+        },
+        {
+          "rubricVersion": 2,
+          "topThirty": 111,
+          "picks": {
+            "counts": {
+              "0.5": 5,
+              "1.0": 14,
+              "1.5": 59,
+              "2.0": 82,
+              "2.5": 124,
+              "3.0": 79,
+              "3.5": 26,
+              "4.0": 8
+            },
+            "total": 397,
+            "share_at_or_above": 0.08564231738035265
+          },
+          "field": {
+            "counts": {
+              "0.5": 3148,
+              "1.0": 7685,
+              "1.5": 15198,
+              "2.0": 16273,
+              "2.5": 11447,
+              "3.0": 7257,
+              "3.5": 2176,
+              "4.0": 886
+            },
+            "total": 64070,
+            "share_at_or_above": 0.04779147807086
+          }
+        },
+        {
+          "rubricVersion": 1,
+          "topThirty": 73,
+          "picks": {
+            "counts": {
+              "0.5": 5,
+              "1.0": 32,
+              "1.5": 61,
+              "2.0": 82,
+              "2.5": 77,
+              "3.0": 86,
+              "3.5": 33,
+              "4.0": 14,
+              "4.5": 7
+            },
+            "total": 397,
+            "share_at_or_above": 0.13602015113350127
+          },
+          "field": {
+            "counts": {
+              "0.5": 2473,
+              "1.0": 9486,
+              "1.5": 11995,
+              "2.0": 9782,
+              "2.5": 10609,
+              "3.0": 12259,
+              "3.5": 4331,
+              "4.0": 2301,
+              "4.5": 834
+            },
+            "total": 64070,
+            "share_at_or_above": 0.11652879662868737
+          }
+        }
+      ]
+    }
+  ],
+  "steps": {
+    "retentionFix": {
+      "before": "detector v1, truncated field",
+      "after": "detector v1, whole field",
+      "edgeBeforePp": -0.5165931056091894,
+      "edgeAfterPp": -2.455809689378599
+    },
+    "detectorRestructure": {
+      "before": "detector v1, whole field",
+      "after": "detector v2, whole field",
+      "edgeBeforePp": -2.455809689378599,
+      "edgeAfterPp": 2.019199008746317
+    }
+  }
+}

--- a/references/discrimination_grid.txt
+++ b/references/discrimination_grid.txt
@@ -4,7 +4,7 @@ the pair is quoted under rubric v1, the rubric §4's 17.3% / 17.8% was measured 
 
 == cells ==
 
-detector v1, truncated field  [hard 1.5xADR cluster cut, pre-#154]
+detector v1, truncated field  [hard 1.5×ADR cluster cut, pre-#154]
   gate:                 1m/3m/6m
   sessions with a field: 505/821
   field detections:      45600  (55.5 per measured session, 90.3 per contributing one)
@@ -14,7 +14,7 @@ detector v1, truncated field  [hard 1.5xADR cluster cut, pre-#154]
   rubric v2:  picks >= 3.5* 14.42%   field 8.83%   edge +5.59pp   top 30 45/656
   rubric v3:  picks >= 3.5* 15.38%   field 10.32%   edge +5.06pp   top 30 46/656
 
-detector v1, whole field  [hard 1.5xADR cluster cut, pre-#154]
+detector v1, whole field  [hard 1.5×ADR cluster cut, pre-#154]
   gate:                 1m/3m/6m
   sessions with a field: 821/821
   field detections:      68654  (83.6 per measured session, 83.6 per contributing one)
@@ -69,3 +69,14 @@ the detector restructure alone (#154)
   field >= 3.5*: 19.81%  ->  12.59%
   edge:              -2.46pp  ->  +2.02pp
   field detections:  68654  ->  148223
+
+== what the deleted sessions held ==
+
+  the 316 sessions the retention emptied, at rubric v1, detector v1:
+  picks >= 3.5*: 24/138 = 17.39%
+  field >= 3.5*: 2834/12877 = 22.01%
+  edge on the deleted sessions: -4.62pp
+
+  The bug deleted the sessions where the field was strongest relative to
+  his picks, so cutting both sides on the same sessions still biased the
+  comparison — and biased it in the rubric's favour.

--- a/references/discrimination_grid.txt
+++ b/references/discrimination_grid.txt
@@ -1,0 +1,71 @@
+Discrimination grid — the detector change held apart from the retention fix (#165)
+scope: US 2019-2022; blind-spot tickers missing from the field: 92
+the pair is quoted under rubric v1, the rubric §4's 17.3% / 17.8% was measured with
+
+== cells ==
+
+detector v1, truncated field  [hard 1.5xADR cluster cut, pre-#154]
+  gate:                 1m/3m/6m
+  sessions with a field: 505/821
+  field detections:      45600  (55.5 per measured session, 90.3 per contributing one)
+  in_field:              104/656
+  field on his eval sessions: 14239
+  rubric v1 (§4's rubric):  picks >= 3.5* 17.31%   field 17.82%   edge -0.52pp   top 30 41/656
+  rubric v2:  picks >= 3.5* 14.42%   field 8.83%   edge +5.59pp   top 30 45/656
+  rubric v3:  picks >= 3.5* 15.38%   field 10.32%   edge +5.06pp   top 30 46/656
+
+detector v1, whole field  [hard 1.5xADR cluster cut, pre-#154]
+  gate:                 1m/3m/6m
+  sessions with a field: 821/821
+  field detections:      68654  (83.6 per measured session, 83.6 per contributing one)
+  in_field:              242/656
+  field on his eval sessions: 27116
+  rubric v1 (§4's rubric):  picks >= 3.5* 17.36%   field 19.81%   edge -2.46pp   top 30 95/656
+  rubric v2:  picks >= 3.5* 13.22%   field 10.27%   edge +2.95pp   top 30 112/656
+  rubric v3:  picks >= 3.5* 15.70%   field 12.10%   edge +3.60pp   top 30 114/656
+
+detector v2, truncated field  [far-outlier guard at 3.0 (#145/#154)]
+  gate:                 1m/3m/6m
+  sessions with a field: 505/821
+  field detections:      101790  (124.0 per measured session, 201.6 per contributing one)
+  in_field:              159/656
+  field on his eval sessions: 29096
+  rubric v1 (§4's rubric):  picks >= 3.5* 13.21%   field 11.06%   edge +2.14pp   top 30 31/656
+  rubric v2:  picks >= 3.5* 9.43%   field 4.32%   edge +5.11pp   top 30 43/656
+  rubric v3:  picks >= 3.5* 11.32%   field 6.75%   edge +4.57pp   top 30 45/656
+
+detector v2, whole field  [far-outlier guard at 3.0 (#145/#154)]
+  gate:                 1m/3m/6m
+  sessions with a field: 821/821
+  field detections:      148223  (180.5 per measured session, 180.5 per contributing one)
+  in_field:              349/656
+  field on his eval sessions: 54399
+  rubric v1 (§4's rubric):  picks >= 3.5* 14.61%   field 12.59%   edge +2.02pp   top 30 78/656
+  rubric v2:  picks >= 3.5* 9.17%   field 5.12%   edge +4.05pp   top 30 109/656
+  rubric v3:  picks >= 3.5* 13.18%   field 8.04%   edge +5.14pp   top 30 110/656
+
+detector v3, whole field  [guard at 3.0, gate admits 12m (#149)]
+  gate:                 1m/3m/6m/12m
+  sessions with a field: 821/821
+  field detections:      175546  (213.8 per measured session, 213.8 per contributing one)
+  in_field:              397/656
+  field on his eval sessions: 64070
+  rubric v1 (§4's rubric):  picks >= 3.5* 13.60%   field 11.65%   edge +1.95pp   top 30 73/656
+  rubric v2:  picks >= 3.5* 8.56%   field 4.78%   edge +3.79pp   top 30 111/656
+  rubric v3:  picks >= 3.5* 12.09%   field 7.41%   edge +4.68pp   top 30 103/656
+
+== the two one-variable steps ==
+
+the retention fix alone (#164)
+  detector v1, truncated field  ->  detector v1, whole field
+  picks >= 3.5*: 17.31%  ->  17.36%
+  field >= 3.5*: 17.82%  ->  19.81%
+  edge:              -0.52pp  ->  -2.46pp
+  field detections:  45600  ->  68654
+
+the detector restructure alone (#154)
+  detector v1, whole field  ->  detector v2, whole field
+  picks >= 3.5*: 17.36%  ->  14.61%
+  field >= 3.5*: 19.81%  ->  12.59%
+  edge:              -2.46pp  ->  +2.02pp
+  field detections:  68654  ->  148223

--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -731,17 +731,31 @@ Only **104 of 658** trades (15.8%) appeared in the app's field at all, and only
 > section were measured the same broken way and are understated too; they're left
 > as the historical record of what was believed at the time.
 >
-> **The scoring conclusion below is also in question, and hasn't been re-settled
-> here.** It compares his picks against the field on the same days, so both sides
-> were truncated together and the comparison isn't obviously broken — but the
-> percentages quoted were computed on the missing-two-thirds field. Recomputed on
-> the whole field with today's setup-finder, his picks score 3.5+ **14.6%** of the
-> time against the field's **12.6%** — a small edge *in his favour*, where the
-> published figures show him fractionally behind. Don't read that as a flip: two
-> things changed at once (the setup-finder rebuild and this fix), and untangling
-> them needs a deliberate re-run rather than the one number above. The point is
-> only that "the scoring can't tell his picks apart from anything else" now needs
-> re-checking rather than assuming.
+> **The scoring conclusion below was also in question. It has now been re-settled
+> — and it got *stronger*, not weaker.** It compares his picks against the field
+> on the same days, so both sides were truncated together and the comparison
+> wasn't obviously broken — but the percentages quoted were computed on the
+> missing-two-thirds field. Recomputed on the whole field with today's
+> setup-finder, his picks score 3.5+ **14.6%** of the time against the field's
+> **12.6%** — a small edge *in his favour*, where the published figures show him
+> fractionally behind. That looked like a flip, but two things had changed at once
+> (the setup-finder rebuild and this fix), so the number couldn't be read either
+> way.
+>
+> Those two changes have now been separated, by measuring the comparison four
+> ways — old setup-finder and new, each against the broken list and the whole one
+> (see "Untangling the two changes" below). **This fix alone doesn't help him. It
+> hurts him.** With the setup-finder held at the old version, fixing the list
+> moves his picks from 17.3% to 17.4% — no change — while the *field* moves from
+> 17.8% to **19.8%**. He goes from fractionally behind the field to clearly
+> behind it. The whole of the apparent edge came from the setup-finder rebuild,
+> not from this fix.
+>
+> The reason is that the missing days weren't a random sample. The days that got
+> deleted were the *older* two-thirds, and on those days the general population of
+> setups scored unusually well — 22.0% of them reached 3.5+, against 17.8% on the
+> days that survived. His own picks scored the same on both (17.4% vs 17.3%). So
+> the bug was quietly comparing him against the *weaker* half of the record.
 
 **The headline result was negative, and it's the study's most consequential
 finding.** Under the scoring system live at the time, his hand-picked entries
@@ -789,6 +803,47 @@ system found his picks".
 > ranking claim should be argued from it in either direction. Deliberately, **no
 > percentile or rank-position figure is ever produced** — those would look precise
 > while quietly flattering the system.
+
+### Untangling the two changes
+
+Two things moved between the published comparison and the one measured after the
+bug fix: the **setup-finder** was rebuilt (it now admits wider, less quiet bases
+instead of rejecting them), and the **list bug** was fixed. A number that moves
+when two things change tells you nothing about either. So the comparison was run
+four ways — each setup-finder against each list — plus the setup-finder live
+today. **The scoring is held at the old weights in every row**, because those are
+the weights the published 17.3 / 17.8 was measured with, and swapping them too
+would put a third moving part back into the table:
+
+| Setup-finder | List | His picks at 3.5+ | The field at 3.5+ | Gap |
+|---|---|---|---|---|
+| old | broken | 17.3% | 17.8% | **−0.5pp** (as published) |
+| old | whole | 17.4% | 19.8% | **−2.5pp** |
+| rebuilt | broken | 13.2% | 11.1% | +2.1pp |
+| rebuilt | whole | 14.6% | 12.6% | +2.0pp |
+| today's | whole | 13.6% | 11.7% | +2.0pp |
+
+Read down the first two rows and only the list changes. Read rows two and four
+and only the setup-finder changes.
+
+**The fix alone makes him look worse.** His own picks don't move at all; the
+field around him improves by two points. **The setup-finder rebuild is where the
+entire apparent edge comes from** — and it comes the same unflattering way the
+reweight did. The rebuild admits about 80,000 extra setups with wider bases, the
+old scoring marks those down, so the *field's* score collapses while his picks
+only dip. The field fell; his picks didn't rise.
+
+**So the headline negative result stands, and hardens.** On the complete record,
+scored the way it was scored when the claim was made, his hand-picked trades
+reach the top of the scale **less** often than the general population they came
+from — 17.4% against 19.8%. Nothing here lets "the scoring can't tell his picks
+apart" be dismissed as an artefact of the bug.
+
+**What today's app actually scores.** With today's setup-finder and today's
+weights, on the whole list: his picks 12.1%, the field 7.4% — a gap of +4.7pp,
+with 103 of his 656 trades landing inside the top 30. That's the honest current
+number, and it carries all three caveats above with it: it's circular, it's
+in-sample, and 29% of the field is still missing.
 
 ---
 

--- a/references/qullamaggie-replay-findings-plain.md
+++ b/references/qullamaggie-replay-findings-plain.md
@@ -753,9 +753,10 @@ Only **104 of 658** trades (15.8%) appeared in the app's field at all, and only
 >
 > The reason is that the missing days weren't a random sample. The days that got
 > deleted were the *older* two-thirds, and on those days the general population of
-> setups scored unusually well — 22.0% of them reached 3.5+, against 17.8% on the
-> days that survived. His own picks scored the same on both (17.4% vs 17.3%). So
-> the bug was quietly comparing him against the *weaker* half of the record.
+> setups scored unusually well — 2,834 of 12,877, or **22.0%**, reached 3.5+,
+> against 17.8% on the days that survived. His own picks scored the same on both
+> (24 of 138, or 17.4%, against 17.3%). So the bug was quietly comparing him
+> against the *weaker* half of the record.
 
 **The headline result was negative, and it's the study's most consequential
 finding.** Under the scoring system live at the time, his hand-picked entries

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -1409,13 +1409,18 @@ detection pass by filtering it. Two identities make that sound rather than conve
 
 ### The grid — all rubric v1, the rubric §4's pair was published under
 
-| Detector | Field | `in_field` | Field, his eval sessions | Picks ≥3.5★ | Field ≥3.5★ | Gap |
-| --- | --- | --- | --- | --- | --- | --- |
-| v1 | truncated | 104/656 | 14,239 | 17.31% | 17.82% | **−0.52pp** (as published) |
-| v1 | whole | 242/656 | 27,116 | 17.36% | 19.81% | **−2.46pp** |
-| v2 | truncated | 159/656 | 29,096 | 13.21% | 11.06% | +2.14pp |
-| v2 | whole | 349/656 | 54,399 | 14.61% | 12.59% | +2.02pp |
-| v3 (live) | whole | 397/656 | 64,070 | 13.60% | 11.65% | +1.95pp |
+| Detector | Field | `in_field` | Field, his eval sessions | Detections / measured session | Picks ≥3.5★ | Field ≥3.5★ | Gap |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| v1 | truncated | 104/656 | 14,239 | 55.5 (90.3 per contributing) | 17.31% | 17.82% | **−0.52pp** (as published) |
+| v1 | whole | 242/656 | 27,116 | **83.6** | 17.36% | 19.81% | **−2.46pp** |
+| v2 | truncated | 159/656 | 29,096 | 124.0 (201.6 per contributing) | 13.21% | 11.06% | +2.14pp |
+| v2 | whole | 349/656 | 54,399 | **180.5** | 14.61% | 12.59% | +2.02pp |
+| v3 (live) | whole | 397/656 | 64,070 | 213.8 | 13.60% | 11.65% | +1.95pp |
+
+The per-session column carries both denominators, because the superseded 90.3 and 201.6 were
+taken over the 505 sessions that survived the retention rather than the 821 measured — the two
+truncated rows reproduce them exactly on that denominator, which is what identifies the
+superseded figures as arithmetic on a partial field rather than a different measurement.
 
 **The grid is checked against the record, not merely computed.** Four of the five cells have a
 committed figure to reproduce and every one of them reproduces to the digit: §4's own
@@ -1431,15 +1436,20 @@ first measurement of `in_field` under the width #149 adopted.
 picks do not move (+0.05pp); the **field's** share rises by 1.99pp. The gap goes from −0.52pp to
 **−2.46pp**.
 
-The mechanism is in *which* sessions were missing, and it is measurable directly. Retention
-pruned the older 316 sessions (2019-09-30 to 2020-12-29), and on those sessions alone the field
-reaches ≥3.5★ **22.01%** of the time (2,834 of 12,877) while his picks on them reach it
-**17.39%** (24 of 138). On the 505 retained sessions the two are 17.82% and 17.31%. So the
-population he was being compared against was **materially stronger on the sessions the bug
-deleted**, and his own picks were not — which is why cutting both sides on the same sessions
-still biased the comparison, and biased it in the rubric's favour. §4 was right to note that both
-sides were truncated together; that is not sufficient for the comparison to survive, and here it
-did not.
+The mechanism is in *which* sessions were missing, and the grid measures it rather than leaving
+it to be inferred — the **"what the deleted sessions held"** block of
+`references/discrimination_grid.txt` reports it with its counts:
+
+| On the 316 sessions the retention emptied | ≥3.5★ | Total | Share |
+| --- | --- | --- | --- |
+| His picks | 24 | 138 | **17.39%** |
+| The field | 2,834 | 12,877 | **22.01%** |
+
+On the 505 retained sessions the same two shares are 17.31% and 17.82%. So the population he
+was being compared against was **materially stronger on the sessions the bug deleted**, and his
+own picks were not. That is why cutting both sides on the same sessions still biased the
+comparison, and biased it in the rubric's favour. §4 was right that both sides were truncated
+together; that is not sufficient for the comparison to survive, and here it did not.
 
 **The detector restructure alone — on the whole field.** −2.46pp → **+2.02pp**. The whole of the
 edge #164 flagged is this step. It is also the mechanism §4a already named, arriving through the

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -576,6 +576,12 @@ store holds ranks for):
 | `cluster` misses | 171 | **2** | −169 |
 | Detections per session | 90.3 | **201.6** | **+111.3 (+123.2%)** |
 
+**That last row's denominator is the 505 sessions, not the 821.** It is correct as stated and is
+left as measured — but #164 later found those were the only sessions carrying a field at all, so
+quoting 90.3 or 201.6 against a whole-chain figure compares two different denominators. On the
+whole chain the same step is **83.6 → 180.5** detections per measured session (§4b), which
+reproduces both figures above exactly when re-divided by the 505.
+
 **The population cost is the headline, not the recall.** The field more than doubles: 111 more
 names per session, or **0.66 additional names per session for each trade recovered**. That is a
 large number and it is the honest denominator — precision cannot be measured, so this ratio is what
@@ -1162,19 +1168,15 @@ across the fix. §4's historical rubric-stamped tables are left alone — they a
 what each rubric did to the field as it then stood. What changes is any figure describing how
 much of the field existed, and every one of those is restated above.
 
-**One thing this leaves open, flagged rather than answered.** The discrimination result —
-"the rubric does not discriminate his picks from the field", **17.3% vs 17.8%** at ≥3.5★ — is
-computed over this same field, on his picks against the field *on the same sessions*. Both
-sides were truncated together, so the comparison is not obviously invalid, but its published
-rates were measured on the truncated field and are not restated by this ticket. One data
-point says re-deriving them is not a formality: recomputed under **rubric v1 on the whole
-field**, the run above gives picks **14.6%** against field **12.6%** — a +2.0pp edge where
-the published pair shows −0.5pp. That figure is **not** a correction of 17.3/17.8, because two
-changes are confounded in it: the detector moved v1 → v2 with #154, and the field truncation
-was fixed here. Separating them needs a deliberate paired re-run of the kind §4a already does
-for rubric changes. Until then, §4's and §5's discrimination figures should be read as
-pending re-derivation rather than as settled — and the same caution applies to §6's
-"real but modest against A2's 17.3% / 17.8% gap".
+**One thing this left open, and #165 closed.** The discrimination result — "the rubric does
+not discriminate his picks from the field", **17.3% vs 17.8%** at ≥3.5★ — is computed over
+this same field. Recomputed under rubric v1 on the whole field the run above gives **14.6%**
+against **12.6%**, a +2.0pp edge where the published pair shows −0.5pp — but two changes are
+confounded in that figure (the detector moved v1 → v2 with #154, and the truncation was fixed
+here), so it corrects nothing. #164 marked §4/§5's discrimination figures pending rather than
+restating them. **§4b separates the two changes and restates them**, and the answer is not the
+one the confounded figure suggested: with the detector held at v1, the fix moves the pair to
+**17.4% / 19.8%**, a gap of **−2.46pp**. §4's null hardens on the whole field.
 
 Star distribution of his picks against the replayed field, on the same sessions:
 
@@ -1193,9 +1195,11 @@ Star distribution of his picks against the replayed field, on the same sessions:
 
 ### The rubric does not discriminate his picks from the field
 
-**Picks at ≥3.5 stars: 17.3%. Field at ≥3.5 stars: 17.8%.** (Rubric v1. Under the live v2
-rubric, on this same field, the gap opens to +5.6pp — §4a, which is where this conclusion is
-revised.)
+**Picks at ≥3.5 stars: 17.3%. Field at ≥3.5 stars: 17.8%.** (Rubric v1, on the **truncated**
+field — the pair as published. Under the live v2 rubric, on this same field, the gap opens to
++5.6pp — §4a, which is where this conclusion is revised. On the **whole** field with the
+detector held at v1, the pair is **17.4% / 19.8%** and the gap widens to −2.46pp — §4b, which
+is where the truncation is taken out of it.)
 
 His real, high-conviction, hand-picked entries land in the top of the star scale at
 essentially **the same rate as the general population of detections they were drawn
@@ -1373,6 +1377,109 @@ _Reproduce: `python -m replay.study --store data/replay.duckdb`, which writes
 `references/replay_study_report.txt` and `references/replay_study_results.json` — both committed
 beside this document. The store's derived tables must be empty; bars are the only input a chain
 reads (write-once rows from an earlier pass are read back, not recomputed)._
+
+---
+
+## 4b. The discrimination pair, with the two changes separated (#165)
+
+**Question.** §4's pair — picks **17.3%** against field **17.8%** at ≥3.5★ — was measured under
+detector v1 on the field the rank retention had truncated. #164 fixed the truncation and
+reported that the same rubric on the whole field reads **14.6% / 12.6%**, an edge *in his
+favour* where the published pair has him fractionally behind. It also said, correctly, that the
+figure corrects nothing: the detector had moved v1 → v2 with #154 in the same interval, so two
+variables moved between the two pairs and the movement is attributable to neither. This is the
+re-derivation that separates them.
+
+**Method.** The pair is re-measured at each detector version against each field, so exactly one
+variable moves between any two cells read against each other. One read-only pass reconstructs
+the forward chain from the universe rows the store holds with the ranks recomputed in memory —
+`replay.gate_sweep`'s own path, nothing written back — and every cell is derived from that one
+detection pass by filtering it. Two identities make that sound rather than convenient:
+
+- **v1's field is a filter on v2's.** `detection._find_cluster` records it: the restructure
+  grades what it used to gate, so a name inside the old 1.5×ADR cut keeps the same `k`, trigger
+  and span under the guard. Striking the rows past 1.5 reconstructs the older population
+  exactly, and the reconstruction is checkable — the committed store still holds the 45,600
+  `detector_version = 1` rows that pass emitted, and the v1/truncated cell reproduces that count
+  **to the row**.
+- **The truncated field is the whole field restricted to the retained sessions.** A pruned
+  session gated against an empty rank table, so it dropped every member: the truncation removed
+  whole sessions rather than thinning them. The retained set is read off the store's own `ranks`
+  table (505 sessions, 2020-12-30..2022-12-30) and handed in as a parameter.
+
+### The grid — all rubric v1, the rubric §4's pair was published under
+
+| Detector | Field | `in_field` | Field, his eval sessions | Picks ≥3.5★ | Field ≥3.5★ | Gap |
+| --- | --- | --- | --- | --- | --- | --- |
+| v1 | truncated | 104/656 | 14,239 | 17.31% | 17.82% | **−0.52pp** (as published) |
+| v1 | whole | 242/656 | 27,116 | 17.36% | 19.81% | **−2.46pp** |
+| v2 | truncated | 159/656 | 29,096 | 13.21% | 11.06% | +2.14pp |
+| v2 | whole | 349/656 | 54,399 | 14.61% | 12.59% | +2.02pp |
+| v3 (live) | whole | 397/656 | 64,070 | 13.60% | 11.65% | +1.95pp |
+
+**The grid is checked against the record, not merely computed.** Four of the five cells have a
+committed figure to reproduce and every one of them reproduces to the digit: §4's own
+104 / 14,239 / 17.31 / 17.82 and its board hit of 41; §4a's inset block for the v2 truncated
+field (159 / 29,096, and 13.21 / 11.06, 9.43 / 4.32, 11.32 / 6.75 across the three rubrics, with
+31 / 43 / 45 on the board); #164's 349 / 54,399 and the committed report's rubric-v1 board hit of
+78; and #164's own v1-on-the-whole-field diagnostic of **242 / 27,116**. The fifth cell is the
+first measurement of `in_field` under the width #149 adopted.
+
+### The two one-variable steps
+
+**The retention fix alone — detector held at v1.** 17.31% / 17.82% → **17.36% / 19.81%**. His
+picks do not move (+0.05pp); the **field's** share rises by 1.99pp. The gap goes from −0.52pp to
+**−2.46pp**.
+
+The mechanism is in *which* sessions were missing, and it is measurable directly. Retention
+pruned the older 316 sessions (2019-09-30 to 2020-12-29), and on those sessions alone the field
+reaches ≥3.5★ **22.01%** of the time (2,834 of 12,877) while his picks on them reach it
+**17.39%** (24 of 138). On the 505 retained sessions the two are 17.82% and 17.31%. So the
+population he was being compared against was **materially stronger on the sessions the bug
+deleted**, and his own picks were not — which is why cutting both sides on the same sessions
+still biased the comparison, and biased it in the rubric's favour. §4 was right to note that both
+sides were truncated together; that is not sufficient for the comparison to survive, and here it
+did not.
+
+**The detector restructure alone — on the whole field.** −2.46pp → **+2.02pp**. The whole of the
+edge #164 flagged is this step. It is also the mechanism §4a already named, arriving through the
+detector rather than through the weights: the far-outlier guard admits ~80,000 detections whose
+3-bar range sits past 1.5×ADR, rubric v1 scores `Tightness` off `cluster_k >= 5` and those names
+miss it, so the field's ≥3.5★ share falls from 19.81% to 12.59% while his picks fall less
+(17.36% → 14.61%). **The field fell; his picks did not rise** — the same sentence §4a wrote about
+the reweight.
+
+### Verdict — §4's null stands, and hardens
+
+**The negative result is not weakened by the retention fix; it is strengthened.** On the whole
+field, under the rubric and detector §4 published with, his hand-picked entries reach ≥3.5★
+**less** often than the population they were drawn from — 17.4% against 19.8%, a gap two and a
+half times the published one and in the same (unfavourable) direction. Nothing in this grid
+supports reading §4's null as an artefact of the truncation.
+
+**§4a's verdict — weakened, not reversed — survives the fix and is left standing.** Its claim is
+about a *rubric* change on a fixed field, and it reproduces on the whole field in both directions:
+on the v1 whole field the pair moves −2.46pp (v1) → +2.95pp (v2) → +3.60pp (v3), and on the v2
+whole field +2.02pp → +4.05pp → **+5.14pp**. The three reasons §4a gives for refusing to read that
+as validation are untouched by this ticket: it is in-sample and close to circular, it was marginal
+where it was tested, and the coverage hole is permanent.
+
+**What the live pair reads.** On the live detector (v3) and the live rubric (v3), on the whole
+field: picks **12.09%**, field **7.41%**, gap **+4.68pp**, with **103 of 656** inside the board.
+That is the pair to quote for the app as it stands today — and it carries §4a's three reasons
+with it, because it is the same in-sample rubric measured on the same incomplete field.
+
+**Coverage is unchanged and still bounds all of it.** 92 blind-spot tickers / 172 trades / 18.0%
+of realised R (§2). The fix restored sessions, never tickers; #129 is closed won't-do and the
+29% hole is permanent. Every cell above is measured against a field missing it.
+
+_Reproduce: `python -m replay.discrimination_grid --store data/replay.duckdb`, which writes
+`references/discrimination_grid.txt` and `references/discrimination_grid.json` — both committed
+beside this document. Read-only: it reconstructs the forward pass from the universe rows the
+store already holds and writes nothing back, so it runs against a built store in about four
+minutes and leaves it re-runnable. Every detector version's cluster cut and gate width are
+pinned in the module rather than read off the live constants, so it reproduces after a later
+ticket moves either._
 
 ---
 
@@ -1556,13 +1663,17 @@ is needed:
 
 The swap moves his picks **~0.19 stars more than the field** — the first quantified statement
 that a rubric change pushes in the direction A2 (§4) says the current rubric does not. It is
-real but modest against A2's 17.3% / 17.8% gap, and says nothing about whether the **3.5★
+real but modest against A2's 17.3% / 17.8% gap — **−2.46pp once the truncation is out of it**
+(§4b), which makes the gap the reweight is pushing against wider than this paragraph assumed,
+not narrower — and says nothing about whether the **3.5★
 share** moves, which depends on the joint distribution around the boundary. The numbers above
 are the computed expectation; the **measured** paired A2 re-run is **§4a**, and it confirms them
 — measured picks-minus-field shift **+0.196 stars** against the +0.19 predicted here, agreeing
 to about a hundredth of a star. The 3.5★
 share this paragraph declined to predict was also measured there, and it moves: **17.3% / 17.8%
-under v1 → 14.4% / 8.8% under v2 on the same field**.
+under v1 → 14.4% / 8.8% under v2 on the same field**. That pair is stamped to the *truncated*
+field; on the whole field the same rubric step reads **17.4% / 19.8% → 13.2% / 10.3%**, so the
+reweight's direction survives the fix (§4b).
 
 **#136 — the paired re-run is now wired, and separates the two variables by construction.**
 The obstacle #136 was written against — "re-run A2 and risk moving the field *and* the rubric
@@ -2083,6 +2194,23 @@ It baselines against the three-lookback width explicitly rather than reading
 `DETECTION_LOOKBACKS`, so it reproduces byte-for-byte after its own verdict moved that
 constant.
 
+**The discrimination grid is separate and read-only too** (§4b, #165), and stands on the same
+reconstruction for the same reason — it needs five fields over one chain, and rebuilding the
+chain five times to get them is half a day for a measurement that is four minutes of filtering.
+It runs the detector once over the union of every version's gate and derives each cell from that
+one pass:
+
+```
+python -m replay.discrimination_grid --store data/replay.duckdb \
+    --out-report references/discrimination_grid.txt \
+    --out-json   references/discrimination_grid.json
+```
+
+Like the sweep, every detector version's cluster cut and gate width are pinned in the module
+rather than read off `OUTLIER_MULT` and `DETECTION_LOOKBACKS`, so it keeps producing the same
+grid after a later ticket moves either — and unlike a re-run of `replay.study`, it works on the
+committed store as it stands, because it writes nothing and so never meets the write-once guard.
+
 **Runtime.** The chain is 947 sessions (126 burn-in + 821 measured) and dominates: on the
 2026-08-15 run the whole study took **29.8 minutes**, of which the chain was 29.1 and the
 per-session detection pass that builds the field added 0.6. Treat it as an order of
@@ -2104,8 +2232,13 @@ _Provenance: PRD #114; A1 funnel #116/#119; A2 chain/field/placement #117/#118/#
 outcome regression #121; A3 selection contrast #122; this write-up #123. Analysis code:
 `backend/replay/`. Row-level seam: `backend/tests/test_replay_seam.py`. Decile decomposition
 #133; cluster characterisation #132; recalibration #138; paired A2 re-run #136; the tightness
-restructure #145/#154. Study last run **2026-08-22**, on detector v2 and rubric v3 — the run that
-re-pinned §3's detection row, §3's condition table and §4's `in_field` anchor. The
+restructure #145/#154; the discrimination grid #165. Study last run **2026-08-22**, on detector
+v2 and rubric v3 — the run that re-pinned §3's detection row, §3's condition table and §4's
+`in_field` anchor. **§4b's grid is newer than that run** (`replay.discrimination_grid`,
+2026-08-25, read-only over the same store): it carries the only figures measured under the live
+detector v3, so §4's `in_field` anchor is pinned from §4b and not from the 2026-08-22 report.
+Anything else in this document stamped detector v2 is awaiting the next full `replay.study` run
+and says so where it matters. The
 recall-and-inflation ledger in §3b is a side-car, `scripts/base_tightness_restructure.py`, run against
 the same store and outside `replay.study`. The survivorship hole closed won't-do as #129._
 


### PR DESCRIPTION
Closes #165.

## The load-bearing fix

The backtest plan's anchor table carried **"trades detected by the funnel: 159 of 656"** — a row whose stated purpose is that *"a mismatch is a bug in the new store or the new chain"*. A correctly rebuilt pipeline would have failed its own anchor check. The label was wrong independently of the value: "detected by the funnel" is A1's detection recall, while 159 was A2's `in_field`.

Both are now separate, correctly-labelled rows: detection recall **549 of 656** (gate-invariant), and `in_field` **349 of 656** at detector v2 / **397 of 656** at detector v3, anchored against whichever version the run is built at, with every superseded pin recorded beside them.

## The re-derivation (§4b)

#164 flagged §4's discrimination pair as pending because two variables had moved in it: the detector went v1 → v2 (#154) and the field truncation was fixed. `replay.discrimination_grid` separates them — five cells, one read-only detection pass, nothing written back.

It needs one pass rather than five chain rebuilds because of two identities: v1's field is v2's field with the rows past 1.5×ADR struck (`_find_cluster` grades what it used to gate), and the truncated field is the whole field restricted to the sessions the store still holds ranks for.

**Four of the five cells reproduce a committed figure to the digit** — §4's 104 / 14,239 / 17.31 / 17.82, §4a's whole inset block, #164's 349 / 54,399, and #164's own v1-on-the-whole-field diagnostic of 242 / 27,116.

## The answer is not what the confounded number suggested

| Step | Picks ≥3.5★ | Field ≥3.5★ | Gap |
| --- | --- | --- | --- |
| as published (v1, truncated) | 17.31% | 17.82% | −0.52pp |
| **the retention fix alone** (v1, whole) | 17.36% | 19.81% | **−2.46pp** |
| the detector restructure alone (v2, whole) | 14.61% | 12.59% | +2.02pp |

**§4's null hardens.** His picks do not move; the field's share rises 2pp. The whole of the +2.0pp "edge in his favour" is the detector restructure, arriving the way §4a already described — the field falls further than his picks do.

The bug's bias is measured, not asserted: on the 316 deleted sessions the field reached ≥3.5★ **2,834 of 12,877 (22.01%)** against his picks' **24 of 138 (17.39%)**. Both sides were cut on the same sessions, and it was still not enough — the deleted sessions were where the population was strongest relative to him.

## Constraints

`OUTLIER_MULT` untouched and unswept (ADR 0004). No live constant read or assigned — every version's cluster cut and gate width is pinned in the module, with a test asserting no mutation. The committed store is never written to, so §10's write-once guard is respected. Historical rubric-stamped tables left standing; §4a left standing with its reason.

Both review axes ran and their findings are addressed in the second commit. 548 tests pass; every figure asserted across the four documents is verified against the committed artefact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KThtKhsJX6Aq1mL9er9At1