### PR TITLE
Delete `LeaderRow.tier` and `LeaderRow.rs_pctile` (#174)

### DIFF
--- a/backend/screener/app.py
+++ b/backend/screener/app.py
@@ -183,7 +183,6 @@ def create_app(
         boards = [
             Leader(
                 lookback=b.lookback,
-                # tier / rs_pctile / cutoffs are phase-2 and default to null.
                 rows=[LeaderRow(**vars(r)) for r in b.rows],
             )
             for b in build_boards(rows, prev, adrs, sectors, dollar_volumes)

--- a/backend/screener/models.py
+++ b/backend/screener/models.py
@@ -136,9 +136,6 @@ class LeaderRow(BaseModel):
     ship with two live controls and two dead ones. ``sector`` is ``None`` when the
     label was never fetched; ``dollar_volume`` is ``None`` when the name's bars
     could not supply it, the same guard the ADR column carries.
-
-    ``tier`` and ``rs_pctile`` are **phase-2**, typed nullable and returning
-    ``None`` until the cross-sectional tier banding lands in the run (spec §4.4).
     """
 
     symbol: str
@@ -150,10 +147,6 @@ class LeaderRow(BaseModel):
     # Phase-1 (spec §4.4): the sector label and §4.1 median-20d liquidity.
     sector: str | None
     dollar_volume: float | None
-    # Phase-2 (spec §4.4): the tier band (1%/2%/3%) and relative-strength
-    # percentile, both nullable until the run computes the banding.
-    tier: str | None = None
-    rs_pctile: float | None = None
 
 
 class Leader(BaseModel):

--- a/backend/tests/test_leaders_seam.py
+++ b/backend/tests/test_leaders_seam.py
@@ -11,8 +11,8 @@ each board member's bars (for the ADR column), and returns five boards of up to
 
 Two phase-1 leaders-row fields land here — ``sector`` and ``dollar_volume`` —
 both cheap: the read already loads exactly these names' bars for the ADR column,
-and sector is a store lookup (spec §4.4). ``tier``, ``rs_pctile`` and a
-per-lookback ``cutoffs`` block are typed nullable phase-2 and return null.
+and sector is a store lookup (spec §4.4). A per-lookback ``cutoffs`` block is
+typed nullable phase-2 and returns null.
 """
 
 from datetime import date, datetime, timedelta
@@ -91,7 +91,7 @@ def test_sector_is_null_when_label_never_fetched(store: Store):
     assert row["sector"] is None
 
 
-def test_phase2_fields_are_typed_null(store: Store):
+def test_cutoffs_is_typed_null(store: Store):
     session = date(2026, 8, 4)
     _publish(store, "US", session)
     store.append_bars("US", "WIN", _flat_bars(140.0))
@@ -104,9 +104,6 @@ def test_phase2_fields_are_typed_null(store: Store):
     # cutoffs sits beside the rows, one block per lookback board — never repeated
     # on every row (spec §4.4). Phase-2, so null now.
     assert board["cutoffs"] is None
-    row = board["rows"][0]
-    assert row["tier"] is None
-    assert row["rs_pctile"] is None
 
 
 def test_leaders_rank_on_raw_return_and_carry_furniture(store: Store):

--- a/frontend/src/Leaders.tsx
+++ b/frontend/src/Leaders.tsx
@@ -41,7 +41,7 @@ type ViewKey = (typeof VIEWS)[number]["key"];
 const LOW_ADR = 0.04;
 
 // The four sortable columns (spec §5.3): return is the default and the primary
-// key, `k/5`, ADR% and $vol are the others. RS and the tier band are P2.
+// key, `k/5`, ADR% and $vol are the others. The tier band is P2.
 type SortKey = "return" | "breadth" | "adr" | "dvol";
 interface SortState {
   key: SortKey;

--- a/frontend/src/api/fixtures.test.ts
+++ b/frontend/src/api/fixtures.test.ts
@@ -20,17 +20,12 @@ describe("the typed fixture module", () => {
 
   it("defaults every phase-2 nullable field to null", () => {
     expect(fx.candidate().verdict).toBeNull();
-    expect(fx.leaderRow().tier).toBeNull();
-    expect(fx.leaderRow().rs_pctile).toBeNull();
     expect(fx.leader().cutoffs).toBeNull();
     expect(fx.sectorMember().pct_of_52w_high).toBeNull();
     expect(fx.sectorMember().verdict).toBeNull();
   });
 
   it("makes phase-2 fields constructible when a test wants them populated", () => {
-    const row = fx.leaderRow({ tier: "A", rs_pctile: 0.98 });
-    expect(row.tier).toBe("A");
-    expect(row.rs_pctile).toBe(0.98);
     expect(fx.candidate({ verdict: "ready" }).verdict).toBe("ready");
   });
 

--- a/frontend/src/api/fixtures.ts
+++ b/frontend/src/api/fixtures.ts
@@ -107,8 +107,6 @@ export const leaderRow = builder<Schemas["LeaderRow"]>(() => ({
   adr: 0.05, // null when it cannot be computed
   sector: "Technology", // null when the label was never fetched
   dollar_volume: 1_000_000, // null when the name's bars cannot supply it
-  tier: null, // P2 — typed now, returned null
-  rs_pctile: null, // P2 — typed now, returned null
 }));
 
 export const leader = builder<Schemas["Leader"]>(() => ({

--- a/frontend/src/api/openapi.json
+++ b/frontend/src/api/openapi.json
@@ -479,7 +479,7 @@
         "type": "object"
       },
       "LeaderRow": {
-        "description": "One leaderboard row: a name ranked on **pure return**, plus its furniture\n(spec \u00a74.3 / \u00a74.4 / ticket 06). ``breadth`` is the ``k/5`` badge (lookbacks\ncurrently led \u2014 a persistence count, *not* a quality score); ``is_new`` marks\nabsence from this board last session; ``surge`` flags a 1w name up \u226530% over\nthe week; ``adr`` is a column for the toggle, never the sort key, ``None`` when\nit cannot be computed.\n\n``sector`` and ``dollar_volume`` are the two **phase-1** additions (spec \u00a74.4):\nboth cheap, since the read already loads exactly these names' bars for the ADR\ncolumn and sector is a store lookup. Without them the phase-1 control bar would\nship with two live controls and two dead ones. ``sector`` is ``None`` when the\nlabel was never fetched; ``dollar_volume`` is ``None`` when the name's bars\ncould not supply it, the same guard the ADR column carries.\n\n``tier`` and ``rs_pctile`` are **phase-2**, typed nullable and returning\n``None`` until the cross-sectional tier banding lands in the run (spec \u00a74.4).",
+        "description": "One leaderboard row: a name ranked on **pure return**, plus its furniture\n(spec \u00a74.3 / \u00a74.4 / ticket 06). ``breadth`` is the ``k/5`` badge (lookbacks\ncurrently led \u2014 a persistence count, *not* a quality score); ``is_new`` marks\nabsence from this board last session; ``surge`` flags a 1w name up \u226530% over\nthe week; ``adr`` is a column for the toggle, never the sort key, ``None`` when\nit cannot be computed.\n\n``sector`` and ``dollar_volume`` are the two **phase-1** additions (spec \u00a74.4):\nboth cheap, since the read already loads exactly these names' bars for the ADR\ncolumn and sector is a store lookup. Without them the phase-1 control bar would\nship with two live controls and two dead ones. ``sector`` is ``None`` when the\nlabel was never fetched; ``dollar_volume`` is ``None`` when the name's bars\ncould not supply it, the same guard the ADR column carries.",
         "properties": {
           "adr": {
             "anyOf": [
@@ -515,17 +515,6 @@
             "title": "Raw Return",
             "type": "number"
           },
-          "rs_pctile": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Rs Pctile"
-          },
           "sector": {
             "anyOf": [
               {
@@ -544,17 +533,6 @@
           "symbol": {
             "title": "Symbol",
             "type": "string"
-          },
-          "tier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Tier"
           }
         },
         "required": [

--- a/frontend/src/api/schema.d.ts
+++ b/frontend/src/api/schema.d.ts
@@ -389,9 +389,6 @@ export interface components {
          *     ship with two live controls and two dead ones. ``sector`` is ``None`` when the
          *     label was never fetched; ``dollar_volume`` is ``None`` when the name's bars
          *     could not supply it, the same guard the ADR column carries.
-         *
-         *     ``tier`` and ``rs_pctile`` are **phase-2**, typed nullable and returning
-         *     ``None`` until the cross-sectional tier banding lands in the run (spec §4.4).
          */
         LeaderRow: {
             /** Adr */
@@ -404,16 +401,12 @@ export interface components {
             is_new: boolean;
             /** Raw Return */
             raw_return: number;
-            /** Rs Pctile */
-            rs_pctile?: number | null;
             /** Sector */
             sector: string | null;
             /** Surge */
             surge: boolean;
             /** Symbol */
             symbol: string;
-            /** Tier */
-            tier?: string | null;
         };
         /**
          * LeadersResponse


### PR DESCRIPTION
Closes #174.

Both fields were typed nullable in phase-1 as placeholders for the cross-sectional tier banding of spec §4.4. That banding was never built and is not scheduled, so neither has ever carried a value — `app.py` defaulted them to null on every row it constructed.

**Why remove rather than leave.** `rs_pctile` reads as the rank percentile and is not one; §5d guards that vocabulary, and with `Relative move` (#170) pre-registered, a permanently-null `rs_pctile` beside a live index-relative number is a trap for the next reader of the schema. And a typed field with no producer is a claim the API does not keep — a consumer cannot tell "not computed yet" from "not applicable" from "abandoned".

**What changed**

- `LeaderRow` loses both fields and the phase-2 paragraph from its docstring
- `app.py` — the comment's dead half is gone; nothing there constructs `cutoffs`, and the `Leader` docstring already carries that fact, so the whole line went
- `test_leaders_seam.py` — null assertions and the docstring line removed; the test is renamed `test_cutoffs_is_typed_null` for what it now covers
- `fixtures.ts` / `fixtures.test.ts` — fields and the round-trip test removed
- `Leaders.tsx:44` — a stale comment naming an "RS" phase-2 column, which was `rs_pctile`
- `openapi.json` / `schema.d.ts` regenerated

`cutoffs` stays throughout — it is a live phase-2 item.

**Breaking change that costs nothing.** The schema changes; no data does, because no value was ever transmitted. If tier banding is built later it gets a field shaped by that design rather than by a 2025 guess.

**Verification.** 573 backend tests, 174 frontend tests, `tsc --noEmit`, and `npm run gen:types:check` (no contract drift) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Huwo74Q4Nn6wocbNFodKeP