### PR TITLE
Keep references out of the replayed field (#162)

### DIFF
--- a/backend/replay/chain.py
+++ b/backend/replay/chain.py
@@ -43,7 +43,7 @@ from typing import Callable, Iterable, Sequence
 
 from screener.pipeline import rebuild_ranks
 from screener.ranks import Rank, rank_table
-from screener.source import Instrument
+from screener.source import MARKET_INDEX, Instrument
 from screener.store import Store
 from screener.universe import is_common_stock, rebuild_universe
 
@@ -51,6 +51,24 @@ from .caching_store import CachingStore
 
 # The reference set is entirely US breakout trades (PRD "Out of Scope: IDX").
 REPLAY_MARKET = "US"
+
+# Every reference whose bars reached the replay store, named because nothing else
+# can name them (#162). :mod:`replay.store` copies bars filtered by market and
+# date, not by role, and role is never persisted — not in the replay store, not
+# in the live one either; it exists only at enumeration, read off the Nasdaq
+# listing file's ETF flag (:mod:`screener.source`). So the copy brings the
+# references' bars across with no way left to recognise them.
+#
+# The index announces itself with "^" and ``is_common_stock`` rejects it on that.
+# An ETF announces nothing: ``SPY`` is four letters with no "$" and no name, which
+# is exactly what a common stock looks like. These four were fetched as study
+# benchmarks (``QQQ`` is §3f's headline contrast) and each carried 928 ``universe``
+# rows and 2,525 ``ranks`` rows in ``data/replay.duckdb``, the same as ``^IXIC``.
+#
+# This is a blocklist and it rots silently: a benchmark fetched later would be
+# ranked exactly as these were. A test pins it against what the store holds, which
+# turns the rot into a failing test rather than a quiet contamination.
+REPLAY_REFERENCES = {MARKET_INDEX[REPLAY_MARKET], "SPY", "QQQ", "IWM", "DIA"}
 
 # A fixed, deterministic stamp for the run record the chain writes as each
 # session's "already computed" marker (issue #126). The replay has no wall clock —
@@ -113,17 +131,18 @@ def synthesize_instruments(store: Store, market: str = REPLAY_MARKET) -> list[In
     already filtered instrument types before the bars were stored).
 
     Not every symbol with bars is a candidate, though, and for a while this
-    function said otherwise (#162). :mod:`replay.store` copies bars filtered by
-    market and date, not by role, so the benchmark's bars are here too — and with
-    no role column and no name to read, the symbol is the only thing that can say
-    it is a benchmark. ``is_common_stock`` rejects the ``^`` prefix, so the filter
-    below is the same instrument-type rule the live path applies, run over the one
-    piece of identity the replay store kept.
+    function said otherwise (#162). References — indices, ETFs — are never
+    rankable, but :mod:`replay.store` copies bars filtered by market and date and
+    not by role, so their bars are here too, with no role column and no security
+    name left to read them by. The symbol is the whole of the identity that
+    survived the copy, so both halves of the exclusion are read off it:
+    ``is_common_stock`` rejects the index on its ``^``, and
+    :data:`REPLAY_REFERENCES` names the benchmark ETFs, which carry no mark at all.
     """
     return [
         Instrument(market=market, symbol=s, role="candidate")
         for s in store.symbols(market)
-        if is_common_stock(s, "")
+        if s not in REPLAY_REFERENCES and is_common_stock(s, "")
     ]
 
 

--- a/backend/replay/chain.py
+++ b/backend/replay/chain.py
@@ -45,7 +45,7 @@ from screener.pipeline import rebuild_ranks
 from screener.ranks import Rank, rank_table
 from screener.source import Instrument
 from screener.store import Store
-from screener.universe import rebuild_universe
+from screener.universe import is_common_stock, rebuild_universe
 
 from .caching_store import CachingStore
 
@@ -103,19 +103,27 @@ class SessionField:
 
 
 def synthesize_instruments(store: Store, market: str = REPLAY_MARKET) -> list[Instrument]:
-    """One ``candidate`` :class:`Instrument` per symbol with bars in the store.
+    """One ``candidate`` :class:`Instrument` per rankable symbol with bars in the store.
 
     The app's enumeration returns today's listing snapshot, so it is useless for
     reconstructing a past field; the replay's instrument set is instead exactly
-    the names the store holds bars for (PRD "A2 replay chain"). Every synthesised
-    instrument is a candidate — references (indices, ETFs) are never rankable and
-    the reference set is all common-stock breakouts — and carries no security
-    name, which :func:`screener.universe.is_common_stock` reads as common stock
-    (the live pull already filtered instrument types before the bars were stored).
+    the names the store holds bars for (PRD "A2 replay chain"). Synthesised
+    instruments carry no security name, which
+    :func:`screener.universe.is_common_stock` reads as common stock (the live pull
+    already filtered instrument types before the bars were stored).
+
+    Not every symbol with bars is a candidate, though, and for a while this
+    function said otherwise (#162). :mod:`replay.store` copies bars filtered by
+    market and date, not by role, so the benchmark's bars are here too — and with
+    no role column and no name to read, the symbol is the only thing that can say
+    it is a benchmark. ``is_common_stock`` rejects the ``^`` prefix, so the filter
+    below is the same instrument-type rule the live path applies, run over the one
+    piece of identity the replay store kept.
     """
     return [
         Instrument(market=market, symbol=s, role="candidate")
         for s in store.symbols(market)
+        if is_common_stock(s, "")
     ]
 
 

--- a/backend/screener/universe.py
+++ b/backend/screener/universe.py
@@ -76,6 +76,14 @@ _EXCLUDED_INSTRUMENT = re.compile(
 # (:func:`screener.source.provider_symbol`), not here.
 _PREFERRED_SERIES_MARK = "$"
 
+# A market index is a benchmark, never a rankable name (CONTEXT.md "Instrument";
+# spec §2, §4.9), and "^" is the only mark it carries — no "$", and a name that
+# reads as common stock or no name at all. Live, the role filter upstream keeps
+# it out; the replay has no roles to filter on, because its store holds bars and
+# not listings, so the symbol is all there is (#162). Rejecting it here is the
+# second layer for the live path and the only one the replay can reach.
+_INDEX_MARK = "^"
+
 
 @dataclass(frozen=True)
 class Candidate:
@@ -125,8 +133,12 @@ def is_common_stock(symbol: str, name: str) -> bool:
     depositary shares whose name does not (#105).
 
     An empty name is common stock: IDX carries no security name and the screener
-    already guarantees ``quoteType: EQUITY`` (D13). ADRs are kept.
+    already guarantees ``quoteType: EQUITY`` (D13). ADRs are kept. A market index
+    is not, on its symbol alone — an empty name would otherwise read ``^IXIC`` as
+    common stock (#162).
     """
+    if symbol.startswith(_INDEX_MARK):
+        return False
     if _PREFERRED_SERIES_MARK in symbol:
         return False
     return _EXCLUDED_INSTRUMENT.search(name) is None

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -1219,6 +1219,36 @@ def test_synthesize_instruments_one_candidate_per_symbol_with_bars(store: Store)
     assert all(i.market == "US" for i in instruments)
 
 
+def test_synthesize_instruments_excludes_the_market_index(store: Store):
+    """Issue #162. ``replay/store.py`` copies bars filtered by market and date,
+    not by role, so the benchmark's bars are in the replay store — and with no
+    role column and no security name to read, only the symbol can say it is not
+    a rankable name. Left in, ``^IXIC`` entered the universe and was ranked
+    against the single names it is the benchmark *for*."""
+    sessions = _calendar(3)
+    _seed_series(store, "AAA", sessions, [1_000] * 3)
+    _seed_series(store, "^IXIC", sessions, [1_000] * 3)
+
+    instruments = synthesize_instruments(store, "US")
+
+    assert [i.symbol for i in instruments] == ["AAA"]
+
+
+def test_the_replayed_field_never_ranks_the_benchmark(store: Store):
+    """The exclusion where it matters: through the whole chain, not just the
+    instrument list. The benchmark clears every liquidity and age gate the
+    universe applies, so nothing downstream would have kept it out."""
+    sessions = _calendar(22)
+    _seed_series(store, "AAA", sessions, [3_000_000] * 22)
+    _seed_series(store, "^IXIC", sessions, [3_000_000] * 22)
+
+    fields = replay_chain(store, "US", burn_in=0, blind_spot_tickers=[])
+
+    last = fields[-1]
+    assert "^IXIC" not in last.members
+    assert all(r.symbol != "^IXIC" for r in last.ranks)
+
+
 def test_burn_in_default_matches_the_prd_window():
     assert BURN_IN_SESSIONS == 126
 

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -55,6 +55,7 @@ from replay.reference import (
 )
 from replay.chain import (
     BURN_IN_SESSIONS,
+    REPLAY_REFERENCES,
     GapError,
     replay_chain,
     synthesize_instruments,
@@ -1220,11 +1221,8 @@ def test_synthesize_instruments_one_candidate_per_symbol_with_bars(store: Store)
 
 
 def test_synthesize_instruments_excludes_the_market_index(store: Store):
-    """Issue #162. ``replay/store.py`` copies bars filtered by market and date,
-    not by role, so the benchmark's bars are in the replay store — and with no
-    role column and no security name to read, only the symbol can say it is not
-    a rankable name. Left in, ``^IXIC`` entered the universe and was ranked
-    against the single names it is the benchmark *for*."""
+    """Issue #162: the index reaches the replay store as bars, without the role
+    that would have held it out, so only its symbol can say it is a reference."""
     sessions = _calendar(3)
     _seed_series(store, "AAA", sessions, [1_000] * 3)
     _seed_series(store, "^IXIC", sessions, [1_000] * 3)
@@ -1234,15 +1232,37 @@ def test_synthesize_instruments_excludes_the_market_index(store: Store):
     assert [i.symbol for i in instruments] == ["AAA"]
 
 
+def test_synthesize_instruments_excludes_the_benchmark_etfs(store: Store):
+    """The index is not the only reference whose bars reached the replay store
+    (#162). ``SPY``, ``QQQ``, ``IWM`` and ``DIA`` were fetched as study
+    benchmarks, and an ETF carries no mark at all — no ``^``, no ``$``, a plain
+    four-letter symbol indistinguishable from common stock. Only naming them
+    keeps them out."""
+    sessions = _calendar(3)
+    for symbol in ["AAA", "SPY", "QQQ", "IWM", "DIA"]:
+        _seed_series(store, symbol, sessions, [1_000] * 3)
+
+    instruments = synthesize_instruments(store, "US")
+
+    assert [i.symbol for i in instruments] == ["AAA"]
+
+
+def test_the_replay_reference_set_names_every_reference_with_bars():
+    """The set is a blocklist, which rots silently — so it is pinned here against
+    what ``data/replay.duckdb`` actually holds, measured at the time of #162."""
+    assert REPLAY_REFERENCES == {"^IXIC", "SPY", "QQQ", "IWM", "DIA"}
+
+
 def test_the_replayed_field_never_ranks_the_benchmark(store: Store):
     """The exclusion where it matters: through the whole chain, not just the
-    instrument list. The benchmark clears every liquidity and age gate the
-    universe applies, so nothing downstream would have kept it out."""
+    instrument list. The index clears every liquidity and age gate the universe
+    applies, so nothing downstream would have kept it out — left in, ``^IXIC``
+    was ranked against the single names it is the benchmark *for*."""
     sessions = _calendar(22)
     _seed_series(store, "AAA", sessions, [3_000_000] * 22)
     _seed_series(store, "^IXIC", sessions, [3_000_000] * 22)
 
-    fields = replay_chain(store, "US", burn_in=0, blind_spot_tickers=[])
+    fields = replay_chain(store, "US", burn_in=0)
 
     last = fields[-1]
     assert "^IXIC" not in last.members

--- a/backend/tests/test_universe.py
+++ b/backend/tests/test_universe.py
@@ -134,6 +134,18 @@ def test_a_dotted_share_class_is_still_common_stock():
         assert is_common_stock(symbol, "Corp Common Stock"), symbol
 
 
+def test_a_market_index_is_not_common_stock():
+    # Issue #162. The index is a benchmark, never a rankable name, and the "^"
+    # prefix is the only mark it carries: it has no "$", and where the symbol is
+    # read without a security name — the replay store keeps bars, not listings —
+    # an empty name read as common stock let ``^IXIC`` compete in the replayed
+    # field. The live path is protected by the role filter upstream; this is the
+    # second layer, and the only one the replay can reach.
+    for symbol in ["^IXIC", "^JKSE", "^GSPC"]:
+        assert not is_common_stock(symbol, ""), symbol
+        assert not is_common_stock(symbol, "NASDAQ Composite Index"), symbol
+
+
 def test_the_twelve_named_adrs_survive_instrument_exclusion():
     # The D13 defect check: an earlier pattern matching "Depositary Sh" would
     # have deleted the most liquid ADRs the method exists to trade.

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -382,12 +382,22 @@ restated as a hope reads as a weaker commitment than it is.
   contrast is clean and only percentile denominators shift, by ~0.1%. Fixed separately rather
   than before the study, because rebuilding 4.7M rank rows would run this contrast against a
   different field than §5b did and break the comparability the ordinal rule depends on. The
-  code fix has since landed (#162): `synthesize_instruments` filters the replay's synthesized
-  instruments through `is_common_stock`, which now rejects a `^`-prefixed symbol. **The store
-  was deliberately not rebuilt.** `replay.duckdb` still carries the contaminated `universe` and
-  `ranks`, so every figure above still reads off the field it was measured on, and the ~0.1%
-  denominator shift stands as stated. A rebuild remains available, and remains all-or-nothing:
-  it invalidates cross-study comparability until every replay-percentile figure moves with it.
+  code fix has since landed (#162), and it found the contamination was wider than measured
+  here: `^IXIC` was not the only reference copied into the replay store. `SPY`, `QQQ`, `IWM`
+  and `DIA` — fetched as study benchmarks, `role="reference"` live — each carry the same 928
+  `universe` and 2,525 `ranks` rows, so the ranked population was inflated by **five** names in
+  ~1,000, not one. The direction and the order of magnitude of the correction are unchanged
+  (~0.5% rather than ~0.1%, still far below the granularity of any reported conclusion), and
+  the contrast stays clean: no reference holds a single detection row. `synthesize_instruments`
+  now excludes all five — the index on its `^` prefix, via `is_common_stock`; the ETFs by name,
+  via `REPLAY_REFERENCES`, because an ETF ticker carries no mark distinguishing it from common
+  stock. **The store was deliberately not rebuilt.** `replay.duckdb` still carries the
+  contaminated `universe` and `ranks`, so every figure above still reads off the field it was
+  measured on. The fix therefore binds only a *fresh* build: re-running the chain over the
+  shipped store reads membership back from the persisted `universe` (the run record is the
+  "already computed" marker), so it reproduces the contaminated field by design. A rebuild
+  remains available, and remains all-or-nothing: it invalidates cross-study comparability until
+  every replay-percentile figure moves with it.
 - **This is hard to reverse in the direction that matters.** Retiring a dimension changes the
   ceiling's composition and every digest frozen afterwards; re-admitting it later would need
   the evidence this ADR requires, which for `Prior move` can never exist.

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -381,7 +381,13 @@ restated as a hope reads as a weaker commitment than it is.
   rows, and 0 of 505 sessions above the 0.90 gate, global max percentile 0.8246 — so the
   contrast is clean and only percentile denominators shift, by ~0.1%. Fixed separately rather
   than before the study, because rebuilding 4.7M rank rows would run this contrast against a
-  different field than §5b did and break the comparability the ordinal rule depends on.
+  different field than §5b did and break the comparability the ordinal rule depends on. The
+  code fix has since landed (#162): `synthesize_instruments` filters the replay's synthesized
+  instruments through `is_common_stock`, which now rejects a `^`-prefixed symbol. **The store
+  was deliberately not rebuilt.** `replay.duckdb` still carries the contaminated `universe` and
+  `ranks`, so every figure above still reads off the field it was measured on, and the ~0.1%
+  denominator shift stands as stated. A rebuild remains available, and remains all-or-nothing:
+  it invalidates cross-study comparability until every replay-percentile figure moves with it.
 - **This is hard to reverse in the direction that matters.** Retiring a dimension changes the
   ceiling's composition and every digest frozen afterwards; re-admitting it later would need
   the evidence this ADR requires, which for `Prior move` can never exist.


### PR DESCRIPTION
Closes #162.

`synthesize_instruments` tagged **every** symbol with bars in the replay store as a candidate, and its docstring claimed references were never rankable. They were: `replay/store.py` copies bars filtered by market and date, not by role, and `is_common_stock("^IXIC", "")` returned `True` — no `$` mark, empty name, so the exclusion regex never fired. The benchmark competed as a rankable name.

## The contamination is wider than #162 measured

`^IXIC` was not the only reference copied across. Measured against `data/replay.duckdb`:

| symbol | `universe` rows | `ranks` rows | `detections` rows |
|---|---|---|---|
| `^IXIC` | 928 | 2,525 | 0 |
| `SPY` | 928 | 2,525 | 0 |
| `QQQ` | 928 | 2,525 | 0 |
| `IWM` | 928 | 2,525 | 0 |
| `DIA` | 928 | 2,525 | 0 |

So the ranked population was inflated by **five** names in ~1,000, not one — a ~0.5% denominator shift rather than ~0.1%. The direction and order of magnitude of #162's blast-radius finding are unchanged, and the contrast stays clean: no reference holds a single detection row, so none can be among the not-taken.

## The fix

Two layers, both read off the symbol — the whole of the identity that survived the bar copy:

- **The index announces itself.** `is_common_stock` now rejects a `^`-prefixed symbol. This is issue task 4: the live path was protected by the role filter upstream and nothing else. It is a pure defence-in-depth addition — no live call site can reach `is_common_stock` with a reference (`resolve_market` returns one `Resolution` per `role == "candidate"`, and every other call site filters to candidates first), so the live universe is byte-identical.
- **An ETF announces nothing.** `SPY` is four letters with no `$` and no name — exactly what a common stock looks like. Role is persisted nowhere, live store or replay; it exists only at enumeration, read off the Nasdaq listing file's ETF flag. So the ETFs are named in `REPLAY_REFERENCES`. That is a blocklist and it rots silently, so a test pins it against what the store actually holds, turning the rot into a red test rather than a quiet contamination.

## The rebuild decision: no

`replay.duckdb` keeps its contaminated `universe` and `ranks`, so every published figure still reads off the field it was measured on. Rebuilding 4.7M rank rows is all-or-nothing and would break the cross-study comparability ADR 0005's ordinal rule depends on.

ADR 0005's contamination bullet is corrected to five names and now records what the fix does *not* do: re-running the chain over the shipped store reads membership back from the persisted `universe` (the run record is the "already computed" marker), so it reproduces the contaminated field **by design**. The fix binds a fresh build only — which is what the no-rebuild decision asked for.

## Tests

Written test-first; each new test was seen red before the fix.

- `is_common_stock` rejects `^IXIC` / `^JKSE` / `^GSPC`, with and without a name.
- `synthesize_instruments` excludes the index, and separately excludes the four benchmark ETFs.
- `REPLAY_REFERENCES` is pinned against what `data/replay.duckdb` holds.
- End to end through `replay_chain`: the benchmark is in neither `members` nor `ranks`. Before the fix it ranked at percentile 1.0.

578 backend tests pass. Verified `^` cannot over-exclude legitimate common stock in either market: US class and preferred marks are `.`, `$` and `-`; IDX tickers are four letters; `^` is Yahoo index-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3KC4XJqDfk2HxJbMK1hnE
