### PR TITLE
Pre-register `Relative move`, the second candidate dimension (#170)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -247,9 +247,11 @@ A dimension **under measurement**, not in the rubric: computed on every detectio
 replay, carried beside the star score, reported as a column of the **selection contrast**, and
 weighted by nothing. It is how ADR 0005's admission rule is exercised — a dimension earns a
 rubric slot on a measured non-zero gap with non-zero pooled spread, and until that measurement
-exists it must be unable to move a star, a sort or a board place. So it lives on the field
-member (`replay.field.ScoredDetection.rs_line`), never inside `SevenDimScore`, and nothing in
-`screener` scores it. **Pre-registered as one variant, pass or fail** — trying several and
+exists it must be unable to move a star, a sort or a board place. So it lives on a field member
+of its own (`RS line` on `replay.field.ScoredDetection.rs_line`), never inside `SevenDimScore`,
+and nothing in `screener` scores it. Two are registered — `RS line`, measured and rejected, and
+**Relative move**, whose definition exists but whose contrast (#171) has not been run, so it has
+no field member yet. **Pre-registered as one variant, pass or fail** — trying several and
 keeping the largest gap is magnitude-fitting (#128 Q2). A candidate that fails leaves its
 measurement behind and takes its wiring with it.
 _Avoid_: experimental dimension, provisional dimension (a **graded dimension** is live; this
@@ -268,7 +270,7 @@ was proposed for is still open, and **Relative move** is the second candidate fo
 
 **Relative move**:
 The `6m` return **relative to `MARKET_INDEX`**, compounded — `(1 + stock) / (1 + index) − 1` —
-divided by the name's own `ADR`. Hit when it is above zero: the name outran the index over six
+divided by the name's own `ADR`, taken at the session being scored and never past it. Hit when it is above zero: the name outran the index over six
 months. The second **candidate dimension** (#170), **pre-registered and not yet measured**;
 #171 runs the contrast that can judge it. Both legs read `calendar_return`, so the anchor is
 calendar-dated and resolves to the last bar on or before it, and a missing leg is **absent**,
@@ -277,7 +279,8 @@ scoring `False` and never carried forward. Named apart from `Prior move` on purp
 quantities. The cut sits at zero, which makes the boolean ADR-invariant; the units are there
 for the *value* a row would carry, so a later grading question can be asked without re-scoring
 history.
-_Avoid_: relative strength, RS (that is the rejected **RS line**), outperformance.
+_Avoid_: RS, outperformance. "Relative strength" names the *module* both candidates live
+in (`screener.relative_strength`) and nothing narrower — never the dimension.
 
 **Rubric version**:
 The stamp identifying which weights and mappings produced a star score (`score.RUBRIC_VERSION`,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -264,7 +264,20 @@ could only ever be computed in a caller (`screener.relative_strength`), never in
 The first **candidate dimension**, and **rejected** (findings §5d, #160): Δ −2.1pp, a wrong-way
 gap, on 11.2% disagreement with the break test it nearly restates. The live app does not
 compute it — only the replay and the study script do, so §5d stays reproducible. The slot it
-was proposed for is still open.
+was proposed for is still open, and **Relative move** is the second candidate for it.
+
+**Relative move**:
+The `6m` return **relative to `MARKET_INDEX`**, compounded — `(1 + stock) / (1 + index) − 1` —
+divided by the name's own `ADR`. Hit when it is above zero: the name outran the index over six
+months. The second **candidate dimension** (#170), **pre-registered and not yet measured**;
+#171 runs the contrast that can judge it. Both legs read `calendar_return`, so the anchor is
+calendar-dated and resolves to the last bar on or before it, and a missing leg is **absent**,
+scoring `False` and never carried forward. Named apart from `Prior move` on purpose — a
+**rubric version** re-scores a stored row by dimension name, so one label cannot mean two
+quantities. The cut sits at zero, which makes the boolean ADR-invariant; the units are there
+for the *value* a row would carry, so a later grading question can be asked without re-scoring
+history.
+_Avoid_: relative strength, RS (that is the rejected **RS line**), outperformance.
 
 **Rubric version**:
 The stamp identifying which weights and mappings produced a star score (`score.RUBRIC_VERSION`,

--- a/backend/screener/relative_strength.py
+++ b/backend/screener/relative_strength.py
@@ -1,5 +1,33 @@
-"""The RS line: an index-relative **candidate dimension**, measured and **not
-admitted** (issue #160, findings §5d).
+"""Index-relative **candidate dimensions** — quantities under measurement for the
+rubric slot ``Prior move`` cannot earn, and scored by nothing here.
+
+Two live in this module, in the order they were registered under
+``docs/adr/0005-what-admits-a-dimension-to-the-rubric.md``:
+
+- **RS line** (#160) — the ratio to the index across the detection's own base.
+  Measured and **rejected** (findings §5d).
+- **Relative move** (#170) — the `6m` return relative to the index, compounded,
+  in ADR units. **Pre-registered, not yet measured**; #171 runs the contrast.
+
+They share a benchmark and a never-carried-forward rule and differ in the one
+thing §5d's post-mortem named as the mechanism behind its null: the **anchor**.
+The RS line measures from ``base_start``, a local high, over a median 12-session
+window; the relative move measures from a fixed calendar date that on the modal
+detection sits about five months before the base begins. That is what makes the
+second a different statistic rather than the first re-registered, and ADR 0005
+records what result would say the distinction did not matter.
+
+**Computed in a caller, never in :mod:`screener.score`.** The score module is
+pure and does no I/O, and that guarantee is worth keeping; both dimensions need a
+*second symbol's* bars, so either could only ever be a caller-supplied
+cross-sectional input like ``prior_move`` and ``sector_share``. The benchmark is
+:data:`~screener.source.MARKET_INDEX` as it stands — ``^IXIC`` (US), ``^JKSE``
+(IDX).
+
+Pure over clean, oldest-first ``list[Bar]`` series, so both are unit-tested
+without the network.
+
+## The RS line, and why it was refused
 
 ``RS = adj_close(name) / adj_close(index)``, hit when ``RS_today >=
 RS_at_base_start``. It was proposed for the rubric slot ``Prior move`` cannot
@@ -50,20 +78,30 @@ equivalent:
   the module deliberately departs from :func:`screener.indicators.calendar_return`,
   which reads the last bar on or before its anchor.
 
-**Computed in the caller, never in :mod:`screener.score`.** The score module is
-pure and does no I/O, and that guarantee is worth keeping; the RS line needs a
-*second symbol's* bars, which is why it could only ever have been a
-caller-supplied cross-sectional input like ``prior_move`` and ``sector_share``.
-The benchmark is :data:`~screener.source.MARKET_INDEX` as it stands — ``^IXIC``
-(US), ``^JKSE`` (IDX).
-
 **No schema change.** :class:`~screener.detection.Detection` persists ``base_len``
 and ``session``, and the bars table has no retention cap, so ``base_start`` — and
 with it the whole dimension — is recomputable from stored bars for any past
 session. The replay property in spec §7.5 survives intact.
 
-Pure over two clean, oldest-first ``list[Bar]`` series, so it is unit-tested
-without the network.
+## The relative move, and what is fixed about it in advance
+
+The registration is ADR 0005's; what lives here is the executable half of it, so
+that "the exact definition" is a thing #171 imports rather than a paragraph it
+re-reads. Three choices are load-bearing and each rules out a variant that looks
+equivalent:
+
+- **`6m`, chosen before the contrast exists** (:data:`RELATIVE_MOVE_LOOKBACK`).
+- **Compounded, not subtracted** — see :func:`relative_move_adr`.
+- **The cut sits at zero** (:data:`RELATIVE_MOVE_CUT`), which is also why the
+  boolean is ADR-invariant: the units buy the stored *value*, not the pass/fail.
+
+What the units are for is the part worth reading twice. ADR 0005 admits a
+dimension as a **boolean** — grading needs demonstrated signal, and a candidate
+has none by definition — so nothing here grades anything. But a breakdown row
+carries the *value* and the rubric owns the mapping (#154), and a row cannot be
+re-denominated retroactively. Persisting the relative move in ADR units now is
+what would let ADR 0004's grading question be asked later, on measured evidence,
+without re-scoring history.
 """
 
 from __future__ import annotations
@@ -73,6 +111,7 @@ from datetime import date
 
 from .bars import Bar
 from .detection import Detection
+from .indicators import adr, calendar_return
 
 
 def _adj_close_on(bars: list[Bar], when: date) -> float | None:
@@ -155,3 +194,75 @@ def rs_line_for(det: Detection, bars: list[Bar], index_bars: list[Bar]) -> bool:
     if base_start is None:
         return False
     return rs_line(bars, index_bars, base_start=base_start, as_of=det.session)
+
+
+# The window the `Relative move` candidate is registered over (#170). Six months,
+# fixed in advance on two figures §3f published before the registration: the
+# beat-rate against the index is *higher* at `6m` (74.2%) than at `12m` (67.5%),
+# and the `12m` ADR-unit gap, though larger, is the noisier column — §3f records
+# it as set by a handful of ten-baggers against an ordinary day's +0.4% median.
+# One window, no sweep: trying `3m`/`6m`/`12m` and keeping the widest gap is the
+# magnitude-fitting ADR 0005's pre-registration clause exists to prevent.
+RELATIVE_MOVE_LOOKBACK = "6m"
+
+# The pre-registered cut-point, in ADR units. **Zero, and it has to be.** ADR is
+# positive, so the denominator cannot flip a sign — the boolean is ADR-invariant
+# and "outran the index" is the whole rule, with no free parameter. Any non-zero
+# cut would be a magnitude read off the replay, which #128 Q2 forbids, and no
+# published bucket boundary supports one here: §3f denominates the *raw* returns
+# in ADR, not the relative ones, so even ADR 0004's "use the study's own bucket
+# edges" route is unavailable.
+RELATIVE_MOVE_CUT = 0.0
+
+
+def relative_move_adr(
+    bars: list[Bar],
+    index_bars: list[Bar],
+    as_of: date,
+    *,
+    lookback: str = RELATIVE_MOVE_LOOKBACK,
+) -> float | None:
+    """The name's ``lookback`` return relative to the benchmark, in ADR units.
+
+    ``(1 + r(name)) / (1 + r(index)) − 1``, divided by the name's own
+    :func:`~screener.indicators.adr`. Compounded rather than subtracted because
+    over these horizons a percentage-point difference and a multiple are
+    different quantities, and only the second means "outran the market"
+    (findings §3f).
+
+    Both legs are :func:`~screener.indicators.calendar_return` — the rank table's
+    own definition, calendar-anchored, resolving to the last bar **on or before**
+    the anchor. That is the one place this departs from :func:`rs_line`, and
+    deliberately: an anchor six calendar months back lands on a weekend or a
+    holiday about three days in ten, so an exact-bar rule would score a calendar
+    artefact rather than the name. The RS line's anchors are traded sessions by
+    construction, which is why exactness was free there.
+
+    ``None`` — **absent, not zero** — when either leg has no bar on or before its
+    anchor (the name had not listed, the benchmark's series does not reach back)
+    or the name has fewer than 20 bars for an ADR. Callers score that ``False``
+    via :func:`relative_move_hit`; the value is never carried forward and never
+    excludes the name.
+    """
+    name_return = calendar_return(bars, as_of, lookback)
+    index_return = calendar_return(index_bars, as_of, lookback)
+    if name_return is None or index_return is None or index_return <= -1:
+        return None
+    name_adr = adr(bars)
+    if name_adr is None or name_adr <= 0:
+        return None
+    return ((1 + name_return) / (1 + index_return) - 1) / name_adr
+
+
+def relative_move_hit(value: float | None) -> bool:
+    """The pre-registered boolean over :func:`relative_move_adr`'s value.
+
+    Strictly above :data:`RELATIVE_MOVE_CUT`. A tie is measure-zero and the
+    strictness is fixed only so the definition has no ambiguity — unlike
+    :func:`rs_line`, where ``>=`` is load-bearing because *non-decayed* is the
+    concept there. An absent value scores ``False``.
+
+    One site owns the cut, so the boolean the contrast reads and the value the
+    breakdown row would carry can never disagree about where the line is.
+    """
+    return value is not None and value > RELATIVE_MOVE_CUT

--- a/backend/screener/relative_strength.py
+++ b/backend/screener/relative_strength.py
@@ -238,17 +238,25 @@ def relative_move_adr(
     artefact rather than the name. The RS line's anchors are traded sessions by
     construction, which is why exactness was free there.
 
+    **The ADR leg is sliced to ``as_of`` before it is taken.**
+    :func:`~screener.indicators.adr` averages the last 20 bars of whatever series
+    it is handed, and :mod:`replay.field` hands whole series in and never slices
+    them to the session — a convention that is safe for :func:`rs_line` only
+    because that function reads two named sessions exactly. Without the slice a
+    2019 session would be denominated by 2022's volatility, and the study would
+    never see it: the leak is invisible in any fixture whose range is constant.
+
     ``None`` — **absent, not zero** — when either leg has no bar on or before its
     anchor (the name had not listed, the benchmark's series does not reach back)
-    or the name has fewer than 20 bars for an ADR. Callers score that ``False``
-    via :func:`relative_move_hit`; the value is never carried forward and never
-    excludes the name.
+    or the name has fewer than 20 bars through ``as_of`` for an ADR. Callers score
+    that ``False`` via :func:`relative_move_hit`; the value is never carried
+    forward and never excludes the name.
     """
     name_return = calendar_return(bars, as_of, lookback)
     index_return = calendar_return(index_bars, as_of, lookback)
     if name_return is None or index_return is None or index_return <= -1:
         return None
-    name_adr = adr(bars)
+    name_adr = adr(bars[: bisect_right([b.session for b in bars], as_of)])
     if name_adr is None or name_adr <= 0:
         return None
     return ((1 + name_return) / (1 + index_return) - 1) / name_adr

--- a/backend/tests/test_relative_strength.py
+++ b/backend/tests/test_relative_strength.py
@@ -32,7 +32,7 @@ from screener.relative_strength import (
 CAL = [date(2021, 3, 1) + timedelta(days=i) for i in range(40)]
 # A calendar long enough to reach back a year, for the `Relative move` block
 # below. The RS line is measured over a base and never needs one.
-CAL6 = [date(2021, 1, 1) + timedelta(days=i) for i in range(400)]
+CAL_YEAR = [date(2021, 1, 1) + timedelta(days=i) for i in range(400)]
 
 
 def _bars(sessions, adj_closes):
@@ -255,7 +255,7 @@ def test_base_start_recovers_the_detectors_own_base_from_the_persisted_row():
 # The `6m` calendar return relative to ``MARKET_INDEX``, compounded, in ADR
 # units. Pre-registered in ADR 0005 and measured by #171; nothing scores it.
 
-_AS_OF = CAL6[-1]
+_AS_OF = CAL_YEAR[-1]
 _ANCHOR = anchor_date(_AS_OF, "6m")
 
 
@@ -275,15 +275,15 @@ def _step(sessions, before, after, *, adr_pct=0.05, anchor=None):
 
 
 def test_a_name_that_outran_the_index_over_6m_scores_positive():
-    name = _step(CAL6, 100.0, 200.0)
-    index = _step(CAL6, 100.0, 125.0)
+    name = _step(CAL_YEAR, 100.0, 200.0)
+    index = _step(CAL_YEAR, 100.0, 125.0)
     assert relative_move_adr(name, index, _AS_OF) > 0
     assert relative_move_hit(relative_move_adr(name, index, _AS_OF)) is True
 
 
 def test_a_name_that_lagged_the_index_over_6m_scores_negative():
-    name = _step(CAL6, 100.0, 110.0)
-    index = _step(CAL6, 100.0, 125.0)
+    name = _step(CAL_YEAR, 100.0, 110.0)
+    index = _step(CAL_YEAR, 100.0, 125.0)
     assert relative_move_adr(name, index, _AS_OF) < 0
     assert relative_move_hit(relative_move_adr(name, index, _AS_OF)) is False
 
@@ -295,8 +295,8 @@ def test_the_relative_move_is_compounded_not_subtracted():
     quantities, and only the second means "outran the market" (findings §3f).
     +100% against +25% is +60% relative, not +75pp.
     """
-    name = _step(CAL6, 100.0, 200.0, adr_pct=0.10)
-    index = _step(CAL6, 100.0, 125.0)
+    name = _step(CAL_YEAR, 100.0, 200.0, adr_pct=0.10)
+    index = _step(CAL_YEAR, 100.0, 125.0)
     assert relative_move_adr(name, index, _AS_OF) == pytest.approx(0.6 / 0.10)
 
 
@@ -307,9 +307,9 @@ def test_the_value_is_denominated_in_the_names_own_adr():
     a +60% relative advance means something different on a 5% ADR name than on a
     10% one.
     """
-    index = _step(CAL6, 100.0, 125.0)
-    quiet = _step(CAL6, 100.0, 200.0, adr_pct=0.05)
-    wild = _step(CAL6, 100.0, 200.0, adr_pct=0.10)
+    index = _step(CAL_YEAR, 100.0, 125.0)
+    quiet = _step(CAL_YEAR, 100.0, 200.0, adr_pct=0.05)
+    wild = _step(CAL_YEAR, 100.0, 200.0, adr_pct=0.10)
     assert relative_move_adr(quiet, index, _AS_OF) == pytest.approx(
         2 * relative_move_adr(wild, index, _AS_OF)
     )
@@ -323,13 +323,13 @@ def test_the_boolean_is_adr_invariant__the_cut_sits_at_zero():
     #128 Q2 forbids. The units buy the stored *value*, which is what a later
     grading question (ADR 0004) would be asked of — not the pass/fail.
     """
-    index = _step(CAL6, 100.0, 125.0)
+    index = _step(CAL_YEAR, 100.0, 125.0)
     for adr_pct in (0.01, 0.05, 0.50):
         assert relative_move_hit(
-            relative_move_adr(_step(CAL6, 100.0, 130.0, adr_pct=adr_pct), index, _AS_OF)
+            relative_move_adr(_step(CAL_YEAR, 100.0, 130.0, adr_pct=adr_pct), index, _AS_OF)
         ) is True
         assert relative_move_hit(
-            relative_move_adr(_step(CAL6, 100.0, 120.0, adr_pct=adr_pct), index, _AS_OF)
+            relative_move_adr(_step(CAL_YEAR, 100.0, 120.0, adr_pct=adr_pct), index, _AS_OF)
         ) is False
 
 
@@ -337,7 +337,7 @@ def test_matching_the_index_exactly_misses__the_rule_is_outran_not_kept_up():
     """A tie is measure-zero; the strictness is fixed so the definition has no
     ambiguity, and nothing rests on it. Contrast the RS line, whose ``>=`` was
     load-bearing because *non-decayed* was the whole concept there."""
-    both = _step(CAL6, 100.0, 125.0)
+    both = _step(CAL_YEAR, 100.0, 125.0)
     assert relative_move_adr(both, both, _AS_OF) == 0.0
     assert relative_move_hit(relative_move_adr(both, both, _AS_OF)) is False
 
@@ -350,23 +350,23 @@ def test_a_name_that_had_not_listed_6m_ago_is_absent_not_zero():
     point on an edge, where *excluding* the name would let a data gap remove a
     candidate from the list.
     """
-    young = _step(CAL6[-40:], 100.0, 200.0, anchor=CAL6[-40])
-    index = _step(CAL6, 100.0, 125.0)
+    young = _step(CAL_YEAR[-40:], 100.0, 200.0, anchor=CAL_YEAR[-40])
+    index = _step(CAL_YEAR, 100.0, 125.0)
     assert relative_move_adr(young, index, _AS_OF) is None
     assert relative_move_hit(None) is False
 
 
 def test_a_benchmark_with_no_bar_back_at_the_anchor_scores_absent():
-    name = _step(CAL6, 100.0, 200.0)
-    short_index = _step(CAL6[-40:], 100.0, 125.0, anchor=CAL6[-40])
+    name = _step(CAL_YEAR, 100.0, 200.0)
+    short_index = _step(CAL_YEAR[-40:], 100.0, 125.0, anchor=CAL_YEAR[-40])
     assert relative_move_adr(name, short_index, _AS_OF) is None
 
 
 def test_under_twenty_bars_there_is_no_adr_and_so_no_value():
     """ADR is ``SMA20(high/low − 1)`` and is ``None`` until 20 bars exist, so a
     name with a long enough price history but too few *bars* is absent too."""
-    sparse = [b for i, b in enumerate(_step(CAL6, 100.0, 200.0)) if i % 40 == 0]
-    index = _step(CAL6, 100.0, 125.0)
+    sparse = [b for i, b in enumerate(_step(CAL_YEAR, 100.0, 200.0)) if i % 40 == 0]
+    index = _step(CAL_YEAR, 100.0, 125.0)
     assert len(sparse) < 20
     assert relative_move_adr(sparse, index, _AS_OF) is None
 
@@ -379,7 +379,7 @@ def test_the_anchor_is_calendar_and_resolves_to_the_last_bar_on_or_before_it():
     artefact rather than on the name. The RS line's anchors are traded sessions
     by construction, so exactness was free there and is not here.
     """
-    traded = [s for s in CAL6 if s != _ANCHOR]
+    traded = [s for s in CAL_YEAR if s != _ANCHOR]
     name = _step(traded, 100.0, 200.0)
     index = _step(traded, 100.0, 125.0)
     assert _ANCHOR not in {b.session for b in name}
@@ -391,8 +391,8 @@ def test_the_window_is_a_parameter_so_the_study_can_carry_more_than_one():
     the `6m` one — :data:`RELATIVE_MOVE_LOOKBACK` — and the others are carried as
     lines on the contrast, not as candidate variants to choose between."""
     assert RELATIVE_MOVE_LOOKBACK == "6m"
-    name = _step(CAL6, 100.0, 200.0, anchor=anchor_date(_AS_OF, "12m"))
-    index = _step(CAL6, 100.0, 125.0, anchor=anchor_date(_AS_OF, "12m"))
+    name = _step(CAL_YEAR, 100.0, 200.0, anchor=anchor_date(_AS_OF, "12m"))
+    index = _step(CAL_YEAR, 100.0, 125.0, anchor=anchor_date(_AS_OF, "12m"))
     assert relative_move_adr(name, index, _AS_OF, lookback="12m") == pytest.approx(
         0.6 / 0.05
     )
@@ -403,8 +403,41 @@ def test_a_benchmark_that_lost_everything_is_absent_rather_than_a_divide_by_zero
     """A −100% index makes the compounding denominator zero. It cannot happen on
     real bars, and the guard is here so that if it ever does the dimension goes
     absent like every other missing leg rather than taking the caller down."""
-    name = _step(CAL6, 100.0, 200.0)
+    name = _step(CAL_YEAR, 100.0, 200.0)
     wiped = [Bar(b.session, b.open, b.high, b.low, b.close, 0.0, 1000)
              if b.session > _ANCHOR else b
-             for b in _step(CAL6, 100.0, 100.0)]
+             for b in _step(CAL_YEAR, 100.0, 100.0)]
     assert relative_move_adr(name, wiped, _AS_OF) is None
+
+
+def test_the_adr_leg_is_denominated_at_as_of_and_never_reads_past_it():
+    """The replay hands whole bar series in and never slices them to the session
+    (``replay.field``), which is only safe if the dimension does its own slicing.
+    ``adr`` averages the last 20 bars of whatever it is given, so without this a
+    2019 session would be denominated by 2022's volatility.
+    """
+    index = _step(CAL_YEAR, 100.0, 125.0)
+    quiet = _step(CAL_YEAR, 100.0, 200.0, adr_pct=0.05)
+    # The same name, its range blowing out *after* the session being scored.
+    later = [
+        b if b.session <= _AS_OF else Bar(
+            b.session, b.open, b.low * 2, b.low, b.close, b.adj_close, b.volume
+        )
+        for b in _step(CAL_YEAR + [_AS_OF + timedelta(days=i) for i in range(1, 40)],
+                       100.0, 200.0, adr_pct=0.05)
+    ]
+    assert relative_move_adr(later, index, _AS_OF) == pytest.approx(
+        relative_move_adr(quiet, index, _AS_OF)
+    )
+
+
+def test_a_name_with_no_range_at_all_is_absent_rather_than_a_divide_by_zero():
+    """``ADR`` is zero when every bar prints ``high == low``. Phantom bars are
+    already stripped at ingest, but a halted name that traded at one price is not
+    a phantom, and zero in the denominator would take the caller down."""
+    index = _step(CAL_YEAR, 100.0, 125.0)
+    rangeless = [
+        Bar(b.session, b.low, b.low, b.low, b.low, b.adj_close, 1000)
+        for b in _step(CAL_YEAR, 100.0, 200.0)
+    ]
+    assert relative_move_adr(rangeless, index, _AS_OF) is None

--- a/backend/tests/test_relative_strength.py
+++ b/backend/tests/test_relative_strength.py
@@ -19,9 +19,20 @@ import pytest
 
 from screener.bars import Bar
 from screener.detection import Detection
-from screener.relative_strength import base_start_session, rs_line, rs_line_for
+from screener.indicators import anchor_date
+from screener.relative_strength import (
+    RELATIVE_MOVE_LOOKBACK,
+    base_start_session,
+    relative_move_adr,
+    relative_move_hit,
+    rs_line,
+    rs_line_for,
+)
 
 CAL = [date(2021, 3, 1) + timedelta(days=i) for i in range(40)]
+# A calendar long enough to reach back a year, for the `Relative move` block
+# below. The RS line is measured over a base and never needs one.
+CAL6 = [date(2021, 1, 1) + timedelta(days=i) for i in range(400)]
 
 
 def _bars(sessions, adj_closes):
@@ -237,3 +248,163 @@ def test_base_start_recovers_the_detectors_own_base_from_the_persisted_row():
     over_base = [b for b in bars if start <= b.session <= det.session]
     assert len(over_base) == det.base_len
     assert min(b.low for b in over_base) == det.base_low
+
+
+# -- Relative move: the second candidate dimension (#170) ---------------------
+#
+# The `6m` calendar return relative to ``MARKET_INDEX``, compounded, in ADR
+# units. Pre-registered in ADR 0005 and measured by #171; nothing scores it.
+
+_AS_OF = CAL6[-1]
+_ANCHOR = anchor_date(_AS_OF, "6m")
+
+
+def _step(sessions, before, after, *, adr_pct=0.05, anchor=None):
+    """A series priced ``before`` through ``anchor`` and ``after`` past it.
+
+    ``low == adj_close`` and ``high == adj_close × (1 + adr_pct)`` on every bar,
+    so ``SMA20(high/low − 1)`` is exactly ``adr_pct`` and the ADR denominator is
+    a fixture rather than an accident of the path.
+    """
+    anchor = anchor or _ANCHOR
+    prices = [before if s <= anchor else after for s in sessions]
+    return [
+        Bar(s, p, p * (1 + adr_pct), p, p, p, 1000)
+        for s, p in zip(sessions, prices)
+    ]
+
+
+def test_a_name_that_outran_the_index_over_6m_scores_positive():
+    name = _step(CAL6, 100.0, 200.0)
+    index = _step(CAL6, 100.0, 125.0)
+    assert relative_move_adr(name, index, _AS_OF) > 0
+    assert relative_move_hit(relative_move_adr(name, index, _AS_OF)) is True
+
+
+def test_a_name_that_lagged_the_index_over_6m_scores_negative():
+    name = _step(CAL6, 100.0, 110.0)
+    index = _step(CAL6, 100.0, 125.0)
+    assert relative_move_adr(name, index, _AS_OF) < 0
+    assert relative_move_hit(relative_move_adr(name, index, _AS_OF)) is False
+
+
+def test_the_relative_move_is_compounded_not_subtracted():
+    """``(1 + stock)/(1 + index) − 1``, not ``stock − index``.
+
+    Over six months a percentage-point difference and a multiple are different
+    quantities, and only the second means "outran the market" (findings §3f).
+    +100% against +25% is +60% relative, not +75pp.
+    """
+    name = _step(CAL6, 100.0, 200.0, adr_pct=0.10)
+    index = _step(CAL6, 100.0, 125.0)
+    assert relative_move_adr(name, index, _AS_OF) == pytest.approx(0.6 / 0.10)
+
+
+def test_the_value_is_denominated_in_the_names_own_adr():
+    """The same relative move on a twice-as-volatile name is half the value.
+
+    The units are the point of the row: ADR is the method's volatility unit, and
+    a +60% relative advance means something different on a 5% ADR name than on a
+    10% one.
+    """
+    index = _step(CAL6, 100.0, 125.0)
+    quiet = _step(CAL6, 100.0, 200.0, adr_pct=0.05)
+    wild = _step(CAL6, 100.0, 200.0, adr_pct=0.10)
+    assert relative_move_adr(quiet, index, _AS_OF) == pytest.approx(
+        2 * relative_move_adr(wild, index, _AS_OF)
+    )
+
+
+def test_the_boolean_is_adr_invariant__the_cut_sits_at_zero():
+    """ADR is positive, so the denominator cannot flip the sign.
+
+    This is why the pre-registered cut is sited at zero and not at some number of
+    ADR: a non-zero cut-point would be a magnitude read off the replay, which
+    #128 Q2 forbids. The units buy the stored *value*, which is what a later
+    grading question (ADR 0004) would be asked of — not the pass/fail.
+    """
+    index = _step(CAL6, 100.0, 125.0)
+    for adr_pct in (0.01, 0.05, 0.50):
+        assert relative_move_hit(
+            relative_move_adr(_step(CAL6, 100.0, 130.0, adr_pct=adr_pct), index, _AS_OF)
+        ) is True
+        assert relative_move_hit(
+            relative_move_adr(_step(CAL6, 100.0, 120.0, adr_pct=adr_pct), index, _AS_OF)
+        ) is False
+
+
+def test_matching_the_index_exactly_misses__the_rule_is_outran_not_kept_up():
+    """A tie is measure-zero; the strictness is fixed so the definition has no
+    ambiguity, and nothing rests on it. Contrast the RS line, whose ``>=`` was
+    load-bearing because *non-decayed* was the whole concept there."""
+    both = _step(CAL6, 100.0, 125.0)
+    assert relative_move_adr(both, both, _AS_OF) == 0.0
+    assert relative_move_hit(relative_move_adr(both, both, _AS_OF)) is False
+
+
+def test_a_name_that_had_not_listed_6m_ago_is_absent_not_zero():
+    """``None`` — absent — and the dimension scores ``False``.
+
+    The rank table's own convention: a recent IPO is simply missing from the long
+    lookbacks rather than zero-filled (§4.3). Scoring ``False`` costs at most a
+    point on an edge, where *excluding* the name would let a data gap remove a
+    candidate from the list.
+    """
+    young = _step(CAL6[-40:], 100.0, 200.0, anchor=CAL6[-40])
+    index = _step(CAL6, 100.0, 125.0)
+    assert relative_move_adr(young, index, _AS_OF) is None
+    assert relative_move_hit(None) is False
+
+
+def test_a_benchmark_with_no_bar_back_at_the_anchor_scores_absent():
+    name = _step(CAL6, 100.0, 200.0)
+    short_index = _step(CAL6[-40:], 100.0, 125.0, anchor=CAL6[-40])
+    assert relative_move_adr(name, short_index, _AS_OF) is None
+
+
+def test_under_twenty_bars_there_is_no_adr_and_so_no_value():
+    """ADR is ``SMA20(high/low − 1)`` and is ``None`` until 20 bars exist, so a
+    name with a long enough price history but too few *bars* is absent too."""
+    sparse = [b for i, b in enumerate(_step(CAL6, 100.0, 200.0)) if i % 40 == 0]
+    index = _step(CAL6, 100.0, 125.0)
+    assert len(sparse) < 20
+    assert relative_move_adr(sparse, index, _AS_OF) is None
+
+
+def test_the_anchor_is_calendar_and_resolves_to_the_last_bar_on_or_before_it():
+    """The one place this departs from the RS line's exact-bar rule.
+
+    An anchor six calendar months back lands on a weekend or holiday about three
+    days in ten; requiring a bar *on* it would score ``False`` on a calendar
+    artefact rather than on the name. The RS line's anchors are traded sessions
+    by construction, so exactness was free there and is not here.
+    """
+    traded = [s for s in CAL6 if s != _ANCHOR]
+    name = _step(traded, 100.0, 200.0)
+    index = _step(traded, 100.0, 125.0)
+    assert _ANCHOR not in {b.session for b in name}
+    assert relative_move_adr(name, index, _AS_OF) == pytest.approx(0.6 / 0.05)
+
+
+def test_the_window_is_a_parameter_so_the_study_can_carry_more_than_one():
+    """#171 measures `12m` and `1w` beside the registered `6m`. The dimension is
+    the `6m` one — :data:`RELATIVE_MOVE_LOOKBACK` — and the others are carried as
+    lines on the contrast, not as candidate variants to choose between."""
+    assert RELATIVE_MOVE_LOOKBACK == "6m"
+    name = _step(CAL6, 100.0, 200.0, anchor=anchor_date(_AS_OF, "12m"))
+    index = _step(CAL6, 100.0, 125.0, anchor=anchor_date(_AS_OF, "12m"))
+    assert relative_move_adr(name, index, _AS_OF, lookback="12m") == pytest.approx(
+        0.6 / 0.05
+    )
+    assert relative_move_adr(name, index, _AS_OF) == pytest.approx(0.0)
+
+
+def test_a_benchmark_that_lost_everything_is_absent_rather_than_a_divide_by_zero():
+    """A −100% index makes the compounding denominator zero. It cannot happen on
+    real bars, and the guard is here so that if it ever does the dimension goes
+    absent like every other missing leg rather than taking the caller down."""
+    name = _step(CAL6, 100.0, 200.0)
+    wiped = [Bar(b.session, b.open, b.high, b.low, b.close, 0.0, 1000)
+             if b.session > _ANCHOR else b
+             for b in _step(CAL6, 100.0, 100.0)]
+    assert relative_move_adr(name, wiped, _AS_OF) is None

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -62,6 +62,8 @@ wrong-way. So a candidate dimension is pre-registered as **one** variant, chosen
 and the study returns pass or fail on that variant. Selecting among several candidate
 booleans by whichever produces the largest gap is magnitude-fitting, which #128 Q2 forbids.
 
+### First registration: `RS line` (#160) — **measured, and refused**
+
 The first dimension registered under this ADR is **`RS line`** (#160, with the rubric change in
 #161) — `RS = adj_close(name) /
 adj_close(index)`, hit when `RS_today >= RS_at_base_start` over the detection's own base — with
@@ -77,6 +79,148 @@ these four criteria fixed in advance:
 Criterion 2's ~15% is a judgement, not a measurement, and is the one magnitude in this design
 without evidence behind it. It is stated here so that a later argument about it is an argument
 about a number on the record rather than a number nobody wrote down.
+
+**The verdict was do not ship**, on criterion 4 (findings §5d): Δ **−5.8pp** under detector v1
+and **−2.1pp** under the live v3, with criterion 2 at 11.2% disagreement standing ready to
+refuse it had the sign come back the other way. The mechanism was the **anchor** — `base_start`
+is a local high under both of the detector's branches, so the rule asks a name to hold its
+ratio to the index measured *from a local maximum*, which almost nothing does. The dimension
+fires on one detection in ten in **both** groups. So the process worked: a criterion nobody
+could argue with afterwards fired on a number nobody had seen when it was written. `Prior move`
+stayed at ×1, `RUBRIC_VERSION` stayed 3, and the slot stayed open.
+
+### Second registration: `Relative move` (#170) — pre-registered, unmeasured
+
+§3f (#169) measured the quantity `Prior move` gates on, directly, for the first time, and found
+it has real spread once expressed as a degree: `6m` median **+55.8%**, p25 +15.1 to p95 +370.7,
+and **74.2%** of his entries beating `MARKET_INDEX` over six months against **37.8%** of the
+same names on an ordinary day. That is the limb this ADR requires and the binary dimension
+cannot reach — so the slot `RS line` failed to fill has a second candidate.
+
+**The dimension, as registered.** The name's `6m` calendar return **relative to
+`MARKET_INDEX`**, compounded, in **ADR units**:
+
+```
+value = ((1 + r6m(name)) / (1 + r6m(index)) − 1) / ADR(name)
+hit   = value > 0
+```
+
+- **Compounded, not subtracted.** Over six months a percentage-point difference and a multiple
+  are different quantities, and only the second means "outran the market" (§3f's own wording,
+  and its own arithmetic).
+- **Both legs are `indicators.calendar_return`** — the rank table's own definition,
+  calendar-anchored through `anchor_date`, resolving to the **last bar on or before** the
+  anchor. This is the one place the dimension departs from `RS line`, which requires a bar
+  *exactly* on its anchor, and the departure is forced: an anchor six calendar months back
+  lands on a weekend or a holiday about three days in ten, so an exact rule would score a
+  calendar artefact rather than a name. `RS line`'s anchors are traded sessions by
+  construction, which is why exactness was free there.
+- **A missing bar on either leg scores `False`**, with the value **absent rather than zero**,
+  and is never carried forward. Same rule and same reason as `RS line`: scoring `False` costs
+  at most one point on a rare edge, where *excluding* the name would let a data gap remove a
+  candidate from the list. A name that had not listed six months ago is already absent from the
+  `6m` lookback in the rank table, so this is the substrate's convention and not a new one.
+- **`ADR` is the name's own `SMA20(high/low − 1)`**, absent under 20 bars — and absent means
+  `False` by the rule above.
+- **The benchmark is `MARKET_INDEX`** — `^IXIC` (US), `^JKSE` (IDX) — declined `^GSPC` for the
+  reason in the consequences below. §3f cross-checked `QQQ` against `^IXIC` and every row agreed
+  within two points, so the choice is not load-bearing for the result.
+- **It is named `Relative move`, not `Prior move`.** `score.RUBRICS` re-scores a stored
+  breakdown by dimension *name*, so reusing the label would make a v4 row mean one quantity and
+  a v3 row another under the same key, and the paired A2 re-run (#136) would compare two
+  quantities while believing it compares two rubrics. The executable definition is
+  `screener.relative_strength.relative_move_adr`.
+
+**Why `6m`, fixed before the contrast exists.** Two figures §3f published: the beat-rate against
+the index is *higher* at `6m` (74.2%) than at `12m` (67.5%), and 26.0% of entries underperformed
+the index over the year; and while the entry-vs-ordinary gap in ADR units is larger at `12m`
+(+22.83 against **+12.41**), §3f records that column as the noisier one — an ordinary day's
+`12m` median is +0.4%, so it is set by a handful of ten-baggers, where `6m` sits against an ordinary
+day's −11.2%. One window. Trying three and keeping the widest gap is the magnitude-fitting this
+section exists to prevent.
+
+**Why the cut sits at zero, and what the ADR units are for.** ADR is positive, so the
+denominator cannot flip a sign: **the boolean is ADR-invariant**, and "outran the index" is the
+whole rule, with no free parameter — the property that made `RS line`'s definition honest, kept.
+Any non-zero ADR cut-point would be a magnitude read off the replay, which #128 Q2 forbids, and
+no published boundary supports one: §3f denominates the *raw* returns in ADR and the *relative*
+ones in percent, so even ADR 0004's "use the study's own bucket edges" route is unavailable
+here. The units therefore buy nothing at admission — they buy the **stored value**. This ADR
+admits a dimension as a boolean because grading needs demonstrated signal and a candidate has
+none; but a breakdown row carries the value while the rubric owns the mapping (#154), and a row
+cannot be re-denominated retroactively. Persisting ADR units now is what would let ADR 0004's
+grading question be asked later, on measured evidence, without re-scoring history. A tie scores
+`False`; that is measure-zero and is fixed only so the definition has no ambiguity.
+
+**The weight is not a number yet, and that is the rule rather than an omission.** Weights come
+from the *ordering* of the measured gaps. §5d republished that ordering under the live detector
+— ADR +26.4, Tightness +13.5, MA support +6.3, `Prior move` 0.0, Volume −0.3, Orderliness −5.9,
+Base length −7.8 — with ×2 held by the top two and ×1 by everything positive below. So: **×2 if
+the measured Δ outranks `Tightness`, ×1 otherwise.** That is an ordinal position, not a reading
+of a gap's value.
+
+The four criteria, fixed in advance:
+
+1. **Δ positive, and the not-taken hit rate between ~15% and ~85%** — ship, at the weight above,
+   as `RUBRIC_VERSION = 4`, and `Prior move` retires with the binding-lookback metadata
+   replacing it (see the consequences). A hit rate strictly inside those bounds makes pooled
+   spread non-zero by construction, so the original criterion 1's second clause is carried
+   rather than dropped.
+2. **Δ positive, but disagreement with `Prior move` under ~15%** — do not ship. `Prior move` is
+   `True` on every detection, so disagreement with it is exactly `1 − hit rate`, and a dimension
+   firing on more than five names in six is the constant in a new costume: the decile gate
+   already guarantees top-decile in one of four lookbacks, and a `6m`-relative grade may have
+   little left to say *within* that population even though it has plenty within his trade
+   record. §3f cannot see this — it never looks at the field — which is why #171 exists and why
+   this is the criterion most likely to fire.
+3. **The not-taken hit rate under ~15%** — do not ship. This **widens** criterion 3 as it was
+   written for `RS line` ("pooled spread 0.000"), and the widening is §5d's tuition: that
+   dimension had pooled spread **0.326** and still could not speak, because a rule firing on one
+   detection in ten measures its −2.1pp gap across a sliver of the field. Spread 0.000 is the
+   degenerate case of the two bounds — 0% here, 100% under criterion 2 — so nothing is lost by
+   stating it this way, and the rule gets harder to pass rather than easier.
+4. **Δ negative** — do not ship, and record it. **This is what kills it**, and it is the
+   pre-registered answer to the objection that `RS line` had this shape already.
+
+**What a negative gap would mean, said before the numbers.** `RS line`'s Δ is negative because
+he selects names whose strength against the index *decayed through the base* — and §5d's own
+post-mortem names the anchor as the mechanism. This dimension is anchored somewhere else: a
+fixed calendar date six months back, which on the modal detection (median base length 12) sits
+roughly five months before the base begins. It measures the advance, where `RS line` measures
+the consolidation of it. That is the argument, in advance, for why the two are different
+statistics. **If Δ comes back negative anyway, the anchor was not the mechanism** — and what is
+measured is that within an already-gated field he selects names with *less* index-relative
+strength than the ones he passed over. That folds the index-relative family, not just this
+variant, and **no third anchor may be proposed off the back of it**: choosing one after seeing
+two negatives is exactly the fitting this section forbids. The `Prior move` slot would then be
+closed by evidence rather than left open by default, which is a result worth having.
+
+**Two things this registration deliberately does not settle.** It says nothing about
+`detection_gate`, which stays a percentile union of four lookbacks — this is about the rubric
+only. And the boolean cannot duplicate the `ADR ×2` dimension, being ADR-invariant, but a later
+*graded* form would divide by the same quantity a ×2 dimension already scores; that is a
+question for the grading proposal ADR 0004 would govern, and it is recorded here so that
+proposal starts from it rather than discovering it.
+
+**If it ships, the decile gate leaves the score, and #161's answer is what brings it back.**
+`Prior move` is the only breakdown row recording that a name cleared the gate ADR 0003 is about
+— the one discarding ~40% of his real entries — so retiring it without a replacement loses that
+outright. The replacement is the **binding lookback name** (`"3m"`) as a non-scored field on the
+candidates payload, and **not** its percentile, for the reason the consequences give. This is
+not a separate ticket because it only becomes real if this dimension is admitted; if it is
+refused the way `RS line` was, `Prior move` stays at ×1 and the gate keeps its record in the
+score.
+
+**It is inert until #171 runs.** §3f is executed trades against a same-name background, which is
+not a control group of rejected setups — the footing `RS line` was rightly refused on. Until the
+selection contrast exists there is no Δ, no pooled spread and no hit rate, and none of the four
+criteria can fire. #171's constraints attach: the contrast is measured under the detector the
+dimension would ship against (live v3, not the store's persisted v1), and it reproduces §5b's
+seven gaps as its control before anything new is trusted. Three bounds ride the result whatever
+it says: §2's coverage hole (§3f joined **70.2%** of his logged breakout longs to bars, skewed
+against the blown-up 2020–21 small-cap cohort), §9's absent control group on the *trade* side,
+and the regime bound below — which this candidate carries with full force, being index-relative
+by construction.
 
 ## The regime bound every candidate carries (#169)
 
@@ -119,6 +263,12 @@ instrument that could retire it, since it is the only planned measurement outsid
 
 ## Consequences
 
+**None of the first four have happened.** They are what follows *if* a registered dimension is
+admitted, and nothing has been: `RS line` was refused on criterion 4 and `Relative move` is
+unmeasured until #171. They are written in the indicative because they were written before the
+first verdict, and are left that way — a consequence restated as a hope reads as a weaker
+commitment than it is.
+
 - **`Prior move` is retired and the rubric's floor goes with it.** The permanent 0.5★ that
   `score.py` describes — "``Prior move`` fires for every detection by construction (a permanent
   half-star floor)" — was that dimension. The real star range becomes **0.0–4.5**, and
@@ -131,11 +281,12 @@ instrument that could retire it, since it is the only planned measurement outsid
   the rubric." That constraint governs the replay rather than the live app, whose ranks have no
   such hole — but the margin is thin enough that the lookback's *name* is the honest thing to
   publish and the percentile is declined.
-- **A new dimension forces a rubric version.** `RS line` ships as `RUBRIC_VERSION = 4`, joining
-  the `RUBRIC_WEIGHTS` table so the paired re-run (#136) can score one field under v3 and v4 and
-  separate a rubric change from a field change. Digests written under v3 are not recomputed.
+- **A new dimension forces a rubric version.** An admitted dimension ships as
+  `RUBRIC_VERSION = 4`, joining the `RUBRIC_WEIGHTS` table so the paired re-run (#136)
+  can score one field under v3 and v4 and separate a rubric change from a field change.
+  Digests written under v3 are not recomputed.
 - **The new dimension is measured on US only and ships to IDX unmeasured.** The replay field is
-  US-only, so `RS line` is contrasted against `^IXIC` and never against `^JKSE`. §8 permits a
+  US-only, so a candidate is contrasted against `^IXIC` and never against `^JKSE`. §8 permits a
   weight *ordering* travelling to IDX as shape rather than magnitude, and `Tightness` and `ADR`
   already ride that precedent — but those were reweights of measured dimensions and this is a
   whole dimension, so the precedent is being stretched rather than applied. Recorded here
@@ -145,7 +296,11 @@ instrument that could retire it, since it is the only planned measurement outsid
   `^GSPC` was considered and declined: a second reference instrument per market means the
   scorer and `regime.py` disagree about what the market is, for reasons nobody will recall.
   Revisit only if the dimension is found to fire on sector lines.
-- **The contrast this rule reads must be re-run under `DETECTOR_VERSION = 2`.** §5b's published
+- **The contrast this rule reads must be re-run under the detector the dimension ships
+  against** — written as `DETECTOR_VERSION = 2` when this ADR was drafted, and already one
+  version stale by the time §5d ran it: #149 admitted `12m` to the detection gate
+  afterwards, so the live detector is **v3**. The requirement is the version the dimension
+  would ship against, not the number written here. §5b's published
   table — 69 taken against 14,354 not-taken — was measured under detector v1. #154's graded
   tightness grew the detector's population by **+111.3 detections per session (+123%)**, and
   while §3's detection row and §4's `in_field` anchor were re-pinned (104 → 159 of 656 — since

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -93,9 +93,10 @@ stayed at ×1, `RUBRIC_VERSION` stayed 3, and the slot stayed open.
 
 §3f (#169) measured the quantity `Prior move` gates on, directly, for the first time, and found
 it has real spread once expressed as a degree: `6m` median **+55.8%**, p25 +15.1 to p95 +370.7,
-and **74.2%** of his entries beating `MARKET_INDEX` over six months against **37.8%** of the
-same names on an ordinary day. That is the limb this ADR requires and the binary dimension
-cannot reach — so the slot `RS line` failed to fill has a second candidate.
+and **74.2%** of his entries beating `QQQ` over six months against **37.8%** of the same names
+on an ordinary day — `^IXIC`, which is `MARKET_INDEX` and so the benchmark this dimension would
+actually use, reads **75.1%** on the same column. That is the limb this ADR requires and the
+binary dimension cannot reach — so the slot `RS line` failed to fill has a second candidate.
 
 **The dimension, as registered.** The name's `6m` calendar return **relative to
 `MARKET_INDEX`**, compounded, in **ADR units**:
@@ -120,11 +121,16 @@ hit   = value > 0
   at most one point on a rare edge, where *excluding* the name would let a data gap remove a
   candidate from the list. A name that had not listed six months ago is already absent from the
   `6m` lookback in the rank table, so this is the substrate's convention and not a new one.
-- **`ADR` is the name's own `SMA20(high/low − 1)`**, absent under 20 bars — and absent means
-  `False` by the rule above.
+- **`ADR` is the name's own `SMA20(high/low − 1)`, taken at the session being scored** and
+  never past it, absent under 20 bars — and absent means `False` by the rule above. The
+  denominator is where a lookahead would hide: the replay hands whole bar series in and never
+  slices them to the session, which is safe for `RS line` because it reads two named sessions
+  exactly, and is not safe for a trailing average. `relative_move_adr` does its own slicing.
 - **The benchmark is `MARKET_INDEX`** — `^IXIC` (US), `^JKSE` (IDX) — declined `^GSPC` for the
-  reason in the consequences below. §3f cross-checked `QQQ` against `^IXIC` and every row agreed
-  within two points, so the choice is not load-bearing for the result.
+  reason in the consequences below. §3f's headline columns are `QQQ` and its `^IXIC` check
+  reproduces every row within two points, so the switch of benchmark is not load-bearing for
+  the result — but every figure quoted here is `QQQ`'s unless it says otherwise, and the
+  contrast will be run against `^IXIC`.
 - **It is named `Relative move`, not `Prior move`.** `score.RUBRICS` re-scores a stored
   breakdown by dimension *name*, so reusing the label would make a v4 row mean one quantity and
   a v3 row another under the same key, and the paired A2 re-run (#136) would compare two
@@ -132,12 +138,12 @@ hit   = value > 0
   `screener.relative_strength.relative_move_adr`.
 
 **Why `6m`, fixed before the contrast exists.** Two figures §3f published: the beat-rate against
-the index is *higher* at `6m` (74.2%) than at `12m` (67.5%), and 26.0% of entries underperformed
-the index over the year; and while the entry-vs-ordinary gap in ADR units is larger at `12m`
-(+22.83 against **+12.41**), §3f records that column as the noisier one — an ordinary day's
-`12m` median is +0.4%, so it is set by a handful of ten-baggers, where `6m` sits against an ordinary
-day's −11.2%. One window. Trying three and keeping the widest gap is the magnitude-fitting this
-section exists to prevent.
+the index is *higher* at `6m` (74.2%) than at `12m` (67.5%; both `QQQ`), and 26.0% of entries
+underperformed the index over the year; and while the entry-vs-ordinary gap in ADR units is
+larger at `12m` (+22.83 against **+12.41**), §3f records that column as the noisier one — an
+ordinary day's `12m` median is +0.4%, so it is set by a handful of ten-baggers, where `6m` sits
+against an ordinary day's −11.2%. One window. Trying three and keeping the widest gap is the
+magnitude-fitting this section exists to prevent.
 
 **Why the cut sits at zero, and what the ADR units are for.** ADR is positive, so the
 denominator cannot flip a sign: **the boolean is ADR-invariant**, and "outran the index" is the
@@ -166,9 +172,11 @@ The four criteria, fixed in advance:
    replacing it (see the consequences). A hit rate strictly inside those bounds makes pooled
    spread non-zero by construction, so the original criterion 1's second clause is carried
    rather than dropped.
-2. **Δ positive, but disagreement with `Prior move` under ~15%** — do not ship. `Prior move` is
-   `True` on every detection, so disagreement with it is exactly `1 − hit rate`, and a dimension
-   firing on more than five names in six is the constant in a new costume: the decile gate
+2. **Δ positive, but disagreement with `Prior move` under ~15% on the not-taken group** — do not
+   ship. `Prior move` is `True` on every detection, so disagreement with it is exactly
+   `1 − hit rate`, read on the same group criteria 1 and 3 read. A dimension
+   firing on more than five names in six of the field he passed over is the constant in a new
+   costume: the decile gate
    already guarantees top-decile in one of four lookbacks, and a `6m`-relative grade may have
    little left to say *within* that population even though it has plenty within his trade
    record. §3f cannot see this — it never looks at the field — which is why #171 exists and why


### PR DESCRIPTION
Closes #170.

`RS line` was refused on criterion 4 (findings §5d) and the rubric slot `Prior move` cannot earn is still open. §3f measured the quantity the decile gate is nominally about and found real spread once it is expressed as a degree, so this registers the second candidate for that slot — **before** #171 makes any number visible.

## The dimension, as registered

The name's `6m` calendar return relative to `MARKET_INDEX`, compounded, in ADR units:

```
value = ((1 + r6m(name)) / (1 + r6m(index)) − 1) / ADR(name)
hit   = value > 0
```

ADR 0005 gains the registration — window, definition, missing-bar rule, benchmark, weight rule, four ship criteria and the result that kills it. `screener.relative_strength` gains the executable half (`relative_move_adr` / `relative_move_hit`), so #171 imports the definition rather than re-reading a paragraph. `CONTEXT.md` gains the glossary entry.

Nothing is scored. `RUBRIC_VERSION` stays 3, `DIMENSIONS` is untouched, and no `detection_gate` change rides along.

## Three things the issue left open, and how they are settled

- **The cut sits at zero, not at some number of ADR.** This is a real narrowing of the issue's "graded in ADR units", and the ADR says so rather than substituting quietly: ADR 0005 admits a dimension as a **boolean** because grading needs demonstrated signal, and a non-zero ADR cut-point would be a magnitude read off the replay (#128 Q2) with no published relative-return bucket edge to borrow — §3f denominates the *raw* returns in ADR and the *relative* ones in percent, so even ADR 0004's "use the study's own bucket edges" route is unavailable. Because ADR is positive the boolean is **ADR-invariant**, so the units buy the *stored value*, which is what keeps ADR 0004's grading question askable later without re-scoring history. **The issue's title is inaccurate for what this ships** — worth editing or arguing with.
- **Criterion 2's duplication suspect is `Prior move` itself.** It is `True` on every detection, so disagreement with it is exactly `1 − hit rate` on the not-taken group — which makes the ~15% floor precisely the "constant in disguise" test the decile gate makes likely. This is the criterion most likely to fire, and §3f cannot see it because it never looks at the field.
- **Criterion 3 is widened**, from "pooled spread 0.000" to a hit-rate floor. `RS line` had pooled spread **0.326** and still could not speak, because a rule firing on one detection in ten measures its −2.1pp gap across a sliver of the field. Spread 0.000 is the degenerate case of the two bounds, so nothing is lost — and widening *before* the numbers makes the rule harder to pass, not easier.

`RS line`'s verdict is also backfilled into the ADR that registered it, and the consequences that read as if it would ship are de-named. Outside #170's ask, but the document was stating a counterfactual in the indicative.

## The defect the review caught

`relative_move_adr` denominated by `adr(bars)`, which averages the last 20 bars of the **series**. `replay.field` hands whole series in and never slices them to the session — safe for `rs_line`, which reads two named sessions exactly, and not safe for a trailing average. #171 would have denominated a 2019 session with 2022's volatility, and no fixture with a constant range could have shown it. The ADR leg is now sliced to `as_of`, with a test that fails without the slice.

Also from the review: the 74.2% / 37.8% pair is §3f's **`QQQ`** columns, not `MARKET_INDEX`'s (`^IXIC` reads 75.1%), and every figure the registration quotes now says which benchmark it belongs to.

## Testing

`npm run test:backend` — **562 passed**. 16 new tests in `test_relative_strength.py` covering compounding, the ADR denomination and its `as_of` slice, the ADR-invariance of the boolean, the calendar anchor's last-bar-on-or-before rule, and every absent-leg path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BNso1nYoqQWYEcV6eqzUpg
