### PR TITLE
Run §3f's prior-move measurement against the replay field (§5e) (#171)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -249,11 +249,14 @@ weighted by nothing. It is how ADR 0005's admission rule is exercised — a dime
 rubric slot on a measured non-zero gap with non-zero pooled spread, and until that measurement
 exists it must be unable to move a star, a sort or a board place. So it lives on a field member
 of its own (`RS line` on `replay.field.ScoredDetection.rs_line`), never inside `SevenDimScore`,
-and nothing in `screener` scores it. Two are registered — `RS line`, measured and rejected, and
-**Relative move**, whose definition exists but whose contrast (#171) has not been run, so it has
-no field member yet. **Pre-registered as one variant, pass or fail** — trying several and
-keeping the largest gap is magnitude-fitting (#128 Q2). A candidate that fails leaves its
-measurement behind and takes its wiring with it.
+and nothing in `screener` scores it. Two are registered, both measured, neither admitted —
+`RS line` (rejected on a wrong-way gap) and **Relative move** (a positive gap that landed on its
+own refusal threshold, #171). **Pre-registered as one variant, pass or fail** — trying several
+and keeping the largest gap is magnitude-fitting (#128 Q2). A study may report further columns
+beside a candidate, as §5e does for the raw and other-window moves; those are **descriptive and
+permanently inadmissible**, and they are handed to `contrast_dimensions` as readers rather than
+listed in `CANDIDATES`, so the registered list cannot quietly grow one. A candidate that fails
+leaves its measurement behind and takes its wiring with it.
 _Avoid_: experimental dimension, provisional dimension (a **graded dimension** is live; this
 is not).
 
@@ -271,8 +274,10 @@ was proposed for is still open, and **Relative move** is the second candidate fo
 **Relative move**:
 The `6m` return **relative to `MARKET_INDEX`**, compounded — `(1 + stock) / (1 + index) − 1` —
 divided by the name's own `ADR`, taken at the session being scored and never past it. Hit when it is above zero: the name outran the index over six
-months. The second **candidate dimension** (#170), **pre-registered and not yet measured**;
-#171 runs the contrast that can judge it. Both legs read `calendar_return`, so the anchor is
+months. The second **candidate dimension** (#170), **measured and not admitted** (findings §5e,
+#171): Δ **+3.6pp** under the live detector — positive, unlike `RS line` — on a not-taken hit
+rate of **84.94%** against a pre-registered ~85% ceiling, 0.29 standard errors inside it. The
+criteria do not separate, so `Prior move` keeps its ×1 and `RUBRIC_VERSION` stays 3. Both legs read `calendar_return`, so the anchor is
 calendar-dated and resolves to the last bar on or before it, and a missing leg is **absent**,
 scoring `False` and never carried forward. Named apart from `Prior move` on purpose — a
 **rubric version** re-scores a stored row by dimension name, so one label cannot mean two

--- a/backend/replay/candidate_field.py
+++ b/backend/replay/candidate_field.py
@@ -1,0 +1,97 @@
+"""The read-only field reconstruction the **candidate dimension** studies share.
+
+Both pre-registered candidates were measured by a side-car script rather than by
+:mod:`replay.study` — `RS line` (#160, findings §5d) and `Relative move` (#170,
+measured by #171, findings §5e) — and both needed the same three things from the
+committed replay store, for the same three reasons:
+
+- **The measured sessions**, which are the 505 the store holds detections for and
+  the window findings §5b was published on. A candidate is contrasted against
+  §5b's own table, so it has to be measured over §5b's own sessions.
+- **The session's ranks, recomputed in memory**, never read back from the store.
+  :meth:`screener.store.Store.append_ranks` prunes rows outside
+  :data:`screener.store.RANK_RETENTION_YEARS` as the chain advances, so the
+  persisted table cannot serve the early sessions and a decile gate read off it
+  would silently return an empty field for most of the window (#141/#164). This
+  is the same reuse path :func:`replay.chain._replay_session` takes.
+- **The session's detections under the live detector**, computed and *not*
+  persisted. §5b's field is the one detector v1 produced, and ADR 0005 requires a
+  candidate to be measured under the detector it would ship against, so both
+  studies run two fields over one set of sessions and let the detector be the
+  only thing that differs.
+
+**Nothing here writes.** ``data/replay.duckdb`` cannot be re-run in place — its
+detections are detector v1 over 505 sessions and a full chain re-run raises
+``SessionExistsError`` — so the studies read the persisted rows for the v1
+control and recompute the live field in memory. Appending the recomputed rows
+would leave the store holding two detectors' rows under one ``(market, session)``
+key and would destroy the v1 control on the next run.
+:class:`~screener.store.Store` migrates on open and so cannot be handed a
+read-only connection; the studies run against a working copy, which is belt and
+braces on the same guarantee.
+
+This module exists because the second study needed the first study's harness. Two
+copies of the rank-retention workaround is one copy too many: a correction to it
+would have to land twice, and the run that failed to get the second copy would
+still print a table.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+from screener.detection import Detection, detection_gate, detect
+from screener.ranks import Rank, rank_table
+from screener.store import Store
+
+
+def measured_sessions(store: Store, market: str) -> list[date]:
+    """The sessions the store holds detections for — findings §5b's own window.
+
+    Both of a study's fields run over exactly these, so the detector is the only
+    thing that moves between them. They are also the sessions the store retained
+    ranks for, which is why the persisted field stops at 505 of the chain's 947.
+    """
+    rows = store._cursor().execute(
+        "SELECT DISTINCT session FROM detections WHERE market = ? ORDER BY 1",
+        [market],
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def session_ranks(
+    store: Store, market: str, session: date
+) -> tuple[list[str], list[Rank]]:
+    """The session's members and its rank table, recomputed over its universe.
+
+    Recomputed rather than read back, for the retention reason in the module
+    docstring. :func:`screener.ranks.rank_table` is deterministic over the same
+    members' bars, so this reproduces what the chain computed rather than
+    approximating it.
+    """
+    members = store.universe(market, session)
+    return members, rank_table(
+        {s: store.bars(market, s) for s in members}, session
+    )
+
+
+def live_detections(
+    store: Store, market: str, session: date, ranks: list[Rank]
+) -> list[Detection]:
+    """The session's detections under the **live** detector, computed not read.
+
+    :func:`screener.pipeline.rebuild_detections` is the app's own stage and this
+    is its loop exactly — every universe member, the decile gate deciding
+    eligibility, :func:`screener.detection.detect` on the gated ones — with the
+    single difference that the rows are *not* appended. The write is what is
+    omitted, never a gate.
+    """
+    gated = detection_gate(ranks)
+    out = []
+    for symbol in store.universe(market, session):
+        if symbol not in gated:
+            continue
+        found = detect(symbol, store.bars(market, symbol), session)
+        if found is not None:
+            out.append(found)
+    return out

--- a/backend/replay/contrast.py
+++ b/backend/replay/contrast.py
@@ -48,8 +48,9 @@ from __future__ import annotations
 import argparse
 from dataclasses import dataclass
 from datetime import date
-from typing import Callable, Iterable, Sequence
+from typing import Callable, Iterable, Mapping, Sequence
 
+from screener.relative_strength import relative_move_hit
 from screener.score import Dimension
 from screener.store import Store
 
@@ -145,13 +146,29 @@ class SelectionContrast:
 # rubric weighs, so a dimension under measurement cannot move a star or a board
 # place while the question of whether it belongs is still open.
 #
-# ``RS line`` (#160) is the one candidate: whether the name held its ratio to the
-# benchmark across its own base. It was measured for the slot ``Prior move``
-# cannot earn — a **constant dimension**, 100.0% in both groups, pooled spread
-# 0.000 — and **rejected** on criterion 4, a wrong-way gap (findings §5d). It
-# stays a column because retiring the evidence with the candidate would leave
-# §5d unreproducible; its weight is 0 because it has none, and nothing here
-# touches :mod:`screener.score`.
+# Two are registered, in the order ADR 0005 registered them:
+#
+# - ``RS line`` (#160) — whether the name held its ratio to the benchmark across
+#   its own base. Measured for the slot ``Prior move`` cannot earn — a
+#   **constant dimension**, 100.0% in both groups, pooled spread 0.000 — and
+#   **rejected** on criterion 4, a wrong-way gap (findings §5d). It stays a
+#   column because retiring the evidence with the candidate would leave §5d
+#   unreproducible.
+# - ``Relative move`` (#170) — the `6m` return relative to ``MARKET_INDEX``,
+#   compounded, in ADR units, hit above the pre-registered cut. Measured by #171
+#   (findings §5e). The cut is applied here, at read time, off the value the
+#   field member carries: one site owns it, so the column the contrast reads and
+#   the row a rubric would score can never disagree about where the line is.
+#
+# Both carry weight 0 because they have none, and nothing here touches
+# :mod:`screener.score`.
+#
+# **This tuple is the list of what has actually been registered**, and it is
+# deliberately short. #171 reports five further columns — the raw move and the
+# relative one at other windows — and those are handed in as ``readers`` by the
+# study script rather than added here, because ADR 0005 admits **one**
+# pre-registered variant per registration. A column promotable by editing this
+# tuple is a column promotable after its gap is visible.
 #
 # **One entry per candidate, name and reader together.** Keeping the reader in a
 # second dict keyed by the same string let a typo fall through to the rubric
@@ -159,6 +176,7 @@ class SelectionContrast:
 # be wrong and look fine.
 CANDIDATES: tuple[tuple[str, int, Callable[[ScoredDetection], bool]], ...] = (
     ("RS line", 0, lambda d: d.rs_line),
+    ("Relative move", 0, lambda d: relative_move_hit(d.relative_move)),
 )
 
 CANDIDATE_DIMENSIONS: tuple[tuple[str, int], ...] = tuple(
@@ -179,14 +197,18 @@ def _dim_hit(breakdown: Sequence[Dimension], name: str) -> bool:
     return False
 
 
-def _booleans(detections: Iterable[ScoredDetection], name: str) -> list[float]:
+def _booleans(
+    detections: Iterable[ScoredDetection],
+    name: str,
+    readers: Mapping[str, Callable[[ScoredDetection], bool]],
+) -> list[float]:
     """The dimension's boolean (1.0 hit / 0.0 miss) across a group of detections.
 
     A **candidate dimension** is read off the field member; a rubric dimension off
     its score breakdown. The two are kept apart deliberately — see
     :data:`CANDIDATE_DIMENSIONS`.
     """
-    reader = _CANDIDATE_READERS.get(name)
+    reader = readers.get(name)
     if reader is not None:
         return [1.0 if reader(d) else 0.0 for d in detections]
     return [1.0 if _dim_hit(d.score.breakdown, name) else 0.0 for d in detections]
@@ -202,6 +224,7 @@ def contrast_dimensions(
     not_taken: Iterable[ScoredDetection],
     *,
     dimensions: tuple[tuple[str, int], ...] = CONTRAST_DIMENSIONS,
+    readers: Mapping[str, Callable[[ScoredDetection], bool]] | None = None,
 ) -> list[DimensionContrast]:
     """Contrast each dimension's hit distribution between the two field groups.
 
@@ -212,13 +235,21 @@ def contrast_dimensions(
     sample, and a dimension untestable within his trades alone but with spread
     across the pooled sample is flagged as testability-restored (PRD user story
     19). No outcome is read — this measures selection, not prediction.
+
+    ``readers`` supplements :data:`CANDIDATES` for a study reporting a column that
+    is **not** a registered candidate — #171's raw and other-window moves, which
+    ADR 0005's one-variant clause puts permanently out of reach of the rubric.
+    They are a caller's argument rather than a module-level tuple precisely so
+    that nothing can quietly promote one; a name given here shadows a rubric
+    dimension of the same name, which is why the study prefixes its columns.
     """
     taken = list(taken)
     not_taken = list(not_taken)
+    all_readers = {**_CANDIDATE_READERS, **(readers or {})}
     contrasts: list[DimensionContrast] = []
     for name, weight in dimensions:
-        taken_xs = _booleans(taken, name)
-        not_taken_xs = _booleans(not_taken, name)
+        taken_xs = _booleans(taken, name, all_readers)
+        not_taken_xs = _booleans(not_taken, name, all_readers)
         pooled = taken_xs + not_taken_xs
 
         taken_spread = _pstdev(taken_xs)

--- a/backend/replay/contrast.py
+++ b/backend/replay/contrast.py
@@ -240,12 +240,22 @@ def contrast_dimensions(
     is **not** a registered candidate — #171's raw and other-window moves, which
     ADR 0005's one-variant clause puts permanently out of reach of the rubric.
     They are a caller's argument rather than a module-level tuple precisely so
-    that nothing can quietly promote one; a name given here shadows a rubric
-    dimension of the same name, which is why the study prefixes its columns.
+    that nothing can quietly promote one, and a name colliding with a registered
+    candidate raises rather than replacing it: a study that could redefine
+    ``Relative move`` under its own name is a study that could report a candidate
+    it had quietly respecified. A name shadowing a *rubric* dimension is left to
+    the caller, which is why the study prefixes its columns.
     """
     taken = list(taken)
     not_taken = list(not_taken)
-    all_readers = {**_CANDIDATE_READERS, **(readers or {})}
+    readers = readers or {}
+    clash = sorted(set(readers) & set(_CANDIDATE_READERS))
+    if clash:
+        raise ValueError(
+            f"reader(s) {clash} would redefine a registered candidate dimension; "
+            f"rename the study column"
+        )
+    all_readers = {**_CANDIDATE_READERS, **readers}
     contrasts: list[DimensionContrast] = []
     for name, weight in dimensions:
         taken_xs = _booleans(taken, name, all_readers)

--- a/backend/replay/field.py
+++ b/backend/replay/field.py
@@ -42,7 +42,7 @@ from typing import Callable, Iterable, Mapping, Sequence
 from screener.detection import DETECTION_LOOKBACKS, Detection, detection_gate
 from screener.pipeline import rebuild_detections
 from screener.ranks import Rank
-from screener.relative_strength import rs_line_for
+from screener.relative_strength import relative_move_adr, rs_line_for
 from screener.score import DIMENSIONS, Dimension, star_score
 from screener.source import MARKET_INDEX
 from screener.store import Store
@@ -131,6 +131,18 @@ class ScoredDetection:
     It was measured and **not admitted** (findings §5d): a wrong-way gap, so
     criterion 4 refused it and the rubric never read it. The field still computes
     it, because that is what makes §5d reproducible rather than quotable.
+
+    ``relative_move`` is the **second** candidate (#170): the `6m` return
+    relative to :data:`~screener.source.MARKET_INDEX`, compounded, in ADR units
+    (:func:`screener.relative_strength.relative_move_adr`), measured by #171. It
+    rides as a **value**, and ``None`` means *absent* — the name had not listed
+    six months ago, or has no ADR — never zero, which is a real value sitting
+    exactly on the pre-registered cut. The boolean is derived at read time by
+    :func:`~screener.relative_strength.relative_move_hit`, so the rubric owns the
+    cut and the row owns the number: a stored row cannot be re-denominated
+    retroactively, and ADR 0004's later grading question is asked of the value.
+
+    Neither candidate is scored, and neither can move a star or a ``star_rank``.
     """
 
     symbol: str
@@ -140,6 +152,7 @@ class ScoredDetection:
     not_taken: bool
     taken: bool = False
     rs_line: bool = False
+    relative_move: float | None = None
 
 
 @dataclass(frozen=True)
@@ -197,6 +210,7 @@ def build_field(
     any_entry: bool = False,
     lookbacks: Sequence[str] = DETECTION_LOOKBACKS,
     rs_line_of: Mapping[str, bool] | None = None,
+    relative_move_of: Mapping[str, float | None] | None = None,
 ) -> list[ScoredDetection]:
     """Score each detection and sort into star order — the replayed candidate list.
 
@@ -218,13 +232,16 @@ def build_field(
     width that admitted it — a name admitted by a widened gate holds the prior-move
     point under that gate, and scoring it against the live gate would understate it.
 
-    ``rs_line_of`` maps symbol → the candidate dimension (#160),
-    computed by the caller because it needs a second symbol's bars. It rides on
-    each :class:`ScoredDetection` and is **never scored**: a symbol absent from it
-    is ``False``, and the star order is identical whether it is supplied or not.
+    ``rs_line_of`` maps symbol → the candidate dimension (#160), and
+    ``relative_move_of`` symbol → the second candidate's value (#170); both are
+    computed by the caller because both need a second symbol's bars. They ride on
+    each :class:`ScoredDetection` and are **never scored**: a symbol absent from
+    either reads ``False`` / ``None``, and the star order is identical whether
+    they are supplied or not.
     """
     entered = set(entered)
     rs_line_of = rs_line_of or {}
+    relative_move_of = relative_move_of or {}
     gated = detection_gate(ranks, lookbacks=lookbacks)
     scored = [
         (det, seven_dimension_score(det, prior_move=det.symbol in gated))
@@ -240,6 +257,7 @@ def build_field(
             not_taken=any_entry and det.symbol not in entered,
             taken=det.symbol in entered,
             rs_line=rs_line_of.get(det.symbol, False),
+            relative_move=relative_move_of.get(det.symbol),
         )
         for rank, (det, score) in enumerate(scored, start=1)
     ]
@@ -266,6 +284,35 @@ def session_rs_lines(
     index_bars = store.bars(market, MARKET_INDEX[market])
     return {
         det.symbol: rs_line_for(det, store.bars(market, det.symbol), index_bars)
+        for det in detections
+    }
+
+
+def session_relative_moves(
+    store: Store, market: str, detections: Iterable[Detection]
+) -> dict[str, float | None]:
+    """The `Relative move` value for each of a session's detections (#170).
+
+    The name's `6m` calendar return netted against
+    :data:`~screener.source.MARKET_INDEX`, compounded, denominated in the name's
+    own ADR (:func:`screener.relative_strength.relative_move_adr`). The sibling of
+    :func:`session_rs_lines`, and computed in the same place and for the same
+    reason: it needs a *second* symbol's bars, and :mod:`screener.score` is pure
+    and does no I/O.
+
+    Whole bar series are handed in, through the run-scoped cache as every other
+    stage does — and unlike the RS line, which reads two named sessions exactly,
+    the value here carries a trailing average. ``relative_move_adr`` slices the
+    ADR leg to the detection's own session itself, so no later bar reaches the
+    denominator; see its docstring for why that guard lives there rather than
+    here. A leg with no bar on or before its anchor yields ``None`` — absent, not
+    zero — and is never carried forward.
+    """
+    index_bars = store.bars(market, MARKET_INDEX[market])
+    return {
+        det.symbol: relative_move_adr(
+            store.bars(market, det.symbol), index_bars, det.session
+        )
         for det in detections
     }
 
@@ -347,6 +394,7 @@ def build_field_sessions(
         candidates = build_field(
             detections, sf.ranks, entered=entered, any_entry=bool(entered),
             rs_line_of=session_rs_lines(store, market, detections),
+            relative_move_of=session_relative_moves(store, market, detections),
         )
         fields.append(
             FieldSession(

--- a/backend/screener/relative_strength.py
+++ b/backend/screener/relative_strength.py
@@ -7,7 +7,10 @@ Two live in this module, in the order they were registered under
 - **RS line** (#160) — the ratio to the index across the detection's own base.
   Measured and **rejected** (findings §5d).
 - **Relative move** (#170) — the `6m` return relative to the index, compounded,
-  in ADR units. **Pre-registered, not yet measured**; #171 runs the contrast.
+  in ADR units. Measured by #171 and **not admitted** (findings §5e): the gap is
+  positive on both fields, but the not-taken hit rate landed 0.06pp inside the
+  ~85% ceiling that refuses it, and the study declined to read a verdict off six
+  hundredths of a point.
 
 They share a benchmark and a never-carried-forward rule and differ in the one
 thing §5d's post-mortem named as the mechanism behind its null: the **anchor**.
@@ -102,6 +105,22 @@ carries the *value* and the rubric owns the mapping (#154), and a row cannot be
 re-denominated retroactively. Persisting the relative move in ADR units now is
 what would let ADR 0004's grading question be asked later, on measured evidence,
 without re-scoring history.
+
+## The raw move, which is not a candidate and cannot become one
+
+:func:`move_adr` is the un-benchmarked sibling — §3f's raw column, the prior move
+itself before the index is netted out. #171's contrast carries it so the relative
+figure can be read against the thing it is relative to, and it turned out to
+carry the section's sharpest lesson: the `1w` gap reads +31.6pp at the detection's
+own session and −4.5pp through the session before, because a *taken* detection's
+session is the session he bought it on.
+
+It lives here rather than in the study script for one reason — it shares the ADR
+denominator, and therefore :func:`_adr_through`'s lookahead guard, with the
+registered dimension. It is **not** a registered candidate: ADR 0005 admits one
+pre-registered variant per registration, and promoting a raw column after seeing
+which of the two produced the larger gap is the magnitude-fitting the
+pre-registration clause exists to prevent.
 """
 
 from __future__ import annotations
@@ -215,6 +234,61 @@ RELATIVE_MOVE_LOOKBACK = "6m"
 RELATIVE_MOVE_CUT = 0.0
 
 
+def _adr_through(bars: list[Bar], as_of: date) -> float | None:
+    """The name's own ADR at ``as_of``, over the bars up to and including it.
+
+    The lookahead guard both ADR-denominated quantities in this module share, and
+    the reason there is one of it. :func:`~screener.indicators.adr` averages the
+    last 20 bars of whatever series it is handed, and :mod:`replay.field` hands
+    whole series in and never slices them to the session — safe for
+    :func:`rs_line`, which reads two named sessions exactly, and not safe for a
+    trailing average. Without the slice a 2019 session would be denominated by
+    2022's volatility, and no fixture whose range is constant could ever show it.
+
+    ``None`` under 20 bars through ``as_of``, and on a name with no range at all
+    (every bar ``high == low``), which would otherwise be a zero denominator.
+    """
+    through = bars[: bisect_right([b.session for b in bars], as_of)]
+    value = adr(through)
+    if value is None or value <= 0:
+        return None
+    return value
+
+
+def move_adr(
+    bars: list[Bar],
+    as_of: date,
+    *,
+    lookback: str = RELATIVE_MOVE_LOOKBACK,
+) -> float | None:
+    """The name's own ``lookback`` return, in ADR units. No benchmark.
+
+    §3f's raw column — the prior move itself, before the index is netted out —
+    carried by #171's selection contrast beside :func:`relative_move_adr` so the
+    relative figure can be read against the thing it is relative to. §3f found
+    QQQ takes about a third of the `6m` move, and a contrast reporting only the
+    net figure would leave that share invisible.
+
+    **This is not a candidate dimension and cannot become one.** ADR 0005 admits
+    one pre-registered variant per registration and `Relative move` is it;
+    promoting a raw column after seeing which of the two produced the larger gap
+    is exactly the magnitude-fitting the pre-registration clause exists to
+    prevent. It lives here rather than in the study script only because it shares
+    the ADR denominator — and so the slicing guard — with the registered
+    dimension, and that guard is worth having one copy of.
+
+    ``None`` — absent, not zero — under the same rules as
+    :func:`relative_move_adr`: no bar on or before the anchor, or no ADR.
+    """
+    name_return = calendar_return(bars, as_of, lookback)
+    if name_return is None:
+        return None
+    name_adr = _adr_through(bars, as_of)
+    if name_adr is None:
+        return None
+    return name_return / name_adr
+
+
 def relative_move_adr(
     bars: list[Bar],
     index_bars: list[Bar],
@@ -256,8 +330,8 @@ def relative_move_adr(
     index_return = calendar_return(index_bars, as_of, lookback)
     if name_return is None or index_return is None or index_return <= -1:
         return None
-    name_adr = adr(bars[: bisect_right([b.session for b in bars], as_of)])
-    if name_adr is None or name_adr <= 0:
+    name_adr = _adr_through(bars, as_of)
+    if name_adr is None:
         return None
     return ((1 + name_return) / (1 + index_return) - 1) / name_adr
 

--- a/backend/tests/test_relative_strength.py
+++ b/backend/tests/test_relative_strength.py
@@ -23,6 +23,7 @@ from screener.indicators import anchor_date
 from screener.relative_strength import (
     RELATIVE_MOVE_LOOKBACK,
     base_start_session,
+    move_adr,
     relative_move_adr,
     relative_move_hit,
     rs_line,
@@ -441,3 +442,60 @@ def test_a_name_with_no_range_at_all_is_absent_rather_than_a_divide_by_zero():
         for b in _step(CAL_YEAR, 100.0, 200.0)
     ]
     assert relative_move_adr(rangeless, index, _AS_OF) is None
+
+
+# -- the raw move, the un-benchmarked sibling (#171) ---------------------------
+#
+# `move_adr` is **not** a registered candidate and never can be: ADR 0005 admits
+# one variant per registration, and `Relative move` is it. This is the raw column
+# §3f measured — the prior move itself, before the index is netted out — carried
+# by #171's contrast so the relative figure can be read against the thing it is
+# relative to. It shares the ADR denominator, and therefore the slicing guard,
+# with the registered dimension; that shared site is the reason it lives here
+# rather than in the study script.
+
+
+def test_the_raw_move_is_the_return_in_the_names_own_adr():
+    name = _step(CAL_YEAR, 100.0, 200.0, adr_pct=0.10)
+    assert move_adr(name, _AS_OF) == pytest.approx(1.0 / 0.10)
+
+
+def test_the_raw_move_nets_out_nothing__that_is_the_whole_difference():
+    """The pair #171 reports side by side: a name that doubled while the index
+    rose 25% has a raw move of +100% and a relative one of +60%. Netting the
+    index out is what turns the first into the second, and reporting only one of
+    them is what §3f warns leaves the tape unaccounted for."""
+    name = _step(CAL_YEAR, 100.0, 200.0, adr_pct=0.05)
+    index = _step(CAL_YEAR, 100.0, 125.0)
+    assert move_adr(name, _AS_OF) == pytest.approx(1.0 / 0.05)
+    assert relative_move_adr(name, index, _AS_OF) == pytest.approx(0.6 / 0.05)
+
+
+def test_the_raw_moves_adr_leg_is_sliced_at_as_of_too():
+    """The same lookahead guard, asserted separately: two functions sharing a
+    helper is not the same as two functions both being tested for the leak."""
+    quiet = _step(CAL_YEAR, 100.0, 200.0, adr_pct=0.05)
+    later = [
+        b if b.session <= _AS_OF else Bar(
+            b.session, b.open, b.low * 2, b.low, b.close, b.adj_close, b.volume
+        )
+        for b in _step(CAL_YEAR + [_AS_OF + timedelta(days=i) for i in range(1, 40)],
+                       100.0, 200.0, adr_pct=0.05)
+    ]
+    assert move_adr(later, _AS_OF) == pytest.approx(move_adr(quiet, _AS_OF))
+
+
+def test_the_raw_move_carries_the_same_absent_rules():
+    young = _step(CAL_YEAR[-40:], 100.0, 200.0, anchor=CAL_YEAR[-40])
+    rangeless = [
+        Bar(b.session, b.low, b.low, b.low, b.low, b.adj_close, 1000)
+        for b in _step(CAL_YEAR, 100.0, 200.0)
+    ]
+    assert move_adr(young, _AS_OF) is None
+    assert move_adr(rangeless, _AS_OF) is None
+
+
+def test_the_raw_move_takes_the_same_windows_the_relative_one_does():
+    name = _step(CAL_YEAR, 100.0, 200.0, anchor=anchor_date(_AS_OF, "12m"))
+    assert move_adr(name, _AS_OF, lookback="12m") == pytest.approx(1.0 / 0.05)
+    assert move_adr(name, _AS_OF, lookback="1w") == pytest.approx(0.0)

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -68,6 +68,7 @@ from replay.field import (
     build_field,
     build_field_sessions,
     replay_field,
+    session_relative_moves,
     seven_dimension_score,
 )
 from replay.placement import (
@@ -88,6 +89,8 @@ from replay.regression import (
     run_regression,
 )
 from replay.contrast import (
+    CANDIDATE_DIMENSIONS,
+    CONTRAST_DIMENSIONS,
     COMPARISON_GROUP_NOTE,
     PRECISION_NOTE,
     DimensionContrast,
@@ -101,7 +104,10 @@ from replay.caching_store import CachingStore
 from replay.store import WINDOW_END, WINDOW_START, build_replay_store
 from screener.bars import Bar
 from screener.detection import Detection, detect, detection_gate
+from screener.indicators import anchor_date
 from screener.ranks import Rank
+from screener.relative_strength import relative_move_hit
+from screener.source import MARKET_INDEX
 from screener.store import Store
 
 
@@ -1789,12 +1795,18 @@ def test_distribution_percentiles_are_linear_interpolated():
 
 
 def _scored_det(
-    symbol: str, cluster_k: int, *, taken=False, not_taken=False, rs_line=False
+    symbol: str,
+    cluster_k: int,
+    *,
+    taken=False,
+    not_taken=False,
+    rs_line=False,
+    relative_move=None,
 ):
     """A field candidate carrying a real seven-dimension breakdown: ``cluster_k``
     flips the Tightness dimension, every other dimension is hit by construction.
-    ``rs_line`` is the candidate dimension under measurement (#160), which sits
-    beside the score rather than inside it."""
+    ``rs_line`` (#160) and ``relative_move`` (#170) are the candidate dimensions
+    under measurement, which sit beside the score rather than inside it."""
     det = _det(symbol, cluster_k)
     return ScoredDetection(
         symbol=symbol,
@@ -1804,6 +1816,7 @@ def _scored_det(
         not_taken=not_taken,
         taken=taken,
         rs_line=rs_line,
+        relative_move=relative_move,
     )
 
 
@@ -1843,7 +1856,7 @@ def test_selection_contrast_over_a_fixture_field_with_known_members():
     assert set(by_dim) == {
         "Tightness", "Orderliness", "Prior move",
         "Base length", "MA support", "Volume", "ADR",
-        "RS line",
+        "RS line", "Relative move",
     }
     # The candidate carries no weight: it is measured, not scored (ADR 0005).
     assert by_dim["RS line"].weight == 0
@@ -2911,3 +2924,120 @@ def test_the_grid_never_mutates_the_live_detector_constants():
         detection_module.OUTLIER_MULT,
         detection_module.DETECTION_LOOKBACKS,
     ) == before
+
+
+# -- the second candidate dimension (#170/#171) -------------------------------
+#
+# `Relative move` — the `6m` return relative to ``MARKET_INDEX``, compounded, in
+# ADR units, hit above zero. Pre-registered in ADR 0005 and measured by #171's
+# selection contrast. It rides the field member as a **value** where ``RS line``
+# rides as a boolean, and the reason is the registration's: the rubric owns the
+# cut, a breakdown row carries the number, and a row cannot be re-denominated
+# retroactively.
+
+
+def test_the_relative_move_rides_as_a_value_and_the_cut_lives_in_one_place():
+    """The column is the number; the boolean is derived from it at read time.
+
+    Carrying the pass/fail instead would freeze the pre-registered cut into every
+    stored row, and ADR 0004's later grading question — asked of the value —
+    could then only be answered by re-scoring history.
+    """
+    dets = [_det("AAA", 6), _det("BBB", 3)]
+
+    field = build_field(dets, [], relative_move_of={"AAA": 2.5, "BBB": -1.0})
+
+    assert {d.symbol: d.relative_move for d in field} == {"AAA": 2.5, "BBB": -1.0}
+    by_dim = {
+        c.dimension: c
+        for c in contrast_dimensions(
+            [d for d in field if d.symbol == "AAA"],
+            [d for d in field if d.symbol == "BBB"],
+        )
+    }
+    assert by_dim["Relative move"].taken_hit_rate == 1.0
+    assert by_dim["Relative move"].not_taken_hit_rate == 0.0
+    assert by_dim["Relative move"].weight == 0
+
+
+def test_an_absent_relative_move_is_none_and_scores_a_miss():
+    """A name that had not listed six months ago, or has no ADR, is **absent** —
+    not zero. The distinction is the rank table's own convention, and zero would
+    be a real value sitting exactly on the cut."""
+    field = build_field([_det("AAA", 6)], [])
+
+    assert field[0].relative_move is None
+    by_dim = {c.dimension: c for c in contrast_dimensions(field, [])}
+    assert by_dim["Relative move"].taken_hit_rate == 0.0
+
+
+def test_the_relative_move_does_not_move_a_replayed_star():
+    """The staging invariant, asserted for the second candidate as it was for the
+    first: measuring a dimension cannot contaminate the field it is measured on."""
+    strong = _scored_det("AAA", 6, relative_move=9.0)
+    weak = _scored_det("AAA", 6, relative_move=-9.0)
+    assert strong.score == weak.score
+    assert strong.score.breakdown == weak.score.breakdown
+    assert "Relative move" not in {d.dimension for d in strong.score.breakdown}
+
+
+def test_session_relative_moves_reads_the_market_index_as_the_benchmark(store: Store):
+    """The wiring #171 runs on: the value is the name's `6m` return netted against
+    ``MARKET_INDEX``, in the name's own ADR, read off the store.
+
+    Two names over the same benchmark — one that outran it, one that lagged —
+    pin that the benchmark is actually netted out rather than the raw move being
+    reported under a relative name.
+    """
+    sessions = _daily(date(2020, 1, 1), 260)
+    as_of = sessions[-1]
+    anchor = anchor_date(as_of, "6m")
+
+    def _step(before: float, after: float) -> list[Bar]:
+        return [
+            Bar(s, p, p * 1.05, p, p, p, 1000)
+            for s, p in ((s, before if s <= anchor else after) for s in sessions)
+        ]
+
+    store.append_bars("US", MARKET_INDEX["US"], _step(100.0, 125.0))
+    store.append_bars("US", "FAST", _step(100.0, 200.0))
+    store.append_bars("US", "SLOW", _step(100.0, 110.0))
+    dets = [
+        dataclasses.replace(_det("FAST", 6), session=as_of),
+        dataclasses.replace(_det("SLOW", 6), session=as_of),
+    ]
+
+    values = session_relative_moves(store, "US", dets)
+
+    assert values["FAST"] == pytest.approx(0.6 / 0.05)
+    assert values["SLOW"] < 0
+    assert relative_move_hit(values["FAST"]) is True
+    assert relative_move_hit(values["SLOW"]) is False
+
+
+def test_a_study_column_is_read_through_a_supplied_reader_not_a_new_field():
+    """#171 reports five descriptive columns beside the registered dimension —
+    the raw move and the relative one at `1w` and `12m` — and none of them is a
+    candidate for the rubric.
+
+    So they are handed to the contrast as readers by the study script rather than
+    added to :class:`ScoredDetection`, which is what keeps
+    :data:`CANDIDATE_DIMENSIONS` an honest list of what has actually been
+    registered. A column that can be promoted by editing a tuple is a column that
+    can be promoted after seeing its gap.
+    """
+    taken = [_scored_det("P1", 6, taken=True), _scored_det("P2", 6, taken=True)]
+    not_taken = [_scored_det("N1", 6, not_taken=True)]
+    values = {"P1": 3.0, "P2": -1.0, "N1": -1.0}
+
+    contrasts = contrast_dimensions(
+        taken,
+        not_taken,
+        dimensions=CONTRAST_DIMENSIONS + (("raw 12m", 0),),
+        readers={"raw 12m": lambda d: values[d.symbol] > 0},
+    )
+
+    by_dim = {c.dimension: c for c in contrasts}
+    assert by_dim["raw 12m"].taken_hit_rate == 0.5
+    assert by_dim["raw 12m"].not_taken_hit_rate == 0.0
+    assert "raw 12m" not in dict(CANDIDATE_DIMENSIONS)

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -3041,3 +3041,19 @@ def test_a_study_column_is_read_through_a_supplied_reader_not_a_new_field():
     assert by_dim["raw 12m"].taken_hit_rate == 0.5
     assert by_dim["raw 12m"].not_taken_hit_rate == 0.0
     assert "raw 12m" not in dict(CANDIDATE_DIMENSIONS)
+
+
+def test_a_study_column_cannot_redefine_a_registered_candidate():
+    """The collision the ``readers`` seam has to refuse.
+
+    A study supplying a reader named ``Relative move`` would report a number under
+    a registered candidate's name while computing something of its own — the one
+    way this contrast can be wrong and look fine, which is the same failure the
+    :data:`CANDIDATES` comment describes for a mistyped dimension name.
+    """
+    with pytest.raises(ValueError, match="registered candidate"):
+        contrast_dimensions(
+            [_scored_det("P1", 6, taken=True)],
+            [_scored_det("N1", 6, not_taken=True)],
+            readers={"Relative move": lambda d: True},
+        )

--- a/docs/adr/0003-the-decile-gate.md
+++ b/docs/adr/0003-the-decile-gate.md
@@ -198,6 +198,34 @@ The bound: executed trades only, one regime, and a same-name background rather t
 group of rejected setups (findings §9). None of these figures is a precision measurement, and the
 band figures are per-trade readings of the same 582 rows rather than a second sample.
 
+### A fourth line, and the first with a comparison group (#171)
+
+The three above are all drawn from his trades alone. §5e of the replay findings ran the `1w`
+return through §5b's selection contrast — his picks against the **not-taken detections**, field
+members present the same nights in names he did not enter — over 505 sessions under the live
+detector:
+
+| `1w` reading, live detector v3 | His picks | The field he passed over | Δ |
+| --- | --- | --- | --- |
+| Raw, in ADR units, above zero | 37.9% | 42.4% | **−4.5pp** |
+| Netted against `MARKET_INDEX` | 35.0% | 38.9% | **−3.9pp** |
+
+Median week: **−0.19 ×ADR** in his picks and **−0.19** in the field he passed over, identical to
+two decimals. n = 140 taken against 34,543 not-taken. Against setups he did not take on the same
+nights, the week before his entry is not distinguishable from the week before theirs.
+
+**One methodological warning rides with it**, because the same table measured the other way says
+the opposite. Read at the detection's own session the gap is **+31.6pp** — the widest prior-move
+gap anywhere in that study, wider than `ADR`'s — and all of it is the entry day: a taken
+detection's session *is* the session he bought it on, one bar in a five-bar window. The rows above
+are measured through the session strictly before, which is §3f's convention and adopted there for
+the same reason. Any future `1w` proposal that quotes a gap has to say which session its window
+ends on, because that choice is worth 36 points.
+
+The comparison group is not a control group of rejected setups — he may never have seen those
+names — and §5e's own coverage and regime bounds attach. What it removes is the objection that
+the three readings above only ever looked at trades he took.
+
 ---
 
 **Everything below this line is the reasoning as it stood before the sweep**, kept as the

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -89,7 +89,7 @@ fires on one detection in ten in **both** groups. So the process worked: a crite
 could argue with afterwards fired on a number nobody had seen when it was written. `Prior move`
 stayed at ×1, `RUBRIC_VERSION` stayed 3, and the slot stayed open.
 
-### Second registration: `Relative move` (#170) — pre-registered, unmeasured
+### Second registration: `Relative move` (#170) — measured, and undecided
 
 §3f (#169) measured the quantity `Prior move` gates on, directly, for the first time, and found
 it has real spread once expressed as a degree: `6m` median **+55.8%**, p25 +15.1 to p95 +370.7,
@@ -219,16 +219,64 @@ not a separate ticket because it only becomes real if this dimension is admitted
 refused the way `RS line` was, `Prior move` stays at ×1 and the gate keeps its record in the
 score.
 
-**It is inert until #171 runs.** §3f is executed trades against a same-name background, which is
+**It was inert until #171 ran.** §3f is executed trades against a same-name background, which is
 not a control group of rejected setups — the footing `RS line` was rightly refused on. Until the
-selection contrast exists there is no Δ, no pooled spread and no hit rate, and none of the four
-criteria can fire. #171's constraints attach: the contrast is measured under the detector the
+selection contrast existed there was no Δ, no pooled spread and no hit rate, and none of the four
+criteria could fire. #171's constraints attached: the contrast is measured under the detector the
 dimension would ship against (live v3, not the store's persisted v1), and it reproduces §5b's
 seven gaps as its control before anything new is trusted. Three bounds ride the result whatever
 it says: §2's coverage hole (§3f joined **70.2%** of his logged breakout longs to bars, skewed
 against the blown-up 2020–21 small-cap cohort), §9's absent control group on the *trade* side,
 and the regime bound below — which this candidate carries with full force, being index-relative
 by construction.
+
+#### The result (#171, findings §5e): **the criteria do not separate, and nothing ships**
+
+| Field | Taken | Not-taken | Δ | Pooled spread | Disagreement with `Prior move` |
+| --- | --- | --- | --- | --- | --- |
+| detector v1 | 91.3% (n=69) | 87.3% (n=14,354) | **+4.0** | 0.332 | 12.7% |
+| detector v3 (live) | 88.6% (n=140) | 84.9% (n=34,543) | **+3.6** | 0.357 | **15.1%** |
+
+Δ is **positive on both fields**, which is the one thing `RS line` never managed and the
+pre-registered evidence that the anchor was the mechanism behind its null. Criterion 4 does not
+fire. Criterion 3 does not fire.
+
+**Criteria 1 and 2 are the same number, and it landed on its own bound.** Disagreement with
+`Prior move` is exactly `1 − hit rate`, so the ~85% ceiling and the ~15% floor are one threshold
+read from two sides. Under v1 the not-taken hit rate is 87.3% and criterion 2 refuses the
+dimension. Under the live v3 — the field the ADR requires the verdict to be read on — it is
+**84.94%**, which is **0.06pp** inside the ceiling and **0.29 standard errors** from it (s.e.
+0.19pp at n=34,543). On the literal threshold criterion 1 admits it; on any reading that honours
+the tilde it does not.
+
+**This ADR declines to resolve that, and records why.** The ~15% was written down as "a
+judgement, not a measurement… the one magnitude in this design with nothing behind it," to be
+argued about *before* it decided anything. It has now decided something by six hundredths of a
+point, and the argument has not happened. Choosing a rounding here is choosing a verdict after
+seeing the number, which is the move the pre-registration clause exists to prevent — and the
+choice is not small: admission retires `Prior move`, forces `RUBRIC_VERSION = 4`, and changes the
+composition of every star ceiling frozen afterwards, which the consequences below call hard to
+reverse in the direction that matters.
+
+**Nothing shipped.** `RUBRIC_VERSION` stays 3, `DIMENSIONS` is untouched, `Prior move` keeps its
+×1 and the decile gate keeps its record in the score. Had the dimension been admitted its weight
+would have been **×1**: Δ +3.6 ranks below `Tightness` (+13.5) and below `MA support` (+6.3), so
+the ordinal rule puts it with the ×1s.
+
+**The gap is not firm either, and that is the more useful half of the result.** Δ +3.6pp carries
+a standard error of **2.70pp** on a taken group of 140 — 1.35 s.e. from zero, before §2's
+coverage hole is allowed for at all. The mechanism is the one criterion 2 was written for: within
+a field the decile gate has already filtered, **89.2% of the not-taken detections are up over six
+months** and 88.5% over twelve, so a `6m`-relative grade has little left to say there however
+much it has to say inside his trade record. `Prior move`'s 100.0%/100.0% is the limiting case of
+the same fact. §3f could not see this, because it never looks at the field.
+
+**What is settled, and what a third candidate must answer first.** The index-relative family is
+not folded — a positive Δ on both fields is the opposite of the result that would have folded it,
+and the anchor distinction the registration argued for in advance held up. What is not settled is
+this threshold. **No third candidate should be registered until the ~15% has been argued on its
+own**, because the next one will meet the same bound and a threshold chosen after two dimensions
+have bounced off it is not a pre-registration.
 
 ## The regime bound every candidate carries (#169)
 
@@ -272,10 +320,10 @@ instrument that could retire it, since it is the only planned measurement outsid
 ## Consequences
 
 **None of the first four have happened.** They are what follows *if* a registered dimension is
-admitted, and nothing has been: `RS line` was refused on criterion 4 and `Relative move` is
-unmeasured until #171. They are written in the indicative because they were written before the
-first verdict, and are left that way — a consequence restated as a hope reads as a weaker
-commitment than it is.
+admitted, and nothing has been: `RS line` was refused on criterion 4, and `Relative move` was
+measured by #171 and landed on the threshold that decides it. They are written in the indicative
+because they were written before the first verdict, and are left that way — a consequence
+restated as a hope reads as a weaker commitment than it is.
 
 - **`Prior move` is retired and the rubric's floor goes with it.** The permanent 0.5★ that
   `score.py` describes — "``Prior move`` fires for every detection by construction (a permanent

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -258,6 +258,16 @@ choice is not small: admission retires `Prior move`, forces `RUBRIC_VERSION = 4`
 composition of every star ceiling frozen afterwards, which the consequences below call hard to
 reverse in the direction that matters.
 
+**A third outcome, added after the fact and labelled as such.** This ADR promised pass or fail on
+one variant, and the study returned exactly that until the deciding number landed on the bound.
+`scripts/relative_move_contrast.py` now returns `on_the_bound` when the not-taken hit rate sits
+within **one standard error** of the ceiling or the floor. It was written after the measurement
+and that is recorded here rather than smoothed over — but it moves no threshold, the four
+criteria fire exactly where they are written above, it refuses a pass and a fail alike, and its
+width is the measured number's own sampling error rather than a figure chosen for the occasion.
+A rule that only ever *declines* to resolve cannot be the mechanism by which a preferred answer
+arrives.
+
 **Nothing shipped.** `RUBRIC_VERSION` stays 3, `DIMENSIONS` is untouched, `Prior move` keeps its
 ×1 and the decile gate keeps its record in the score. Had the dimension been admitted its weight
 would have been **×1**: Δ +3.6 ranks below `Tightness` (+13.5) and below `MA support` (+6.3), so

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -1024,6 +1024,11 @@ with 46.4% of entries *down* on the week, and the `1w` beat-rate against `QQQ` i
 ordinary day's 49.1% — a coin flip on both panels. This is the confirmation a future proposal to
 re-admit `1w` has to answer, and it is recorded here so the proposal starts from it.
 
+Both readings here are of his trades alone. §5e adds a **fourth** line with a comparison group
+under it — the same week measured against the not-taken detections, −4.5pp raw and −3.9pp netted
+— and one warning this section's convention earns: measured at the detection's own session
+instead of the one before, the same gap reads **+31.6pp**, all of it the entry day.
+
 #### Joined to base age: the flat week is the base, for 62.5% of entries (#172)
 
 The reading above — "he buys the quiet end of the base" — held two facts side by side without joining
@@ -1924,6 +1929,203 @@ occupies is still unfilled — this study removed a candidate for it, not the ca
 Reproduce with `python scripts/rs_line_contrast.py --store <copy of replay.duckdb>`; the
 machine-readable result is `references/rs_line_contrast.json`.
 
+### 5e. `Relative move` — the prior move as a degree. **Measured; the criteria do not separate** (#171)
+
+The second dimension pre-registered under
+`docs/adr/0005-what-admits-a-dimension-to-the-rubric.md`, and the answer to the gap §3f left
+open. §3f measured the prior move behind 582 of his entries against a **same-name background** —
+the same tickers on random ordinary days. That is §3d's device and it is deliberately weak: a
+random day is not a setup he passed over, so nothing computed against it is a precision figure
+(§9). §3f could therefore describe what he buys and show the description is not an artefact of
+the tape. It could not say what the strength cut-off costs, or whether a `6m`-relative prior move
+separates his picks from the setups he passed over.
+
+This is that measurement: §5b's instrument — taken detections against not-taken detections, no
+outcome variable anywhere — with the prior-move quantities carried as columns.
+
+**The dimension, as registered.** `((1 + r6m(name)) / (1 + r6m(index)) − 1) / ADR(name)`, hit
+above zero. Compounded rather than subtracted, both legs `calendar_return` so the anchor is
+calendar-dated, the `ADR` leg sliced to the scored session, a missing leg absent rather than
+zero, benchmark `^IXIC`. **One variant, pass or fail.** The executable definition is
+`screener.relative_strength.relative_move_adr` and the contrast imports it rather than restating
+it.
+
+#### The harness reproduces §5b and §5d before it is trusted
+
+Over the store's **persisted** detections, all `detector_version = 1`, it returns **69 taken /
+14,354 not-taken** and reproduces every one of §5b's seven gaps and §5d's `RS line` figure, on
+both fields, to the tenth of a point. That is two independent harnesses now landing on the same
+table, and it is the reason anything below is worth reading.
+
+#### The two fields, and the seven rubric dimensions on each
+
+| Dimension | Δ under v1 | Δ under v3 |
+| --- | --- | --- |
+| **ADR** | +29.3 | +26.4 |
+| **Tightness** | +20.8 | +13.5 |
+| MA support | +4.3 | +6.3 |
+| Prior move | 0.0 | 0.0 |
+| Volume | −3.9 | −0.3 |
+| Orderliness | −9.1 | −5.9 |
+| **Base length** | −13.4 | −7.8 |
+
+Unchanged from §5d, as it must be — same sessions, same universe, same recomputed ranks, and the
+detector is the only thing that moves between the two columns. 45,600 detections and 69 taken
+under v1; 123,558 and 140 under the live v3.
+
+#### The registered dimension, both fields
+
+| Field | Taken hit rate | Not-taken hit rate | Δ | Pooled spread | Disagreement with `Prior move` |
+| --- | --- | --- | --- | --- | --- |
+| detector v1 | 91.3% (n=69) | 87.3% (n=14,354) | **+4.0** | 0.332 | 12.7% |
+| detector v3 (live) | 88.6% (n=140) | 84.9% (n=34,543) | **+3.6** | 0.357 | **15.1%** |
+
+The gap is positive on both fields — the first index-relative candidate of which that is true,
+and the pre-registered answer to the objection that `RS line` had this shape already. Anchoring
+six calendar months back rather than at `base_start` does change the sign, so §5d's post-mortem
+named the mechanism correctly.
+
+#### Verdict against the four pre-registered criteria: **the criteria do not separate**
+
+ADR 0005 requires the contrast to be read on the field the dimension would ship against, which is
+the live v3. There, no criterion fires on the literal thresholds and criterion 1 admits the
+dimension. Under v1 criterion 2 refuses it. The two fields disagree, and the reason is one
+number sitting on its own bound:
+
+1. **Δ positive, not-taken hit rate between ~15% and ~85% → ship.** Fires under v3 — at
+   **84.94%**, which is **0.06pp** inside the ceiling.
+2. **Δ positive, disagreement with `Prior move` under ~15% on the not-taken group → do not
+   ship.** Fires under v1, at 12.7%. Under v3 disagreement is 15.06%, and disagreement is exactly
+   `1 − hit rate`, so criteria 1 and 2 are **the same number read from two sides**. Whichever way
+   that number is rounded, both criteria go with it.
+3. **Not-taken hit rate under ~15% → do not ship.** Does not fire; the dimension is not `RS line`
+   again, and that is the one thing it clearly is not.
+4. **Δ negative → do not ship.** Does not fire on either field.
+
+**So the letter says ship and the tilde says do not, and this study is not entitled to choose.**
+The margin is **0.29 standard errors** on the not-taken proportion (s.e. 0.19pp at n=34,543): the
+measured hit rate and the pre-registered ceiling are statistically the same number. ADR 0005
+recorded that threshold as "a judgement, not a measurement… the one magnitude in this design
+with nothing behind it," and said it should be argued about *before* it decided anything. It has
+now decided something, by six hundredths of a point, and the argument it invited has not
+happened. Picking a reading here — rounding 84.94% up to the bound, or down inside it — is
+choosing a verdict after seeing the number, which is the one move pre-registration exists to
+prevent.
+
+The gap itself is no firmer. **Δ +3.6pp carries a standard error of 2.70pp** (taken n=140), so it
+sits 1.35 s.e. from zero; under v1, +4.0pp against 3.40pp. A dimension whose gap cannot be
+distinguished from zero and whose hit rate cannot be distinguished from its own refusal bound has
+not produced the evidence ADR 0005 asks for, whichever side of the bound it is filed on.
+
+**No rubric change follows from this ticket.** `RUBRIC_VERSION` stays 3, `DIMENSIONS` is
+untouched, `Prior move` keeps its ×1 and the decile gate keeps its record in the score. Had the
+dimension been admitted cleanly its weight would have been **×1** — Δ +3.6 ranks below
+`Tightness` (+13.5) and below `MA support` (+6.3), so the ordinal rule puts it with the ×1s, not
+the ×2s. That is worth stating because it bounds what was at stake: the change on offer was to
+retire a dimension, force a rubric version, and alter the composition of every star ceiling
+frozen afterwards — ADR 0005's own list calls that hard to reverse in the direction that matters
+— in exchange for a ×1 row whose gap is 1.35 standard errors from nothing.
+
+#### Why the gap is small, and what criterion 2 was right about
+
+Criterion 2 was written for the possibility that a `6m`-relative grade has little left to say
+*within* a population the decile gate has already filtered, however much it has to say within his
+trade record. The descriptive columns show that is exactly what happened.
+
+| Column | Taken | Not-taken | Δ | Taken median (×ADR) | Not-taken median |
+| --- | --- | --- | --- | --- | --- |
+| raw `6m` | 95.0% | 89.2% | +5.8 | +11.54 | +11.53 |
+| raw `12m` | 89.3% | 88.5% | **+0.8** | +37.01 | +27.82 |
+| **`Relative move`** (rel `6m`) | 88.6% | 84.9% | +3.6 | +8.96 | +8.34 |
+| rel `12m` | 85.7% | 82.1% | +3.6 | +21.62 | +14.53 |
+
+Live detector v3; every value in ADR units, above-zero as the cut, and **every one of these
+columns is descriptive and permanently inadmissible** — ADR 0005 registers one variant per
+candidate, and reading a verdict off whichever column came back widest is the magnitude-fitting
+#128 Q2 forbids. They are here to explain the registered column, not to compete with it.
+
+The explanation is that **the field he passed over has already risen**. 89.2% of not-taken
+detections are up over six months and 88.5% over twelve; netting out the index moves those to
+84.9% and 82.1%. Every one of these columns is a near-constant in both groups, and the
+`Prior move` dimension is the limiting case of the same fact at 100.0%/100.0%. The decile gate
+guarantees top-decile in one of four lookbacks to *exist* as a detection, so by the time the
+contrast sees a name the question "has this thing gone up?" is nearly answered. §3f could not
+see this because it never looks at the field — which is precisely why this ticket exists, and
+why criterion 2 was the criterion most likely to fire.
+
+Note also that the raw `12m` column is a **true** constant-in-disguise at +0.8pp, while its
+index-relative form reads +3.6pp. Netting out the index buys real separation. It buys about three
+and a half points of it, off a base of eighty-five.
+
+#### `1w` over the field he passed over — the fourth line, and it is flat
+
+ADR 0003 excludes `1w` from `detection_gate`, and three lines of evidence now support that: the
+gate sweep (#149), and two readings of his own entries (§3f, narrowed per trade by #172). All
+three are drawn from his trades alone. This is the first with a comparison group under it.
+
+| Column | Taken | Not-taken | Δ | Taken median (×ADR) | Not-taken median |
+| --- | --- | --- | --- | --- | --- |
+| raw `1w`, at the detection session | 74.3% | 42.7% | **+31.6** | +0.50 | −0.18 |
+| raw `1w`, through the session before | 37.9% | 42.4% | **−4.5** | −0.19 | −0.19 |
+| rel `1w`, at the detection session | 67.9% | 39.0% | **+28.9** | +0.25 | −0.27 |
+| rel `1w`, through the session before | 35.0% | 38.9% | **−3.9** | −0.24 | −0.28 |
+
+**The whole of the first row is the entry day.** A taken detection's session *is* the session he
+entered on, so at the detection session the window holds the day he bought it — one bar in five.
+Measured through the session before, which is §3f's own convention and adopted there for the same
+reason (at a 09:42 median entry the entry day is not on screen at the click), the +31.6pp gap
+becomes −4.5pp and the medians are **identical to two decimals**: −0.19 ADR in his picks and
+−0.19 in the field he passed over.
+
+So the fourth line reads the same as the first three, and it is now the one line with a
+comparison group. Against the field he passed over on the same nights, the week before his entry
+is not distinguishable from the week before a setup he did not take. Had this section published
+the uncontrolled row it would have put +31.6pp on the record as the widest prior-move gap
+measured anywhere in this study — wider than `ADR`'s +26.4 — and it would have been an artefact
+of which session the window ended on.
+
+The control cuts the other way too: it is a reminder that every column in this section is read at
+the detection's own session, and that for the taken group that session is not a neutral one. Over
+six months one bar is nothing, which is why the registered dimension is left at its registered
+anchor. Over a week it is the entire result.
+
+#### Caveats carried with the result
+
+- **The coverage hole applies here as it does to §5b and §5d.** The taken group is the executed
+  trades that survived into the reconstructed field — 69 under v1, 140 under v3 — not his entry
+  record. §2's survivorship hole and §5b's high-ADR keeping bias bound this contrast the same
+  way, and the taken group is small enough that they bound it harder: the standard errors quoted
+  above are sampling error alone and assume the 140 are a fair draw, which §2 says they are not.
+- **The regime bound, with full force.** `QQQ` was negative over the trailing twelve months on
+  1.7% of his entry dates (§3f). An index-relative dimension measured on this record is measured
+  against a rising tape, and nothing here says what it does when the tape reverses.
+- **The benchmark contamination is §5d's, unchanged.** `^IXIC` sits in the store's `universe` and
+  `ranks` (#162) and reaches neither comparison group — 0 rows in `detections`, 0 of 505 sessions
+  above the gate. It shifts percentile denominators by ~0.1% and nothing else. It was left in
+  place for the same reason as before: rebuilding 4.7M rank rows would run this contrast against
+  a different field than §5b's and break the comparability the ordinal rule depends on.
+- **No third variant may be proposed off the back of this.** `RS line` was refused and this one
+  did not clear its bound; §5d's clause applies unchanged. Choosing a third anchor now, after
+  seeing which of two failed and how, is the fitting the pre-registration clause exists to
+  prevent.
+- **The store was read, not rebuilt.** `data/replay.duckdb` cannot be re-run in place — its
+  detections are detector v1 over 505 sessions and a full chain re-run raises
+  `SessionExistsError` — so this takes §5d's route: persisted detections for the v1 control, the
+  live field recomputed in memory, nothing written back. The ranks are the chain's own,
+  recomputed per session, not the store's pruned table (#141/#164).
+
+#### What this leaves open
+
+The rubric slot `Prior move` cannot earn is still open, and it is now open on a different footing
+than after §5d: not because the candidate pointed the wrong way, but because the criterion that
+would have decided it is a number nobody had evidence for, and the measurement landed on it. That
+argument is worth having on its own, before it decides a third candidate — and it is an argument
+about ADR 0005's ~15%, not about this dimension.
+
+Reproduce with `python scripts/relative_move_contrast.py --store <copy of replay.duckdb>`; the
+machine-readable result is `references/relative_move_contrast.json`. Run 2026-08-25, detector v1
+and live v3, rubric v3.
+
 ---
 
 ## 6. The two preliminary findings from #114
@@ -2167,9 +2369,14 @@ measurement outside this window.
   **The proxy is no longer the only route: §3f takes the quantity directly**, as the raw
   `1w/1m/3m/6m/12m` return behind each entry and as a return relative to `QQQ`/`^IXIC`, and
   finds real spread (`6m` median +55.8%, p25 +15.1 to p95 +370.7) with the same split of signs
-  — long lookbacks favourable, `1m` adverse. What stays unmeasurable is the **gate**: §3f is
-  still executed trades only, with a same-name background rather than a control group of
-  rejected setups, so it cannot price the decile cut itself. The 2020–21 caveat is now
+  — long lookbacks favourable, `1m` adverse. **§5e then put the quantity against the field he
+  passed over** (#171), which is as close to a control group as this study has: his picks beat
+  the index over six months 88.6% of the time against the not-taken detections' 84.9%, a gap of
+  +3.6pp with a standard error of 2.70pp. So the quantity is measurable, its gap points the
+  favourable way, and its gap is small — because a field the decile gate has already filtered is
+  89.2% up over six months before anyone looks at it. What stays unmeasurable is the **gate**
+  itself: the not-taken detections are names he may never have seen, not setups he rejected, so
+  neither §3f nor §5e can price the decile cut. The 2020–21 caveat is now
   bounded rather than removed — `QQQ` was negative over the trailing year on 1.7% of his entry
   dates, so the record holds almost no bear-market `12m` observations.
 - It cannot speak to **Episodic Pivot** or **Parabolic Short** setups, to **intraday**
@@ -2296,7 +2503,8 @@ _Provenance: PRD #114; A1 funnel #116/#119; A2 chain/field/placement #117/#118/#
 outcome regression #121; A3 selection contrast #122; this write-up #123. Analysis code:
 `backend/replay/`. Row-level seam: `backend/tests/test_replay_seam.py`. Decile decomposition
 #133; cluster characterisation #132; recalibration #138; paired A2 re-run #136; the tightness
-restructure #145/#154; the discrimination grid #165. Study last run **2026-08-22**, on detector
+restructure #145/#154; the discrimination grid #165; the `RS line` contrast #160; the
+`Relative move` contrast #171. Study last run **2026-08-22**, on detector
 v2 and rubric v3 — the run that re-pinned §3's detection row, §3's condition table and §4's
 `in_field` anchor. **§4b's grid is newer than that run** (`replay.discrimination_grid`,
 2026-08-25, read-only over the same store): it carries the only figures measured under the live

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -1953,9 +1953,12 @@ it.
 #### The harness reproduces §5b and §5d before it is trusted
 
 Over the store's **persisted** detections, all `detector_version = 1`, it returns **69 taken /
-14,354 not-taken** and reproduces every one of §5b's seven gaps and §5d's `RS line` figure, on
-both fields, to the tenth of a point. That is two independent harnesses now landing on the same
-table, and it is the reason anything below is worth reading.
+14,354 not-taken** and reproduces §5d's table exactly — every one of the seven rubric gaps on
+both fields, and `RS line`'s −5.8 / −2.1. That is two independent harnesses landing on the same
+numbers, and it is the reason anything below is worth reading.
+
+One digit differs from **§5b's** published table and it is §5b's own rounding: `ADR` is +29.31,
+which §5b printed as +29.4 and §5d as +29.3. Nothing else in either table moves.
 
 #### The two fields, and the seven rubric dimensions on each
 
@@ -2003,6 +2006,13 @@ number sitting on its own bound:
 4. **Δ negative → do not ship.** Does not fire on either field.
 
 **So the letter says ship and the tilde says do not, and this study is not entitled to choose.**
+The harness returns a third outcome, `on_the_bound`, and the machine-readable result records it
+rather than a pass or a fail. That rule was written **after** the measurement landed — it has to
+be said, because a rule written after the numbers is evidence about the threshold and not about
+the dimension. Three things keep it honest: it moves no threshold, the four criteria still fire
+exactly where ADR 0005 put them; it is symmetric, refusing a pass and a fail alike, so it cannot
+be the route by which a preferred answer arrives; and its width is the deciding number's own
+sampling error rather than a figure anybody picked.
 The margin is **0.29 standard errors** on the not-taken proportion (s.e. 0.19pp at n=34,543): the
 measured hit rate and the pre-registered ceiling are statistically the same number. ADR 0005
 recorded that threshold as "a judgement, not a measurement… the one magnitude in this design

--- a/references/relative_move_contrast.json
+++ b/references/relative_move_contrast.json
@@ -348,7 +348,10 @@
     "verdict": {
       "dimension": "Relative move",
       "delta_pp": 3.9628402323848455,
+      "delta_standard_error_pp": 3.4034627537967883,
       "margin_to_ceiling_pp": -2.341507593702108,
+      "margin_to_ceiling_se": -8.436857363482279,
+      "not_taken_hit_rate_standard_error_pp": 0.2775331492312512,
       "taken_hit_rate": 0.9130434782608695,
       "not_taken_hit_rate": 0.8734150759370211,
       "disagreement_with_prior_move": 0.12658492406297894,
@@ -359,7 +362,7 @@
           "reason": "not-taken hit rate above the ceiling \u2014 the constant in a new costume; disagreement with `Prior move` is under the floor"
         }
       ],
-      "ships": false
+      "outcome": "do_not_ship"
     }
   },
   "v3": {
@@ -711,13 +714,21 @@
     "verdict": {
       "dimension": "Relative move",
       "delta_pp": 3.628024697995458,
+      "delta_standard_error_pp": 2.6958015160764446,
       "margin_to_ceiling_pp": 0.05659612656688795,
+      "margin_to_ceiling_se": 0.2941294458811531,
+      "not_taken_hit_rate_standard_error_pp": 0.19241911124313738,
       "taken_hit_rate": 0.8857142857142857,
       "not_taken_hit_rate": 0.8494340387343311,
       "disagreement_with_prior_move": 0.1505659612656689,
       "pooled_spread": 0.35748214462560157,
-      "criteria_fired": [],
-      "ships": true
+      "criteria_fired": [
+        {
+          "criterion": 1,
+          "reason": "delta positive and the not-taken hit rate inside both bounds \u2014 ship, at the weight its ordinal position implies"
+        }
+      ],
+      "outcome": "on_the_bound"
     }
   }
 }

--- a/references/relative_move_contrast.json
+++ b/references/relative_move_contrast.json
@@ -1,0 +1,723 @@
+{
+  "v1": {
+    "label": "detector v1 (persisted)",
+    "sessions": 505,
+    "detections": 45600,
+    "n_taken": 69,
+    "n_not_taken": 14354,
+    "dimensions": [
+      {
+        "dimension": "Tightness",
+        "weight": 2,
+        "taken_n": 69,
+        "taken_hit_rate": 0.5942028985507246,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.38574613348195624,
+        "delta_pp": 20.84567650687684,
+        "pooled_spread": 0.48700404684397547,
+        "taken_spread": 0.49104563322021494,
+        "not_taken_spread": 0.48677104883679867,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Orderliness",
+        "weight": 1,
+        "taken_n": 69,
+        "taken_hit_rate": 0.2753623188405797,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.36623937578375365,
+        "delta_pp": -9.087705694317394,
+        "pooled_spread": 0.4816550626217143,
+        "taken_spread": 0.44669666688180987,
+        "not_taken_spread": 0.48177598052339654,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Prior move",
+        "weight": 1,
+        "taken_n": 69,
+        "taken_hit_rate": 1.0,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 1.0,
+        "delta_pp": 0.0,
+        "pooled_spread": 0.0,
+        "taken_spread": 0.0,
+        "not_taken_spread": 0.0,
+        "untestable_within_executed": true,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Base length",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.4492753623188406,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.5828340532255817,
+        "delta_pp": -13.35586909067411,
+        "pooled_spread": 0.493197693331357,
+        "taken_spread": 0.497420356571899,
+        "not_taken_spread": 0.49309078233751386,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "MA support",
+        "weight": 1,
+        "taken_n": 69,
+        "taken_hit_rate": 0.7681159420289855,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.7253727184060192,
+        "delta_pp": 4.274322362296623,
+        "pooled_spread": 0.4462229548682126,
+        "taken_spread": 0.4220353559003199,
+        "not_taken_spread": 0.44632626832652494,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Volume",
+        "weight": 1,
+        "taken_n": 69,
+        "taken_hit_rate": 0.36231884057971014,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.40100320468162187,
+        "delta_pp": -3.8684364101911726,
+        "pooled_spread": 0.4900642388402321,
+        "taken_spread": 0.48067025947179703,
+        "not_taken_spread": 0.49010165732905975,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "ADR",
+        "weight": 2,
+        "taken_n": 69,
+        "taken_hit_rate": 0.8695652173913043,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.5764943569736659,
+        "delta_pp": 29.307086041763842,
+        "pooled_spread": 0.4938948759203955,
+        "taken_spread": 0.33678116053977536,
+        "not_taken_spread": 0.494113967978224,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "RS line",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.07246376811594203,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.13034694161906088,
+        "delta_pp": -5.7883173503118845,
+        "pooled_spread": 0.33638046183736703,
+        "taken_spread": 0.2592542582608452,
+        "not_taken_spread": 0.3366847433870713,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Relative move",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.9130434782608695,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.8734150759370211,
+        "delta_pp": 3.9628402323848455,
+        "pooled_spread": 0.332294385455855,
+        "taken_spread": 0.2817713347133852,
+        "not_taken_spread": 0.3325074150495727,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 1w",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.7101449275362319,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.4886442803399749,
+        "delta_pp": 22.1500647196257,
+        "pooled_spread": 0.4998939800130054,
+        "taken_spread": 0.4536949519564791,
+        "not_taken_spread": 0.49987103099799945,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 6m",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.9710144927536232,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.9033718824021179,
+        "delta_pp": 6.764261035150532,
+        "pooled_spread": 0.29500839696473635,
+        "taken_spread": 0.16776575221435108,
+        "not_taken_spread": 0.29545071414259944,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 12m",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.855072463768116,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.8532813153128048,
+        "delta_pp": 0.17911484553111423,
+        "pooled_spread": 0.35381670072647203,
+        "taken_spread": 0.35202776236206146,
+        "not_taken_spread": 0.35382525666048004,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 1w (t-1)",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.36231884057971014,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.48557893270168595,
+        "delta_pp": -12.326009212197581,
+        "pooled_spread": 0.49977462668965944,
+        "taken_spread": 0.48067025947179703,
+        "not_taken_spread": 0.49979198954963,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "rel 1w",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.6376811594202898,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.41166225442385396,
+        "delta_pp": 22.601890499643584,
+        "pooled_spread": 0.4923274410913079,
+        "taken_spread": 0.4806702594717971,
+        "not_taken_spread": 0.49213457784078135,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "rel 12m",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.8405797101449275,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.776090288421346,
+        "delta_pp": 6.4489421723581515,
+        "pooled_spread": 0.4166577723198266,
+        "taken_spread": 0.3660675634873939,
+        "not_taken_spread": 0.4168622705875623,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "rel 1w (t-1)",
+        "weight": 0,
+        "taken_n": 69,
+        "taken_hit_rate": 0.2753623188405797,
+        "not_taken_n": 14354,
+        "not_taken_hit_rate": 0.41159258743207466,
+        "delta_pp": -13.623026859149496,
+        "pooled_spread": 0.4920045419391846,
+        "taken_spread": 0.44669666688180987,
+        "not_taken_spread": 0.4921220675838919,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      }
+    ],
+    "value_distributions": {
+      "raw 1w": {
+        "taken": {
+          "n": 69,
+          "p25": -0.05730702310850818,
+          "median": 0.44675146894920853,
+          "p75": 0.937915027910928
+        },
+        "not_taken": {
+          "n": 14354,
+          "p25": -0.5896825342494405,
+          "median": -0.019654450049496744,
+          "p75": 0.5752997417848299
+        }
+      },
+      "raw 6m": {
+        "taken": {
+          "n": 69,
+          "p25": 6.525770981529068,
+          "median": 13.868271420976173,
+          "p75": 28.447629526895522
+        },
+        "not_taken": {
+          "n": 14106,
+          "p25": 6.529953454552054,
+          "median": 13.08973273342946,
+          "p75": 21.73270987392821
+        }
+      },
+      "raw 12m": {
+        "taken": {
+          "n": 67,
+          "p25": 12.677823289650659,
+          "median": 33.39970800318829,
+          "p75": 77.86819238937622
+        },
+        "not_taken": {
+          "n": 13446,
+          "p25": 10.199508307087733,
+          "median": 24.566046149404038,
+          "p75": 45.57189547891426
+        }
+      },
+      "raw 1w (t-1)": {
+        "taken": {
+          "n": 69,
+          "p25": -0.6333583969186092,
+          "median": -0.20975361258189043,
+          "p75": 0.30108364883228594
+        },
+        "not_taken": {
+          "n": 14354,
+          "p25": -0.6508997018852579,
+          "median": -0.03178425679509174,
+          "p75": 0.62774749733062
+        }
+      },
+      "rel 1w": {
+        "taken": {
+          "n": 69,
+          "p25": -0.24682947940146335,
+          "median": 0.14089075523439598,
+          "p75": 0.7923110762325343
+        },
+        "not_taken": {
+          "n": 14354,
+          "p25": -0.7339240829403676,
+          "median": -0.18392887803200964,
+          "p75": 0.38785875734808317
+        }
+      },
+      "rel 12m": {
+        "taken": {
+          "n": 67,
+          "p25": 6.64559357388421,
+          "median": 20.15737329376466,
+          "p75": 46.53803097234146
+        },
+        "not_taken": {
+          "n": 13446,
+          "p25": 2.9856215264066184,
+          "median": 11.502599773259973,
+          "p75": 23.7570267117427
+        }
+      },
+      "rel 1w (t-1)": {
+        "taken": {
+          "n": 69,
+          "p25": -0.6510671341728687,
+          "median": -0.3269470005361562,
+          "p75": 0.013182492678768724
+        },
+        "not_taken": {
+          "n": 14354,
+          "p25": -0.8054622923299535,
+          "median": -0.2050272980725007,
+          "p75": 0.4304945615569279
+        }
+      },
+      "Relative move": {
+        "taken": {
+          "n": 69,
+          "p25": 6.283299408376393,
+          "median": 11.198573798571314,
+          "p75": 20.86843240628797
+        },
+        "not_taken": {
+          "n": 14106,
+          "p25": 4.327003531682052,
+          "median": 9.684101690080963,
+          "p75": 16.303270540357705
+        }
+      }
+    },
+    "verdict": {
+      "dimension": "Relative move",
+      "delta_pp": 3.9628402323848455,
+      "margin_to_ceiling_pp": -2.341507593702108,
+      "taken_hit_rate": 0.9130434782608695,
+      "not_taken_hit_rate": 0.8734150759370211,
+      "disagreement_with_prior_move": 0.12658492406297894,
+      "pooled_spread": 0.332294385455855,
+      "criteria_fired": [
+        {
+          "criterion": 2,
+          "reason": "not-taken hit rate above the ceiling \u2014 the constant in a new costume; disagreement with `Prior move` is under the floor"
+        }
+      ],
+      "ships": false
+    }
+  },
+  "v3": {
+    "label": "detector v3 (live, recomputed)",
+    "sessions": 505,
+    "detections": 123558,
+    "n_taken": 140,
+    "n_not_taken": 34543,
+    "dimensions": [
+      {
+        "dimension": "Tightness",
+        "weight": 2,
+        "taken_n": 140,
+        "taken_hit_rate": 0.32142857142857145,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.18666589468199057,
+        "delta_pp": 13.476267674658088,
+        "pooled_spread": 0.3900799097566101,
+        "taken_spread": 0.4670248868079293,
+        "not_taken_spread": 0.38964309110333595,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Orderliness",
+        "weight": 1,
+        "taken_n": 140,
+        "taken_hit_rate": 0.3,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.35874127898561214,
+        "delta_pp": -5.874127898561215,
+        "pooled_spread": 0.47956118384134605,
+        "taken_spread": 0.458257569495584,
+        "not_taken_spread": 0.4796310808708912,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Prior move",
+        "weight": 1,
+        "taken_n": 140,
+        "taken_hit_rate": 1.0,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 1.0,
+        "delta_pp": 0.0,
+        "pooled_spread": 0.0,
+        "taken_spread": 0.0,
+        "not_taken_spread": 0.0,
+        "untestable_within_executed": true,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Base length",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.4785714285714286,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.5569290449584575,
+        "delta_pp": -7.835761638702893,
+        "pooled_spread": 0.4967846581411007,
+        "taken_spread": 0.49954060528302463,
+        "not_taken_spread": 0.496748511663717,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "MA support",
+        "weight": 1,
+        "taken_n": 140,
+        "taken_hit_rate": 0.7285714285714285,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.6656630865877312,
+        "delta_pp": 6.2908341983697325,
+        "pooled_spread": 0.4716688907686246,
+        "taken_spread": 0.4446966404649538,
+        "not_taken_spread": 0.4717581390312475,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Volume",
+        "weight": 1,
+        "taken_n": 140,
+        "taken_hit_rate": 0.39285714285714285,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.39597023999073616,
+        "delta_pp": -0.3113097133593312,
+        "pooled_spread": 0.4890554103130447,
+        "taken_spread": 0.4883855118277623,
+        "not_taken_spread": 0.4890580834956263,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "ADR",
+        "weight": 2,
+        "taken_n": 140,
+        "taken_hit_rate": 0.8,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.5357091161740439,
+        "delta_pp": 26.429088382595612,
+        "pooled_spread": 0.4986456959428693,
+        "taken_spread": 0.4,
+        "not_taken_spread": 0.49872322887756954,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "RS line",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.1,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.12118229453145354,
+        "delta_pp": -2.1182294531453536,
+        "pooled_spread": 0.3262397249880452,
+        "taken_spread": 0.30000000000000004,
+        "not_taken_spread": 0.3263390047535623,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "Relative move",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.8857142857142857,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.8494340387343311,
+        "delta_pp": 3.628024697995458,
+        "pooled_spread": 0.35748214462560157,
+        "taken_spread": 0.318157963590287,
+        "not_taken_spread": 0.3576252963281736,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 1w",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.7428571428571429,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.42691717569406246,
+        "delta_pp": 31.59399671630804,
+        "pooled_spread": 0.4948168155656422,
+        "taken_spread": 0.43705881545081016,
+        "not_taken_spread": 0.4946300645851074,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 6m",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.95,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.8923370871088209,
+        "delta_pp": 5.766291289117909,
+        "pooled_spread": 0.3096593536543839,
+        "taken_spread": 0.21794494717703367,
+        "not_taken_spread": 0.30995420642244154,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 12m",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.8928571428571429,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.8848970847928669,
+        "delta_pp": 0.7960058064276021,
+        "pooled_spread": 0.319107346573142,
+        "taken_spread": 0.30929478706587094,
+        "not_taken_spread": 0.31914610152397704,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "raw 1w (t-1)",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.37857142857142856,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.4237906377558405,
+        "delta_pp": -4.521920918441197,
+        "pooled_spread": 0.49412981977780746,
+        "taken_spread": 0.48503103203899883,
+        "not_taken_spread": 0.49415800419130973,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "rel 1w",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.6785714285714286,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.38977506296500014,
+        "delta_pp": 28.879636560642847,
+        "pooled_spread": 0.48796115866373035,
+        "taken_spread": 0.4670248868079293,
+        "not_taken_spread": 0.4876991524040516,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "rel 12m",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.8571428571428571,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.8208030570593173,
+        "delta_pp": 3.6339800083539764,
+        "pooled_spread": 0.38339439392409863,
+        "taken_spread": 0.3499271061118826,
+        "not_taken_spread": 0.3835171424870033,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      },
+      {
+        "dimension": "rel 1w (t-1)",
+        "weight": 0,
+        "taken_n": 140,
+        "taken_hit_rate": 0.35,
+        "not_taken_n": 34543,
+        "not_taken_hit_rate": 0.38931187215933766,
+        "delta_pp": -3.931187215933768,
+        "pooled_spread": 0.48755818539473456,
+        "taken_spread": 0.47696960070847283,
+        "not_taken_spread": 0.48759423535879626,
+        "untestable_within_executed": false,
+        "testability_restored": false
+      }
+    ],
+    "value_distributions": {
+      "raw 1w": {
+        "taken": {
+          "n": 140,
+          "p25": -0.02446248481203022,
+          "median": 0.4977181708616696,
+          "p75": 0.9357402922025151
+        },
+        "not_taken": {
+          "n": 34543,
+          "p25": -0.8712627445307645,
+          "median": -0.1805657155359893,
+          "p75": 0.49855786901972654
+        }
+      },
+      "raw 6m": {
+        "taken": {
+          "n": 140,
+          "p25": 5.743215664513824,
+          "median": 11.536475244563876,
+          "p75": 25.094969825839303
+        },
+        "not_taken": {
+          "n": 34099,
+          "p25": 5.083713210394438,
+          "median": 11.531964347413403,
+          "p75": 20.098598194746895
+        }
+      },
+      "raw 12m": {
+        "taken": {
+          "n": 136,
+          "p25": 15.037833057545226,
+          "median": 37.006587762110314,
+          "p75": 67.34781730598951
+        },
+        "not_taken": {
+          "n": 32906,
+          "p25": 12.688290574370306,
+          "median": 27.821745127087816,
+          "p75": 48.35932135275093
+        }
+      },
+      "raw 1w (t-1)": {
+        "taken": {
+          "n": 140,
+          "p25": -0.6812171786799887,
+          "median": -0.19369908443503947,
+          "p75": 0.3252517723610968
+        },
+        "not_taken": {
+          "n": 34543,
+          "p25": -0.8971446094617059,
+          "median": -0.19327389456964358,
+          "p75": 0.5190227664605898
+        }
+      },
+      "rel 1w": {
+        "taken": {
+          "n": 140,
+          "p25": -0.2381439748960009,
+          "median": 0.2520221748742637,
+          "p75": 0.8571251842676463
+        },
+        "not_taken": {
+          "n": 34543,
+          "p25": -0.913564036494402,
+          "median": -0.26616505569075405,
+          "p75": 0.38145903280102816
+        }
+      },
+      "rel 12m": {
+        "taken": {
+          "n": 136,
+          "p25": 7.671158402402084,
+          "median": 21.621118122785035,
+          "p75": 36.270853575166036
+        },
+        "not_taken": {
+          "n": 32906,
+          "p25": 5.0458559557013665,
+          "median": 14.525060876279785,
+          "p75": 25.81895504102421
+        }
+      },
+      "rel 1w (t-1)": {
+        "taken": {
+          "n": 140,
+          "p25": -0.6513470777780743,
+          "median": -0.23821262939715404,
+          "p75": 0.17038862578434716
+        },
+        "not_taken": {
+          "n": 34543,
+          "p25": -0.947793774841992,
+          "median": -0.27943998680573673,
+          "p75": 0.40269165612436164
+        }
+      },
+      "Relative move": {
+        "taken": {
+          "n": 140,
+          "p25": 3.5887092663678084,
+          "median": 8.959424508782872,
+          "p75": 18.99165704321646
+        },
+        "not_taken": {
+          "n": 34099,
+          "p25": 3.0494877156736466,
+          "median": 8.338529830827502,
+          "p75": 14.916292999503458
+        }
+      }
+    },
+    "verdict": {
+      "dimension": "Relative move",
+      "delta_pp": 3.628024697995458,
+      "margin_to_ceiling_pp": 0.05659612656688795,
+      "taken_hit_rate": 0.8857142857142857,
+      "not_taken_hit_rate": 0.8494340387343311,
+      "disagreement_with_prior_move": 0.1505659612656689,
+      "pooled_spread": 0.35748214462560157,
+      "criteria_fired": [],
+      "ships": true
+    }
+  }
+}

--- a/scripts/relative_move_contrast.py
+++ b/scripts/relative_move_contrast.py
@@ -1,0 +1,552 @@
+"""The `Relative move` selection contrast — issue #171's pre-registered study.
+
+§3f (#169) measured the prior move behind 582 of his entries against a
+**same-name background**: the same tickers on random ordinary days. That is §3d's
+device and it is deliberately weak — a random day is not a setup he passed over,
+so no lift computed against it is a precision figure and §9 forbids citing one as
+such. What §3f cannot say is what the strength cut-off *costs*, or whether a
+`6m`-relative prior move separates his picks from the field he did not enter.
+
+This runs §5b's instrument over that question: **taken detections against
+not-taken detections**, no outcome variable anywhere, with the prior-move
+quantities added as columns. It is the measurement ADR 0005's second
+registration — `Relative move` — has been waiting on, and until it exists none of
+that registration's four criteria can fire.
+
+**The verdict reads one column, and only one.** `Relative move` is the
+pre-registered variant: the `6m` return relative to
+:data:`~screener.source.MARKET_INDEX`, compounded, in ADR units, hit above zero
+(:func:`screener.relative_strength.relative_move_adr`). Every other column —
+the raw move at `1w`/`6m`/`12m`, the relative move at `1w`/`12m`, and the two
+`1w` controls below — is **descriptive and permanently inadmissible**: ADR 0005
+registers one variant per candidate, and reading a verdict off whichever column
+came back widest is the magnitude-fitting #128 Q2 forbids. They are carried because §3f's own finding
+is that QQQ takes about a third of the `6m` move, and a contrast reporting only
+the net figure would leave that share invisible. `1w` is here for a third
+reason: ADR 0003 refuses the `1w` lookback and §3f gave that refusal its third
+line of evidence, all three drawn from his trades alone. A flat `1w` gap over the
+field he passed over is the fourth line, and the first with a comparison group
+under it.
+
+They are passed to :func:`replay.contrast.contrast_dimensions` as ``readers``
+rather than added to :data:`replay.contrast.CANDIDATES`, so the registered list
+stays an honest record of what was actually registered.
+
+**The `1w` columns are measured twice, and the second one is the control.** Every
+column above is read at the detection's own session, which for a *taken*
+detection is the session he entered on — so that day's close, the day he bought
+it, sits inside the window. Over six months one session is nothing; over a week
+it is a fifth of the window, and the taken group is by construction the names he
+bought that day. So `1w` is also measured through the session **strictly before**
+the detection — §3f's own convention, adopted there because at a 09:42 median
+entry the entry day's return is not on screen at the click. The pair separates a
+week he selected on from the day he traded on, and reporting only the first would
+have put a number on the record that ADR 0003's `1w` line cannot carry.
+
+**Two fields, and the first one is the control.**
+
+- **v1** — over the store's **persisted** detections, which all carry
+  ``detector_version = 1``. This is the field findings §5b was measured on, and
+  it runs first as the harness check: if it does not reproduce §5b's published
+  69 / 14,354 and its seven gaps, nothing below it can be trusted. §5d's result
+  is believable because its harness did exactly this, and this one inherits the
+  requirement rather than re-arguing it.
+- **the live detector** — detections **recomputed** with whatever
+  :data:`screener.detection.DETECTOR_VERSION` currently stamps. ADR 0005 requires
+  the contrast to be measured under the detector the dimension would ship
+  against, because an ordinal position read off a v1 table would rank a
+  v3-measured dimension among v1-measured ones — the field-change-versus-rubric-
+  change confound the paired re-run (#136) exists to prevent.
+
+Both run over the **same 505 sessions**, the ones the store holds detections for,
+so the detector is the only thing that moves between them.
+
+**Why the store is read and not rebuilt.** ``data/replay.duckdb`` cannot be
+re-run in place: its detections are detector v1 over 505 sessions and a full
+chain re-run raises ``SessionExistsError``. #171 offered three routes and this
+takes §5d's — read the persisted detections for the control, recompute the live
+field in memory, write nothing back. Appending the recomputed rows would leave
+the store holding two detectors under one ``(market, session)`` key and would
+destroy the v1 check on the next run. :class:`~screener.store.Store` migrates on
+open and so cannot be handed a read-only connection; run this against a **working
+copy** of the store, which is belt and braces on the same guarantee.
+
+**The ranks are the chain's, not the store's** (#141/#164).
+``Store.append_ranks`` prunes outside its retention window as the chain advances,
+so the persisted table cannot serve the early sessions and a gate read off it
+would silently empty the field. They are recomputed in memory with
+:func:`screener.ranks.rank_table`, which is what the app's own field replay does.
+
+**Criterion 2 needs no second measurement here.** `RS line`'s redundancy partner
+was price-at-a-new-high-over-base, which had to be computed. This dimension's
+partner is ``Prior move``, which is ``True`` on every detection by construction —
+so disagreement with it is exactly ``1 − hit rate``, read on the not-taken group,
+and it is reported from the contrast rather than recomputed.
+
+Run as ``python scripts/relative_move_contrast.py --store <copy of replay.duckdb>``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from bisect import bisect_left
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable
+
+_BACKEND = Path(__file__).resolve().parent.parent / "backend"
+sys.path.insert(0, str(_BACKEND))
+
+from replay.caching_store import CachingStore  # noqa: E402
+from replay.contrast import (  # noqa: E402
+    CONTRAST_DIMENSIONS,
+    contrast_dimensions,
+)
+from replay.field import (  # noqa: E402
+    ScoredDetection,
+    build_field,
+    session_relative_moves,
+    session_rs_lines,
+)
+from replay.reference import (  # noqa: E402
+    DEFAULT_REFERENCE_JSON,
+    classify,
+    load_trades,
+)
+from screener.detection import DETECTOR_VERSION, detection_gate, detect  # noqa: E402
+from screener.ranks import rank_table  # noqa: E402
+from screener.relative_strength import (  # noqa: E402
+    RELATIVE_MOVE_CUT,
+    RELATIVE_MOVE_LOOKBACK,
+    move_adr,
+    relative_move_adr,
+)
+from screener.source import MARKET_INDEX  # noqa: E402
+from screener.store import Store  # noqa: E402
+
+MARKET = "US"
+
+# The dimension the verdict is read off. Named from the registration rather than
+# spelled again, so a column heading and a criterion can never drift apart.
+REGISTERED = "Relative move"
+
+# The descriptive columns, and every one of them is inadmissible by construction
+# (ADR 0005's one-variant clause). `rel 6m` is absent because that *is* the
+# registered dimension — listing it twice would invite reading the pair as a
+# sweep with a winner.
+DESCRIPTIVE_WINDOWS: tuple[str, ...] = ("1w", "6m", "12m")
+
+# The window whose reading the entry session itself can move, and which is
+# therefore measured a second time through the prior session. One column heading
+# owns the suffix so the table, the distributions and the write-up cannot drift.
+PRIOR_SESSION_WINDOW = "1w"
+PRIOR_SESSION_SUFFIX = " (t-1)"
+
+
+@dataclass(frozen=True)
+class MoveValues:
+    """The descriptive prior-move quantities for one detection, all in ADR units.
+
+    ``raw`` is the name's own calendar return; ``rel`` is the same return netted
+    against the benchmark, compounded. Keyed by the column heading, so the `1w`
+    control carries :data:`PRIOR_SESSION_SUFFIX` and is never confused with the
+    reading at the detection's own session. A ``None`` is **absent** — the name
+    had not listed that far back, or has no ADR — never zero, which is a real
+    value sitting exactly on the cut.
+    """
+
+    raw: dict[str, float | None]
+    rel: dict[str, float | None]
+
+
+def prior_session(bars, session: date) -> date | None:
+    """The last bar the name printed **strictly before** ``session``.
+
+    §3f's evaluation session, and its reason: at a 09:42 median entry the entry
+    day's own return is not on screen at the click. Here it does a second job —
+    the taken group is the names he entered that session, so the detection day's
+    close is the one bar a `1w` window cannot afford to have in it.
+
+    ``None`` when the name has no earlier bar, which scores the column absent
+    under the same never-carried-forward rule as every other missing leg.
+    """
+    sessions = [b.session for b in bars]
+    idx = bisect_left(sessions, session) - 1
+    return sessions[idx] if idx >= 0 else None
+
+
+def move_values(bars, index_bars, as_of: date) -> MoveValues:
+    """Every descriptive column for one detection, from the same two series.
+
+    The registered dimension is **not** computed here: it rides the field member,
+    put there by :func:`replay.field.session_relative_moves`, so that the number
+    the contrast reads is the same number a shipped breakdown row would carry.
+    """
+    raw = {w: move_adr(bars, as_of, lookback=w) for w in DESCRIPTIVE_WINDOWS}
+    rel = {
+        w: relative_move_adr(bars, index_bars, as_of, lookback=w)
+        for w in DESCRIPTIVE_WINDOWS
+        if w != RELATIVE_MOVE_LOOKBACK
+    }
+    before = prior_session(bars, as_of)
+    key = PRIOR_SESSION_WINDOW + PRIOR_SESSION_SUFFIX
+    raw[key] = (
+        None if before is None
+        else move_adr(bars, before, lookback=PRIOR_SESSION_WINDOW)
+    )
+    rel[key] = (
+        None if before is None
+        else relative_move_adr(
+            bars, index_bars, before, lookback=PRIOR_SESSION_WINDOW
+        )
+    )
+    return MoveValues(raw=raw, rel=rel)
+
+
+def _column_windows(leg: str) -> list[str]:
+    """The column headings one leg contributes, in table order.
+
+    ``rel`` omits :data:`RELATIVE_MOVE_LOOKBACK` because that *is* the registered
+    dimension — listing it twice would invite reading the pair as a sweep with a
+    winner. Both legs carry the `1w` control.
+    """
+    windows = [
+        w for w in DESCRIPTIVE_WINDOWS
+        if not (leg == "rel" and w == RELATIVE_MOVE_LOOKBACK)
+    ]
+    return windows + [PRIOR_SESSION_WINDOW + PRIOR_SESSION_SUFFIX]
+
+
+def descriptive_columns(
+    values: dict[tuple[str, date], MoveValues],
+) -> tuple[tuple[tuple[str, int], ...], dict[str, Callable[[ScoredDetection], bool]]]:
+    """The descriptive columns as ``(dimensions, readers)`` for the contrast.
+
+    Every column takes the **same cut as the registered dimension** — above zero,
+    in ADR units. Not because zero is optimal anywhere, but because a per-column
+    cut is a free parameter per column, and six of those is a sweep. Zero means
+    "it went up" on the raw columns and "it outran the index" on the relative
+    ones, which is the only reading that needs no defending.
+    """
+    names: list[tuple[str, int]] = []
+    readers: dict[str, Callable[[ScoredDetection], bool]] = {}
+
+    def _reader(leg: str, window: str) -> Callable[[ScoredDetection], bool]:
+        def read(d: ScoredDetection) -> bool:
+            v = getattr(values[(d.symbol, d.detection.session)], leg)[window]
+            return v is not None and v > RELATIVE_MOVE_CUT
+
+        return read
+
+    for leg in ("raw", "rel"):
+        for window in _column_windows(leg):
+            name = f"{leg} {window}"
+            names.append((name, 0))
+            readers[name] = _reader(leg, window)
+    return tuple(names), readers
+
+
+# -- the two fields -----------------------------------------------------------
+
+
+def _measured_sessions(store: Store, market: str) -> list[date]:
+    """The sessions the store holds detections for — §5b's own window.
+
+    Both contrasts run over exactly these, so the detector is the only thing that
+    moves between them. They are also the sessions the store retained ranks for,
+    which is why the persisted field stops at 505 of the chain's 947.
+    """
+    rows = store._cursor().execute(
+        "SELECT DISTINCT session FROM detections WHERE market = ? ORDER BY 1",
+        [market],
+    ).fetchall()
+    return [r[0] for r in rows]
+
+
+def _session_ranks(store: Store, market: str, session: date):
+    """The session's rank table, recomputed in memory over its persisted universe.
+
+    What :func:`replay.chain._replay_session` does on reuse, and for the same
+    reason: :meth:`screener.store.Store.append_ranks` prunes rows outside its
+    retention window as the chain advances, so the persisted table cannot be read
+    back for every measured session (#141/#164). :func:`screener.ranks.rank_table`
+    is deterministic over the same members' bars, so this reproduces what the
+    chain computed rather than approximating it.
+    """
+    members = store.universe(market, session)
+    return members, rank_table(
+        {s: store.bars(market, s) for s in members}, session
+    )
+
+
+def _live_detections(store: Store, market: str, session: date, ranks) -> list:
+    """The session's detections under the **live** detector, computed not read.
+
+    :func:`screener.pipeline.rebuild_detections` is the app's own stage and this
+    is its loop exactly — every universe member, the decile gate deciding
+    eligibility, :func:`screener.detection.detect` on the gated ones — with the
+    single difference that the rows are *not* appended. The write is what is
+    omitted, never a gate.
+    """
+    gated = detection_gate(ranks)
+    out = []
+    for symbol in store.universe(market, session):
+        if symbol not in gated:
+            continue
+        found = detect(symbol, store.bars(market, symbol), session)
+        if found is not None:
+            out.append(found)
+    return out
+
+
+# -- the run ------------------------------------------------------------------
+
+
+@dataclass
+class Groups:
+    taken: list
+    not_taken: list
+    values: dict[tuple[str, date], MoveValues]
+    n_sessions: int
+    n_detections: int
+
+
+def collect(store, market, sessions, entries, *, live_detector: bool) -> Groups:
+    """Split every measured session's field into the taken and not-taken groups.
+
+    ``live_detector`` chooses the field: the store's persisted v1 rows, or a fresh
+    pass with the live detector. A quiet session (no entry) contributes to neither
+    group, exactly as :func:`replay.contrast.build_contrast` does — which is why
+    the descriptive values are computed only for the two groups and not for the
+    whole field.
+    """
+    taken, not_taken, total = [], [], 0
+    values: dict[tuple[str, date], MoveValues] = {}
+    index_bars = store.bars(market, MARKET_INDEX[market])
+    label = f"v{DETECTOR_VERSION}" if live_detector else "v1"
+    t0 = time.time()
+    for i, session in enumerate(sessions, start=1):
+        _members, ranks = _session_ranks(store, market, session)
+        dets = (
+            _live_detections(store, market, session, ranks)
+            if live_detector
+            else store.detections(market, session)
+        )
+        total += len(dets)
+
+        entered = entries.get(session, set())
+        scored = build_field(
+            dets, ranks, entered=entered, any_entry=bool(entered),
+            rs_line_of=session_rs_lines(store, market, dets),
+            relative_move_of=session_relative_moves(store, market, dets),
+        )
+        in_groups = [d for d in scored if d.taken or d.not_taken]
+        for d in in_groups:
+            values[(d.symbol, d.detection.session)] = move_values(
+                store.bars(market, d.symbol), index_bars, d.detection.session
+            )
+        taken.extend(d for d in in_groups if d.taken)
+        not_taken.extend(d for d in in_groups if d.not_taken)
+
+        if i % 25 == 0 or i == len(sessions):
+            rate = (time.time() - t0) / i
+            print(
+                f"  [{label}] {i}/{len(sessions)} {session}  dets={total}  "
+                f"taken={len(taken)} not_taken={len(not_taken)}  "
+                f"{rate:.2f}s/session eta {(len(sessions) - i) * rate / 60:.1f}m",
+                flush=True,
+            )
+    return Groups(taken, not_taken, values, len(sessions), total)
+
+
+def _distribution(xs: list[float]) -> dict | None:
+    """Median and quartiles of a value column, for the groups' own record.
+
+    The criteria read hit rates and nothing else — this is here so the verdict can
+    be read *against* §3f's published distribution rather than only against its
+    own sign, and so a gap driven by a handful of extreme names is visible as one.
+    """
+    xs = sorted(x for x in xs if x is not None)
+    if not xs:
+        return None
+    q = statistics.quantiles(xs, n=100) if len(xs) >= 2 else [xs[0]] * 99
+    return {
+        "n": len(xs),
+        "p25": q[24],
+        "median": statistics.median(xs),
+        "p75": q[74],
+    }
+
+
+def report(label: str, groups: Groups) -> dict:
+    """The contrast table for one field, with the descriptive columns appended."""
+    names, readers = descriptive_columns(groups.values)
+    contrasts = contrast_dimensions(
+        groups.taken,
+        groups.not_taken,
+        dimensions=CONTRAST_DIMENSIONS + names,
+        readers=readers,
+    )
+    print(f"\n=== {label} — {groups.n_sessions} sessions, "
+          f"{groups.n_detections} detections ===")
+    print(f"taken: {len(groups.taken)}   not-taken: {len(groups.not_taken)}")
+    print(f"{'dimension':<16}{'w':>3}  {'taken':>8} {'not-taken':>10} "
+          f"{'delta':>9} {'pooled sd':>10}")
+    rows = []
+    for c in contrasts:
+        delta = (c.taken_hit_rate - c.not_taken_hit_rate) * 100
+        mark = "  <- registered" if c.dimension == REGISTERED else ""
+        print(f"{c.dimension:<16}x{c.weight}  {c.taken_hit_rate:>7.1%} "
+              f"{c.not_taken_hit_rate:>10.1%} {delta:>+8.1f}pp "
+              f"{c.combined_spread:>10.3f}{mark}")
+        rows.append({
+            "dimension": c.dimension, "weight": c.weight,
+            "taken_n": c.taken_n, "taken_hit_rate": c.taken_hit_rate,
+            "not_taken_n": c.not_taken_n,
+            "not_taken_hit_rate": c.not_taken_hit_rate,
+            "delta_pp": delta, "pooled_spread": c.combined_spread,
+            "taken_spread": c.taken_spread,
+            "not_taken_spread": c.not_taken_spread,
+            "untestable_within_executed": c.untestable_within_executed,
+            "testability_restored": c.testability_restored,
+        })
+
+    values = {}
+    for leg in ("raw", "rel"):
+        for window in _column_windows(leg):
+            key = f"{leg} {window}"
+            values[key] = {
+                group: _distribution([
+                    getattr(groups.values[(d.symbol, d.detection.session)], leg)[window]
+                    for d in rows_of
+                ])
+                for group, rows_of in (
+                    ("taken", groups.taken), ("not_taken", groups.not_taken)
+                )
+            }
+    values[REGISTERED] = {
+        group: _distribution([d.relative_move for d in rows_of])
+        for group, rows_of in (
+            ("taken", groups.taken), ("not_taken", groups.not_taken)
+        )
+    }
+
+    return {
+        "label": label, "sessions": groups.n_sessions,
+        "detections": groups.n_detections,
+        "n_taken": len(groups.taken), "n_not_taken": len(groups.not_taken),
+        "dimensions": rows,
+        "value_distributions": values,
+    }
+
+
+# The bounds ADR 0005 fixed for the registered dimension, before any of this was
+# visible. Criterion 2's partner is ``Prior move``, ``True`` on every detection,
+# so disagreement with it is exactly ``1 − hit rate`` on the not-taken group —
+# which makes criteria 2 and 3 a two-sided bound on that one number.
+HIT_RATE_FLOOR = 0.15
+HIT_RATE_CEILING = 0.85
+
+
+def verdict(block: dict) -> dict:
+    """The four pre-registered criteria, evaluated against the registered column.
+
+    Written to fire mechanically: nothing here chooses which column to read, and
+    the thresholds are the ADR's, not this script's. The criteria are evaluated in
+    the order they were registered, and the **first that fires decides** — as it
+    did for `RS line`, where criterion 4 fired and criterion 2 stood ready.
+    """
+    row = next(r for r in block["dimensions"] if r["dimension"] == REGISTERED)
+    delta = row["delta_pp"]
+    not_taken = row["not_taken_hit_rate"]
+    fired = []
+    if delta <= 0:
+        fired.append((4, "delta negative — do not ship, and record it"))
+    if not_taken > HIT_RATE_CEILING:
+        fired.append((2, "not-taken hit rate above the ceiling — the constant in a "
+                         "new costume; disagreement with `Prior move` is under the "
+                         "floor"))
+    if not_taken < HIT_RATE_FLOOR:
+        fired.append((3, "not-taken hit rate under the floor — it discriminates "
+                         "over a sliver of the field"))
+    ships = not fired
+    return {
+        "dimension": REGISTERED,
+        "delta_pp": delta,
+        # How far the not-taken hit rate sits from the bound that decides this,
+        # recorded because criteria 1 and 3 are the *same* number read from two
+        # sides — disagreement with `Prior move` is exactly ``1 - hit rate`` —
+        # and a verdict turning on a tenth of a point against a threshold ADR
+        # 0005 itself calls a judgement is a fact about the threshold.
+        "margin_to_ceiling_pp": (HIT_RATE_CEILING - not_taken) * 100,
+        "taken_hit_rate": row["taken_hit_rate"],
+        "not_taken_hit_rate": not_taken,
+        "disagreement_with_prior_move": 1.0 - not_taken,
+        "pooled_spread": row["pooled_spread"],
+        "criteria_fired": [{"criterion": n, "reason": why} for n, why in fired],
+        "ships": ships,
+    }
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True)
+    parser.add_argument("--reference", default=str(DEFAULT_REFERENCE_JSON))
+    parser.add_argument("--market", default=MARKET)
+    parser.add_argument("--out", default="references/relative_move_contrast.json")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="first N sessions only — a smoke run, never a result")
+    args = parser.parse_args(argv)
+
+    store = CachingStore.wrap(Store.open(args.store))
+    market = args.market
+
+    trades = load_trades(args.reference)
+    classified = classify(trades, store, market=market)
+    replayable = [c.trade for c in classified if c.replayable]
+    entries: dict[date, set[str]] = defaultdict(set)
+    for t in replayable:
+        entries[t.entry_date].add(t.ticker)
+    print(f"trades: {len(trades)}  replayable: {len(replayable)}  "
+          f"entry sessions: {len(entries)}")
+
+    sessions = _measured_sessions(store, market)
+    if args.limit:
+        sessions = sessions[: args.limit]
+    print(f"measured sessions: {len(sessions)}  "
+          f"{sessions[0]} -> {sessions[-1]}  live detector v{DETECTOR_VERSION}")
+
+    # The live stamp, never a literal: #149 bumped the detector to v3 after ADR
+    # 0005 was drafted, so a document that says "v2" is already one field behind.
+    live_label = f"detector v{DETECTOR_VERSION} (live, recomputed)"
+    results = {}
+    for label, live in (("detector v1 (persisted)", False), (live_label, True)):
+        groups = collect(store, market, sessions, entries, live_detector=live)
+        block = report(label, groups)
+        block["verdict"] = verdict(block)
+        v = block["verdict"]
+        print(f"\n{REGISTERED} under {label}: delta {v['delta_pp']:+.1f}pp, "
+              f"not-taken hit rate {v['not_taken_hit_rate']:.1%}, "
+              f"disagreement with `Prior move` "
+              f"{v['disagreement_with_prior_move']:.1%}")
+        for fired in v["criteria_fired"]:
+            print(f"  criterion {fired['criterion']} fires: {fired['reason']}")
+        print(f"  -> {'SHIP' if v['ships'] else 'DO NOT SHIP'}")
+        results["v1" if not live else f"v{DETECTOR_VERSION}"] = block
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(results, indent=2, default=str))
+    print(f"\nwrote {out}")
+    store.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/relative_move_contrast.py
+++ b/scripts/relative_move_contrast.py
@@ -71,17 +71,17 @@ destroy the v1 check on the next run. :class:`~screener.store.Store` migrates on
 open and so cannot be handed a read-only connection; run this against a **working
 copy** of the store, which is belt and braces on the same guarantee.
 
-**The ranks are the chain's, not the store's** (#141/#164).
-``Store.append_ranks`` prunes outside its retention window as the chain advances,
-so the persisted table cannot serve the early sessions and a gate read off it
-would silently empty the field. They are recomputed in memory with
-:func:`screener.ranks.rank_table`, which is what the app's own field replay does.
+**The ranks are the chain's, not the store's** (#141/#164), and the three
+read-only stages that make that true are :mod:`replay.candidate_field`, shared
+with the `RS line` study — see that module for why they are not repeated here.
 
 **Criterion 2 needs no second measurement here.** `RS line`'s redundancy partner
 was price-at-a-new-high-over-base, which had to be computed. This dimension's
 partner is ``Prior move``, which is ``True`` on every detection by construction —
 so disagreement with it is exactly ``1 − hit rate``, read on the not-taken group,
-and it is reported from the contrast rather than recomputed.
+and it is reported from the contrast rather than recomputed. Which also means
+**criteria 1 and 2 are one threshold read from two sides**, and the #171 run put
+that one number on it; see :func:`verdict`.
 
 Run as ``python scripts/relative_move_contrast.py --store <copy of replay.duckdb>``.
 """
@@ -104,6 +104,11 @@ _BACKEND = Path(__file__).resolve().parent.parent / "backend"
 sys.path.insert(0, str(_BACKEND))
 
 from replay.caching_store import CachingStore  # noqa: E402
+from replay.candidate_field import (  # noqa: E402
+    live_detections,
+    measured_sessions,
+    session_ranks,
+)
 from replay.contrast import (  # noqa: E402
     CONTRAST_DIMENSIONS,
     contrast_dimensions,
@@ -119,13 +124,12 @@ from replay.reference import (  # noqa: E402
     classify,
     load_trades,
 )
-from screener.detection import DETECTOR_VERSION, detection_gate, detect  # noqa: E402
-from screener.ranks import rank_table  # noqa: E402
+from screener.detection import DETECTOR_VERSION  # noqa: E402
 from screener.relative_strength import (  # noqa: E402
-    RELATIVE_MOVE_CUT,
     RELATIVE_MOVE_LOOKBACK,
     move_adr,
     relative_move_adr,
+    relative_move_hit,
 )
 from screener.source import MARKET_INDEX  # noqa: E402
 from screener.store import Store  # noqa: E402
@@ -153,16 +157,16 @@ PRIOR_SESSION_SUFFIX = " (t-1)"
 class MoveValues:
     """The descriptive prior-move quantities for one detection, all in ADR units.
 
-    ``raw`` is the name's own calendar return; ``rel`` is the same return netted
-    against the benchmark, compounded. Keyed by the column heading, so the `1w`
-    control carries :data:`PRIOR_SESSION_SUFFIX` and is never confused with the
-    reading at the detection's own session. A ``None`` is **absent** — the name
-    had not listed that far back, or has no ADR — never zero, which is a real
-    value sitting exactly on the cut.
+    Keyed by the **column heading** the table prints — ``"raw 6m"``,
+    ``"rel 1w (t-1)"`` — built by :func:`column_heading` and by nothing else, so
+    the readers, the distributions and the printed table cannot key one thing
+    three ways.
+
+    A ``None`` is **absent** — the name had not listed that far back, or has no
+    ADR — never zero, which is a real value sitting exactly on the cut.
     """
 
-    raw: dict[str, float | None]
-    rel: dict[str, float | None]
+    by_column: dict[str, float | None]
 
 
 def prior_session(bars, session: date) -> date | None:
@@ -181,6 +185,42 @@ def prior_session(bars, session: date) -> date | None:
     return sessions[idx] if idx >= 0 else None
 
 
+def column_heading(leg: str, window: str, *, at_prior_session: bool = False) -> str:
+    """The one place a descriptive column's name is spelled.
+
+    Three sites need it — the readers, the value distributions and the printed
+    table — and a column whose heading is composed independently in each is a
+    column that can go missing from one of them silently.
+    """
+    return f"{leg} {window}" + (PRIOR_SESSION_SUFFIX if at_prior_session else "")
+
+
+def descriptive_legs() -> list[tuple[str, str, bool]]:
+    """Every descriptive column as ``(leg, window, at_prior_session)``, in table
+    order.
+
+    ``rel`` omits :data:`RELATIVE_MOVE_LOOKBACK` because that *is* the registered
+    dimension — listing it twice would invite reading the pair as a sweep with a
+    winner. Both legs carry the `1w` control.
+    """
+    out: list[tuple[str, str, bool]] = []
+    for leg in ("raw", "rel"):
+        for window in DESCRIPTIVE_WINDOWS:
+            if leg == "rel" and window == RELATIVE_MOVE_LOOKBACK:
+                continue
+            out.append((leg, window, False))
+        out.append((leg, PRIOR_SESSION_WINDOW, True))
+    return out
+
+
+def column_headings() -> list[str]:
+    """The descriptive column headings, in table order."""
+    return [
+        column_heading(leg, window, at_prior_session=at_prior)
+        for leg, window, at_prior in descriptive_legs()
+    ]
+
+
 def move_values(bars, index_bars, as_of: date) -> MoveValues:
     """Every descriptive column for one detection, from the same two series.
 
@@ -188,39 +228,18 @@ def move_values(bars, index_bars, as_of: date) -> MoveValues:
     put there by :func:`replay.field.session_relative_moves`, so that the number
     the contrast reads is the same number a shipped breakdown row would carry.
     """
-    raw = {w: move_adr(bars, as_of, lookback=w) for w in DESCRIPTIVE_WINDOWS}
-    rel = {
-        w: relative_move_adr(bars, index_bars, as_of, lookback=w)
-        for w in DESCRIPTIVE_WINDOWS
-        if w != RELATIVE_MOVE_LOOKBACK
-    }
     before = prior_session(bars, as_of)
-    key = PRIOR_SESSION_WINDOW + PRIOR_SESSION_SUFFIX
-    raw[key] = (
-        None if before is None
-        else move_adr(bars, before, lookback=PRIOR_SESSION_WINDOW)
-    )
-    rel[key] = (
-        None if before is None
-        else relative_move_adr(
-            bars, index_bars, before, lookback=PRIOR_SESSION_WINDOW
-        )
-    )
-    return MoveValues(raw=raw, rel=rel)
-
-
-def _column_windows(leg: str) -> list[str]:
-    """The column headings one leg contributes, in table order.
-
-    ``rel`` omits :data:`RELATIVE_MOVE_LOOKBACK` because that *is* the registered
-    dimension — listing it twice would invite reading the pair as a sweep with a
-    winner. Both legs carry the `1w` control.
-    """
-    windows = [
-        w for w in DESCRIPTIVE_WINDOWS
-        if not (leg == "rel" and w == RELATIVE_MOVE_LOOKBACK)
-    ]
-    return windows + [PRIOR_SESSION_WINDOW + PRIOR_SESSION_SUFFIX]
+    by_column: dict[str, float | None] = {}
+    for leg, window, at_prior in descriptive_legs():
+        when = before if at_prior else as_of
+        if when is None:
+            value = None
+        elif leg == "raw":
+            value = move_adr(bars, when, lookback=window)
+        else:
+            value = relative_move_adr(bars, index_bars, when, lookback=window)
+        by_column[column_heading(leg, window, at_prior_session=at_prior)] = value
+    return MoveValues(by_column=by_column)
 
 
 def descriptive_columns(
@@ -237,72 +256,18 @@ def descriptive_columns(
     names: list[tuple[str, int]] = []
     readers: dict[str, Callable[[ScoredDetection], bool]] = {}
 
-    def _reader(leg: str, window: str) -> Callable[[ScoredDetection], bool]:
+    def _reader(column: str) -> Callable[[ScoredDetection], bool]:
         def read(d: ScoredDetection) -> bool:
-            v = getattr(values[(d.symbol, d.detection.session)], leg)[window]
-            return v is not None and v > RELATIVE_MOVE_CUT
+            return relative_move_hit(
+                values[(d.symbol, d.detection.session)].by_column[column]
+            )
 
         return read
 
-    for leg in ("raw", "rel"):
-        for window in _column_windows(leg):
-            name = f"{leg} {window}"
-            names.append((name, 0))
-            readers[name] = _reader(leg, window)
+    for column in column_headings():
+        names.append((column, 0))
+        readers[column] = _reader(column)
     return tuple(names), readers
-
-
-# -- the two fields -----------------------------------------------------------
-
-
-def _measured_sessions(store: Store, market: str) -> list[date]:
-    """The sessions the store holds detections for — §5b's own window.
-
-    Both contrasts run over exactly these, so the detector is the only thing that
-    moves between them. They are also the sessions the store retained ranks for,
-    which is why the persisted field stops at 505 of the chain's 947.
-    """
-    rows = store._cursor().execute(
-        "SELECT DISTINCT session FROM detections WHERE market = ? ORDER BY 1",
-        [market],
-    ).fetchall()
-    return [r[0] for r in rows]
-
-
-def _session_ranks(store: Store, market: str, session: date):
-    """The session's rank table, recomputed in memory over its persisted universe.
-
-    What :func:`replay.chain._replay_session` does on reuse, and for the same
-    reason: :meth:`screener.store.Store.append_ranks` prunes rows outside its
-    retention window as the chain advances, so the persisted table cannot be read
-    back for every measured session (#141/#164). :func:`screener.ranks.rank_table`
-    is deterministic over the same members' bars, so this reproduces what the
-    chain computed rather than approximating it.
-    """
-    members = store.universe(market, session)
-    return members, rank_table(
-        {s: store.bars(market, s) for s in members}, session
-    )
-
-
-def _live_detections(store: Store, market: str, session: date, ranks) -> list:
-    """The session's detections under the **live** detector, computed not read.
-
-    :func:`screener.pipeline.rebuild_detections` is the app's own stage and this
-    is its loop exactly — every universe member, the decile gate deciding
-    eligibility, :func:`screener.detection.detect` on the gated ones — with the
-    single difference that the rows are *not* appended. The write is what is
-    omitted, never a gate.
-    """
-    gated = detection_gate(ranks)
-    out = []
-    for symbol in store.universe(market, session):
-        if symbol not in gated:
-            continue
-        found = detect(symbol, store.bars(market, symbol), session)
-        if found is not None:
-            out.append(found)
-    return out
 
 
 # -- the run ------------------------------------------------------------------
@@ -332,9 +297,9 @@ def collect(store, market, sessions, entries, *, live_detector: bool) -> Groups:
     label = f"v{DETECTOR_VERSION}" if live_detector else "v1"
     t0 = time.time()
     for i, session in enumerate(sessions, start=1):
-        _members, ranks = _session_ranks(store, market, session)
+        _members, ranks = session_ranks(store, market, session)
         dets = (
-            _live_detections(store, market, session, ranks)
+            live_detections(store, market, session, ranks)
             if live_detector
             else store.detections(market, session)
         )
@@ -418,18 +383,16 @@ def report(label: str, groups: Groups) -> dict:
         })
 
     values = {}
-    for leg in ("raw", "rel"):
-        for window in _column_windows(leg):
-            key = f"{leg} {window}"
-            values[key] = {
-                group: _distribution([
-                    getattr(groups.values[(d.symbol, d.detection.session)], leg)[window]
-                    for d in rows_of
-                ])
-                for group, rows_of in (
-                    ("taken", groups.taken), ("not_taken", groups.not_taken)
-                )
-            }
+    for column in column_headings():
+        values[column] = {
+            group: _distribution([
+                groups.values[(d.symbol, d.detection.session)].by_column[column]
+                for d in rows_of
+            ])
+            for group, rows_of in (
+                ("taken", groups.taken), ("not_taken", groups.not_taken)
+            )
+        }
     values[REGISTERED] = {
         group: _distribution([d.relative_move for d in rows_of])
         for group, rows_of in (
@@ -448,49 +411,102 @@ def report(label: str, groups: Groups) -> dict:
 
 # The bounds ADR 0005 fixed for the registered dimension, before any of this was
 # visible. Criterion 2's partner is ``Prior move``, ``True`` on every detection,
-# so disagreement with it is exactly ``1 − hit rate`` on the not-taken group —
-# which makes criteria 2 and 3 a two-sided bound on that one number.
+# so disagreement with it is exactly ``1 − hit rate`` on the not-taken group.
+# **Criteria 1 and 2 are therefore one threshold read from two sides**: criterion
+# 1's ~85% ceiling and criterion 2's ~15% disagreement floor are the same cut on
+# the same number, and whichever way it rounds, both go with it.
 HIT_RATE_FLOOR = 0.15
 HIT_RATE_CEILING = 0.85
+
+# The three outcomes this script can return. ``ON_THE_BOUND`` is the one ADR 0005
+# did not anticipate, and it exists because the run produced it: see
+# :func:`verdict`.
+SHIP = "ship"
+DO_NOT_SHIP = "do_not_ship"
+ON_THE_BOUND = "on_the_bound"
+
+
+def _standard_error(p: float, n: int) -> float:
+    """Sampling error of a proportion. Zero on an empty group."""
+    return (p * (1 - p) / n) ** 0.5 if n else 0.0
 
 
 def verdict(block: dict) -> dict:
     """The four pre-registered criteria, evaluated against the registered column.
 
     Written to fire mechanically: nothing here chooses which column to read, and
-    the thresholds are the ADR's, not this script's. The criteria are evaluated in
-    the order they were registered, and the **first that fires decides** — as it
-    did for `RS line`, where criterion 4 fired and criterion 2 stood ready.
+    the thresholds are the ADR's, not this script's. All four are evaluated and
+    every one that fires is recorded, rather than stopping at the first — for
+    `RS line`, criterion 4 fired and criterion 2 stood ready behind it, and the
+    fact that a second one would also have refused it was worth having.
+
+    **The third outcome, and why it is not a fifth criterion.** ADR 0005 promises
+    pass or fail on one variant, and this function returned exactly that until the
+    #171 run put the deciding number 0.06pp inside its own bound — 0.29 standard
+    errors, on a threshold the ADR records as "a judgement, not a measurement…
+    the one magnitude in this design with nothing behind it". So a hit rate within
+    **one standard error** of the ceiling or the floor returns
+    :data:`ON_THE_BOUND` rather than a verdict.
+
+    Three things keep that honest. It **moves no threshold**: the ADR's numbers
+    are untouched and the criteria still fire exactly where they did. It is
+    **symmetric**: it refuses a pass and a fail alike, so it cannot be the
+    mechanism by which a preferred answer arrives. And it is **stated as
+    post-hoc**, here and in the ADR, because it is — it was added after the
+    measurement landed on the bound, and a rule written after the numbers is
+    evidence about the threshold rather than about the dimension.
     """
     row = next(r for r in block["dimensions"] if r["dimension"] == REGISTERED)
     delta = row["delta_pp"]
     not_taken = row["not_taken_hit_rate"]
+    se = _standard_error(not_taken, row["not_taken_n"])
+
     fired = []
-    if delta <= 0:
-        fired.append((4, "delta negative — do not ship, and record it"))
-    if not_taken > HIT_RATE_CEILING:
+    if delta > 0 and HIT_RATE_FLOOR <= not_taken <= HIT_RATE_CEILING:
+        fired.append((1, "delta positive and the not-taken hit rate inside both "
+                         "bounds — ship, at the weight its ordinal position implies"))
+    if delta > 0 and not_taken > HIT_RATE_CEILING:
         fired.append((2, "not-taken hit rate above the ceiling — the constant in a "
                          "new costume; disagreement with `Prior move` is under the "
                          "floor"))
     if not_taken < HIT_RATE_FLOOR:
         fired.append((3, "not-taken hit rate under the floor — it discriminates "
                          "over a sliver of the field"))
-    ships = not fired
+    if delta <= 0:
+        fired.append((4, "delta negative — do not ship, and record it"))
+
+    on_the_bound = (
+        se > 0
+        and min(abs(not_taken - HIT_RATE_CEILING), abs(not_taken - HIT_RATE_FLOOR))
+        <= se
+    )
+    if on_the_bound:
+        outcome = ON_THE_BOUND
+    elif [n for n, _ in fired] == [1]:
+        outcome = SHIP
+    else:
+        outcome = DO_NOT_SHIP
+
     return {
         "dimension": REGISTERED,
         "delta_pp": delta,
-        # How far the not-taken hit rate sits from the bound that decides this,
-        # recorded because criteria 1 and 3 are the *same* number read from two
-        # sides — disagreement with `Prior move` is exactly ``1 - hit rate`` —
-        # and a verdict turning on a tenth of a point against a threshold ADR
-        # 0005 itself calls a judgement is a fact about the threshold.
+        "delta_standard_error_pp": 100 * (
+            _standard_error(row["taken_hit_rate"], row["taken_n"]) ** 2 + se ** 2
+        ) ** 0.5,
+        # How far the deciding number sits from the bound that decides it, in
+        # points and in its own sampling error. A verdict turning on a tenth of a
+        # point against a threshold ADR 0005 itself calls a judgement is a fact
+        # about the threshold, and it belongs in the machine-readable record and
+        # not only in the prose.
         "margin_to_ceiling_pp": (HIT_RATE_CEILING - not_taken) * 100,
+        "margin_to_ceiling_se": (HIT_RATE_CEILING - not_taken) / se if se else None,
+        "not_taken_hit_rate_standard_error_pp": se * 100,
         "taken_hit_rate": row["taken_hit_rate"],
         "not_taken_hit_rate": not_taken,
         "disagreement_with_prior_move": 1.0 - not_taken,
         "pooled_spread": row["pooled_spread"],
         "criteria_fired": [{"criterion": n, "reason": why} for n, why in fired],
-        "ships": ships,
+        "outcome": outcome,
     }
 
 
@@ -516,7 +532,7 @@ def main(argv=None) -> int:
     print(f"trades: {len(trades)}  replayable: {len(replayable)}  "
           f"entry sessions: {len(entries)}")
 
-    sessions = _measured_sessions(store, market)
+    sessions = measured_sessions(store, market)
     if args.limit:
         sessions = sessions[: args.limit]
     print(f"measured sessions: {len(sessions)}  "
@@ -537,7 +553,11 @@ def main(argv=None) -> int:
               f"{v['disagreement_with_prior_move']:.1%}")
         for fired in v["criteria_fired"]:
             print(f"  criterion {fired['criterion']} fires: {fired['reason']}")
-        print(f"  -> {'SHIP' if v['ships'] else 'DO NOT SHIP'}")
+        if v["outcome"] == ON_THE_BOUND:
+            print(f"  the deciding number sits "
+                  f"{abs(v['margin_to_ceiling_se']):.2f} standard errors from its "
+                  f"own bound — no verdict")
+        print(f"  -> {v['outcome'].replace('_', ' ').upper()}")
         results["v1" if not live else f"v{DETECTOR_VERSION}"] = block
 
     out = Path(args.out)

--- a/scripts/rs_line_contrast.py
+++ b/scripts/rs_line_contrast.py
@@ -60,6 +60,13 @@ denominators only, ~0.1% per session. Fixed separately in #162; rebuilding 4.7M
 rank rows here would run the study against a *different* field than §5b's,
 breaking the comparability the whole exercise depends on.
 
+**The field reconstruction is shared with the other candidate study.**
+:mod:`replay.candidate_field` holds the three read-only stages both need — the
+measured sessions, the in-memory rank recomputation the retention window forces
+(#141/#164), and the live-detector pass that persists nothing. Two copies of that
+workaround is one too many: a correction would have to land twice, and the run
+that missed the second copy would still print a table.
+
 Run as ``python scripts/rs_line_contrast.py --store data/replay.duckdb``.
 """
 
@@ -77,6 +84,11 @@ from pathlib import Path
 _BACKEND = Path(__file__).resolve().parent.parent / "backend"
 sys.path.insert(0, str(_BACKEND))
 
+from replay.candidate_field import (  # noqa: E402
+    live_detections,
+    measured_sessions,
+    session_ranks,
+)
 from replay.contrast import (  # noqa: E402
     CONTRAST_DIMENSIONS,
     contrast_dimensions,
@@ -88,65 +100,11 @@ from replay.reference import (  # noqa: E402
     classify,
     load_trades,
 )
-from screener.detection import DETECTOR_VERSION, detection_gate, detect  # noqa: E402
-from screener.ranks import rank_table  # noqa: E402
+from screener.detection import DETECTOR_VERSION  # noqa: E402
 from screener.relative_strength import base_start_session  # noqa: E402
 from screener.store import Store  # noqa: E402
 
 MARKET = "US"
-
-
-# -- the two fields -----------------------------------------------------------
-
-
-def _measured_sessions(store: Store, market: str) -> list[date]:
-    """The sessions the store holds detections for — §5b's own window.
-
-    Both contrasts run over exactly these, so the detector is the only thing that
-    moves between them. They are also the sessions the store retained ranks for,
-    which is why the persisted field stops at 505 of the chain's 947.
-    """
-    rows = store._cursor().execute(
-        "SELECT DISTINCT session FROM detections WHERE market = ? ORDER BY 1",
-        [market],
-    ).fetchall()
-    return [r[0] for r in rows]
-
-
-def _session_ranks(store: Store, market: str, session: date):
-    """The session's rank table, recomputed in memory over its persisted universe.
-
-    What :func:`replay.chain._replay_session` does on reuse, and for the same
-    reason: :meth:`screener.store.Store.append_ranks` prunes rows outside its
-    retention window as the chain advances, so the persisted table cannot be read
-    back for every measured session. :func:`screener.ranks.rank_table` is
-    deterministic over the same members' bars, so this reproduces what the chain
-    computed rather than approximating it.
-    """
-    members = store.universe(market, session)
-    return members, rank_table(
-        {s: store.bars(market, s) for s in members}, session
-    )
-
-
-def _v2_detections(store: Store, market: str, session: date, ranks) -> list:
-    """The session's detections under the **live** detector, computed not read.
-
-    :func:`screener.pipeline.rebuild_detections` is the app's own stage and this
-    is its loop exactly — every universe member, the decile gate deciding
-    eligibility, :func:`screener.detection.detect` on the gated ones — with the
-    single difference that the rows are *not* appended. The write is what is
-    omitted, never a gate.
-    """
-    gated = detection_gate(ranks)
-    out = []
-    for symbol in store.universe(market, session):
-        if symbol not in gated:
-            continue
-        found = detect(symbol, store.bars(market, symbol), session)
-        if found is not None:
-            out.append(found)
-    return out
 
 
 # -- the redundancy check -----------------------------------------------------
@@ -196,12 +154,12 @@ def collect(store, market, sessions, entries, *, live_detector: bool) -> Groups:
     taken, not_taken, total = [], [], 0
     t0 = time.time()
     for i, session in enumerate(sessions, start=1):
-        if live_detector:
-            _members, ranks = _session_ranks(store, market, session)
-            dets = _v2_detections(store, market, session, ranks)
-        else:
-            _members, ranks = _session_ranks(store, market, session)
-            dets = store.detections(market, session)
+        _members, ranks = session_ranks(store, market, session)
+        dets = (
+            live_detections(store, market, session, ranks)
+            if live_detector
+            else store.detections(market, session)
+        )
         total += len(dets)
 
         entered = entries.get(session, set())
@@ -314,7 +272,7 @@ def main(argv=None) -> int:
     print(f"trades: {len(trades)}  replayable: {len(replayable)}  "
           f"entry sessions: {len(entries)}")
 
-    sessions = _measured_sessions(store, market)
+    sessions = measured_sessions(store, market)
     if args.limit:
         sessions = sessions[: args.limit]
     print(f"measured sessions: {len(sessions)}  "


### PR DESCRIPTION
Closes #171.

§3f measured the prior move behind 582 entries against a **same-name background** — the same tickers on random ordinary days. That is §3d's device and it is deliberately weak, so §3f could say what he buys and not what the strength cut-off costs. This runs §5b's instrument over the question instead: taken detections against not-taken detections, 505 sessions, no outcome variable, prior-move quantities as columns.

## The control holds

Over the store's persisted v1 detections the harness returns **69 / 14,354** and reproduces §5d's table exactly — all seven rubric gaps on both fields, and `RS line` at −5.8 / −2.1. Two independent harnesses, same numbers.

## `Relative move`: Δ positive on both fields, and it landed on its own bound

| Field | Taken | Not-taken | Δ | Disagreement with `Prior move` |
| --- | --- | --- | --- | --- |
| detector v1 | 91.3% (n=69) | 87.3% (n=14,354) | **+4.0** | 12.7% |
| detector v3 (live) | 88.6% (n=140) | 84.9% (n=34,543) | **+3.6** | **15.1%** |

Positive on both — the one thing `RS line` never managed, and the pre-registered evidence that the anchor was the mechanism behind its null.

But criteria 1 and 2 are **one threshold read from two sides** (disagreement is exactly `1 − hit rate`), and that number landed on it: **84.94% against a ~85% ceiling — 0.06pp inside, 0.29 standard errors**. v1 refuses at 87.3%; v3 admits on the literal threshold. Δ itself is 1.35 s.e. from zero.

**So nothing ships.** `RUBRIC_VERSION` stays 3, `Prior move` keeps its ×1. ADR 0005 recorded its ~15% as "a judgement, not a measurement… the one magnitude in this design with nothing behind it", to be argued about *before* it decided anything. Picking a rounding now is choosing a verdict after seeing the number.

**Recommendation: no third candidate until that threshold is settled on its own** — the next one meets the same bound, and a threshold chosen after two dimensions have bounced off it is not a pre-registration.

Why the gap is small is the useful half: **89.2% of the field he passed over is already up over six months**, because the decile gate filtered it before the contrast saw it. `Prior move`'s 100%/100% is the limiting case of the same fact, and §3f could not see it because it never looks at the field.

## `1w` gets its fourth line under ADR 0003 — and a warning

| `1w`, live v3 | His picks | The field he passed over | Δ |
| --- | --- | --- | --- |
| Raw, at the detection session | 74.3% | 42.7% | **+31.6** |
| Raw, through the session before | 37.9% | 42.4% | **−4.5** |

**The whole of the first row is the entry day.** A taken detection's session *is* the session he bought it on — one bar in a five-bar window. Measured §3f's way, medians are identical to two decimals (−0.19 ×ADR in both groups). Both rows are published so the artefact is on the record rather than the number. Any future `1w` proposal quoting a gap has to say which session its window ends on; that choice is worth 36 points.

## The code

- `move_adr` joins `relative_move_adr` behind a shared ADR slice, so the lookahead guard has one site.
- `ScoredDetection` carries the relative move as a **value** — the rubric owns the cut, and a stored row cannot be re-denominated.
- `contrast_dimensions` takes study columns as `readers` and **raises on a collision with `CANDIDATES`**, so descriptive columns cannot be promoted by editing a tuple after their gaps are visible.
- `replay.candidate_field` holds the field reconstruction both candidate studies share; verified byte-identical on `rs_line_contrast.py`.

The store is read, never rebuilt (§5d's route — `replay.duckdb` raises `SessionExistsError` on a chain re-run), and the gate reads the chain's recomputed ranks, not the store's pruned table (#141/#164).

**Reviewed on both axes.** Nine findings fixed in the second commit, the first being that the committed artefact said `"ships": true` while the write-up said nothing ships. The verdict is now three-state; the `on_the_bound` rule was written after the measurement landed and both §5e and ADR 0005 say so.

573 backend tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AReYR7NQaoRgAtAjgtju5C