### PR TITLE
Simulate arm B end to end, and prove there is no look-ahead (#189)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -419,6 +419,41 @@ rebuild it, but the index series carries no survivorship hole, so a backtest rec
 it legitimately across the whole window.
 _Avoid_: conditioning on breadth; it conditions on the **state**.
 
+**Simulated trade**:
+One detection from the **denominator**, taken mechanically on one **exit arm** (PRD #182,
+`backtest.simulate`). Entry is the detection's own **trigger**, signalled by a close through
+it on the session after the detection and filled at the next open; the stop is the
+detection's own, unmodified. Every price it carries is stamped with the session that decided
+it, so any trade can be audited back to its inputs. A counterfactual, like a **simulated
+exit** — but a whole trade rather than an exit bolted onto one he really took, which is the
+difference between the denominator and the reference set. A detection whose next session does
+not close through its trigger produces **no trade**, and that is a measurement: the share of
+detections that trigger is one of the figures the denominator exists to produce.
+_Avoid_: backtest trade, mechanical entry — and never **executed trade**, which is observed
+fact.
+
+**Exit arm**:
+One of three exit rules — A, B and C — run off **one shared entry and one shared stop**, so a
+difference between them is attributable to the exit alone. **B is a pure 10MA trail** and the
+arm the pre-registered primary metric is computed on; A is the trader's documented behaviour
+(50% off at the close of the fifth session after entry, remainder trailed on a 10MA) and C a
+pure 20MA trail. A trail **signals on a close through the MA and fills at the next open**, and
+that mechanic — like "day 5" — is recorded as *arbitrary*, so a later run varies it
+deliberately instead of rediscovering it. The trail reads the **unadjusted** close the trigger
+and the stop are quoted in, never `indicators.sma`'s adjusted one.
+_Avoid_: exit strategy, variant.
+
+**Price-scale validity**:
+The per-trade flag saying whether a **simulated trade**'s absolute-price comparison can be
+trusted (`price_scale_ok`). Yahoo applies an *unlabelled* retroactive rescale for rights
+issues — measured on BBRI as pre-2021-09-08 OHLC scaled by exactly 10/11, with no split or
+dividend row to explain it. **Geometry in ADR units is immune**, because both terms rescale
+together, which is why R is denominated by the detection's stop width in ADR priced off the
+bars' own ADR. Absolute prices are not immune, and one such comparison is unavoidable: a
+trigger persisted earlier against a bar read now. Flagged, never silently dropped, and **the
+count it would drop is reported beside every result**.
+_Avoid_: adjustment flag, bad data — the trade is not wrong, its scale is unverified.
+
 **Not-taken detection**:
 A member of the replayed field on a session where he entered something else. Not a
 declined setup — he may never have seen it — so it is a comparison group, never a

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -45,6 +45,20 @@ it as ``__main__`` — which Python reports as a ``RuntimeWarning`` on every
 invocation of the documented command. So the entry point is reached as
 ``backtest.run.run_denominator``.
 
+Issue #189 lands Phase 4's first arm: :mod:`backtest.simulate` turns each persisted
+detection into a trade. Entry is the detection's own trigger — a close through it
+signals, the next open fills — the stop is the detection's own unmodified, and arm B
+trails a 10MA on the same terms. The result is denominated in R off the detection's
+stop width **in ADR**, so a rescale of the bar series moves numerator and denominator
+together and R does not move at all; the one absolute-price comparison that is not
+immune rides on every trade as a price-scale flag whose dropped count is reported.
+
+:mod:`backtest.simulate`'s names are **not** re-exported here, and for the same
+mechanical reason :mod:`backtest.run`'s are not: it imports
+:class:`~backtest.run.ContractDrift`, so re-exporting it would pull ``backtest.run``
+into ``sys.modules`` at package-import time and make ``python -m backtest.run`` warn
+on every invocation. The entry point is reached as ``backtest.simulate.simulate_market``.
+
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean
 something else one import away (:mod:`screener.universe`, :mod:`replay.reference`),

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -53,11 +53,13 @@ stop width **in ADR**, so a rescale of the bar series moves numerator and denomi
 together and R does not move at all; the one absolute-price comparison that is not
 immune rides on every trade as a price-scale flag whose dropped count is reported.
 
-:mod:`backtest.simulate`'s names are **not** re-exported here, and for the same
-mechanical reason :mod:`backtest.run`'s are not: it imports
-:class:`~backtest.run.ContractDrift`, so re-exporting it would pull ``backtest.run``
-into ``sys.modules`` at package-import time and make ``python -m backtest.run`` warn
-on every invocation. The entry point is reached as ``backtest.simulate.simulate_market``.
+:mod:`backtest.simulate`'s names are **not** re-exported here, and the mechanical
+reason is now doubled: it is a command in its own right
+(``python -m backtest.simulate``), *and* it imports
+:class:`~backtest.run.ContractDrift`, so re-exporting it would pull both it and
+``backtest.run`` into ``sys.modules`` at package-import time and make either
+documented command warn on every invocation. The entry point is reached as
+``backtest.simulate.simulate_market``.
 
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean

--- a/backend/backtest/chain.py
+++ b/backend/backtest/chain.py
@@ -249,7 +249,6 @@ def backtest_chain(
     )
 
 
-
 def bar_cut(bars: Sequence[Bar], session: date) -> int:
     """How many bars fall on or before ``session`` — the package's point-in-time cut.
 
@@ -292,10 +291,10 @@ def trailing_bars(bars: Sequence[Bar], session: date, depth: int) -> list[Bar]:
 
 
 __all__ = [
-    "bar_cut",
-    "bar_index",
     "WindowNotCovered",
     "backtest_chain",
+    "bar_cut",
+    "bar_index",
     "burn_in_count",
     "check_window_covered",
     "excluded_references",

--- a/backend/backtest/chain.py
+++ b/backend/backtest/chain.py
@@ -34,6 +34,7 @@ instead.
 
 from __future__ import annotations
 
+import bisect
 from datetime import date
 from typing import Callable, Sequence
 
@@ -44,6 +45,7 @@ from replay.chain import (
     replay_references,
     synthesize_instruments,
 )
+from screener.bars import Bar
 from screener.source import Instrument
 from screener.store import Store
 
@@ -247,7 +249,51 @@ def backtest_chain(
     )
 
 
+
+def bar_cut(bars: Sequence[Bar], session: date) -> int:
+    """How many bars fall on or before ``session`` — the package's point-in-time cut.
+
+    **Every point-in-time decision in this package goes through this one bisect.** It
+    lives here beside the chain's own argument for handing whole bar series to a
+    classifier that slices them itself: a second copy of this arithmetic is a second
+    place the point-in-time claim can quietly stop being true, and the claim is the
+    thing the whole phase is worth nothing without.
+
+    A count rather than a slice, so a caller that needs a *position* — which bar is
+    this session's? — does not have to copy the series to find out.
+    """
+    return bisect.bisect_right(bars, session, key=lambda b: b.session)
+
+
+def bar_index(bars: Sequence[Bar], session: date) -> int | None:
+    """The position of ``session`` in ``bars``, or ``None`` if it did not trade.
+
+    Distinct from :func:`bar_cut`, which answers "how much was knowable then" and is
+    happy to land between bars. This answers "which bar is that session", and a
+    session with no bar has no answer — a market that did not trade is not the same
+    fact as the last day it did.
+    """
+    cut = bar_cut(bars, session)
+    if cut == 0 or bars[cut - 1].session != session:
+        return None
+    return cut - 1
+
+
+def trailing_bars(bars: Sequence[Bar], session: date, depth: int) -> list[Bar]:
+    """The last ``depth`` bars on or before ``session``, without copying the rest.
+
+    A binary search over the already-sorted series (:func:`bar_cut`), so the cut is
+    never a scan of fourteen years of history per symbol per session.
+    :mod:`backtest.run` denominates a session's regime with it and
+    :mod:`backtest.simulate` decides every price a trade carries with it.
+    """
+    cut = bar_cut(bars, session)
+    return list(bars[max(0, cut - depth) : cut])
+
+
 __all__ = [
+    "bar_cut",
+    "bar_index",
     "WindowNotCovered",
     "backtest_chain",
     "burn_in_count",
@@ -255,5 +301,6 @@ __all__ = [
     "excluded_references",
     "stateless_universe",
     "synthesize_instruments",
+    "trailing_bars",
     "window_sessions",
 ]

--- a/backend/backtest/run.py
+++ b/backend/backtest/run.py
@@ -41,7 +41,6 @@ from typing import Callable, Sequence, TextIO
 from replay.caching_store import CachingStore
 from replay.chain import SessionField
 from replay.field import FieldSession, build_field_sessions
-from screener.bars import Bar
 from screener.detection import DETECTION_LOOKBACKS
 from screener.regime import REGIME_WARMUP, breadth, index_broke_out, regime_state
 from screener.source import MARKET_INDEX

--- a/backend/backtest/run.py
+++ b/backend/backtest/run.py
@@ -31,7 +31,6 @@ silent rather than loud:
 from __future__ import annotations
 
 import argparse
-import bisect
 import json
 import sys
 from dataclasses import dataclass
@@ -48,7 +47,7 @@ from screener.regime import REGIME_WARMUP, breadth, index_broke_out, regime_stat
 from screener.source import MARKET_INDEX
 from screener.store import Store
 
-from .chain import backtest_chain, excluded_references
+from .chain import backtest_chain, excluded_references, trailing_bars
 from .contract import DETECTION_GATE_KEY, DEFAULT_CONTRACT, RunContract
 from .denominator import (
     BREADTH_BASIS,
@@ -105,16 +104,6 @@ def check_detection_gate(contract: RunContract) -> None:
         )
 
 
-def _trailing(bars: Sequence[Bar], session: date, depth: int) -> list[Bar]:
-    """The last ``depth`` bars on or before ``session``, without copying the rest.
-
-    ``bisect`` over the already-sorted series, so the cut is a binary search rather
-    than a scan of fourteen years of history per symbol per session.
-    """
-    cut = bisect.bisect_right(bars, session, key=lambda b: b.session)
-    return list(bars[max(0, cut - depth) : cut])
-
-
 def session_regime(
     store: Store, market: str, session: date, members: Sequence[str]
 ) -> RegimeReading:
@@ -134,11 +123,11 @@ def session_regime(
     store's coverage, and the run reports it as an undefined regime instead of
     stopping a fourteen-year pass on a missing benchmark.
     """
-    index_bars = _trailing(
+    index_bars = trailing_bars(
         store.bars(market, MARKET_INDEX[market]), session, REGIME_TAIL
     )
     members_bars = {
-        symbol: _trailing(store.bars(market, symbol), session, REGIME_TAIL)
+        symbol: trailing_bars(store.bars(market, symbol), session, REGIME_TAIL)
         for symbol in members
     }
     return RegimeReading(

--- a/backend/backtest/simulate.py
+++ b/backend/backtest/simulate.py
@@ -1,0 +1,423 @@
+"""Arm B: turning a persisted detection into a trade (issue #189, PRD #182 Phase 4).
+
+The denominator (:mod:`backtest.denominator`) says which setups the detector named
+over the window. This module says what happened to them. One detection becomes at
+most one trade per arm, denominated in R, and every price it carries is stamped
+with the session that decided it.
+
+The mechanic, end to end
+------------------------
+Every step is a contract cell, not a code decision (:mod:`backtest.contract`):
+
+1. **The trigger** is the detection's own — ``cluster_high``, by identity. It is a
+   decision made on the detection's session.
+2. **The break** is the app's own :term:`Break`: a close above the trigger, checked
+   on the session *after* the detection. There is no search forward beyond that
+   one session, and none is needed — the detector re-names a setup that still
+   stands every night, so a base that breaks on its fifth day arrives as that
+   night's detection breaking on its next session. Searching forward instead would
+   need a holding window that no contract cell defines, and would let one setup
+   produce several overlapping trades.
+3. **The fill** is the next session's open. Signal, then fill — the same shape the
+   trail uses, and the reason neither can read the bar that decides it.
+4. **The stop** is the detection's own, unmodified: ``trigger − stop``
+   (:attr:`~screener.detection.Detection.stop_price`). It is checked intraday and
+   takes precedence over the trail within a session, because a stop is an order
+   resting in the market and the trail is a decision taken at the close.
+5. **The trail** is a simple moving average of ``trail_ma`` sessions. A close
+   through it signals; the next open fills.
+
+A detection whose next session does not break produces **no trade**, and that is a
+measurement rather than a dropped row: the share of detections that trigger is one
+of the figures the denominator exists to produce.
+
+Why the trail reads the unadjusted close
+----------------------------------------
+:func:`screener.indicators.sma` averages ``adj_close``, because a return series
+must be dividend-continuous. The trail must not: it is compared against a close and
+sits in the same price the trigger and the stop are quoted in, which is the
+*unadjusted* one — the same reasoning that gives the detector its own
+``detection._sma_close`` for the catch-up MA. Mixing the two would compare a price
+against a level from a different series and call the difference a signal.
+
+The two price scales, and what is immune to them
+------------------------------------------------
+Yahoo applies an **unlabelled retroactive rescale** for rights issues — measured on
+BBRI as pre-2021-09-08 OHLC scaled by exactly 10/11, with no split or dividend row
+to explain it. Two consequences, and this module answers each separately:
+
+- **Geometry in ADR units is immune**, because both terms rescale together. So R is
+  denominated by the detection's stop width *in ADR* (``stopw_adr``, the detection's
+  own stop expressed in the system's own unit) priced off the ADR measured on the
+  **bars** at the deciding session. Numerator and denominator are then both prices
+  from the same series, and a constant rescale cancels.
+- **Absolute prices are not immune**, and one absolute comparison is unavoidable:
+  the trigger is imported from a row persisted earlier and compared against a bar
+  read now. So every trade carries a :attr:`SimulatedTrade.price_scale` and the
+  flag derived from it, and :func:`price_scale_drops` reports how many trades it
+  would drop. Flagged, never silently dropped — the same call the
+  ``prototype-tightness`` spike made (commit ``233c008``), whose band this borrows.
+
+Point-in-time, proved rather than cared about
+---------------------------------------------
+Every decision slices the bars with :func:`backtest.chain.trailing_bars` to the
+session deciding it, so no bar after a decision can reach it. That claim is not
+worth a docstring on its own: it is asserted by
+``test_shifting_a_future_bar_into_an_entry_decision_changes_nothing``, which
+replaces every bar after the fill with a 10× spike and requires the entry to be
+identical. A look-ahead bug produces a beautiful equity curve and no error message,
+so it is the one defect here that reading the output can never catch.
+
+What this module does not do
+----------------------------
+Arms A and C (#190) and costs (#191) are not here. The shape is built for them
+anyway: the entry and the stop are computed once and the exit is the only per-arm
+step, which is the whole reason to run three arms — a difference between them is
+then attributable to the exit alone.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Sequence
+
+from screener.bars import Bar
+from screener.detection import Detection
+from screener.indicators import ADR_WINDOW, adr_abs
+from screener.store import Store
+
+from .chain import bar_index, trailing_bars
+from .contract import EXIT_ARM_B_KEY, EXIT_TRAIL_MECHANIC_KEY, RunContract
+from .denominator import DenominatorStore
+from .result import stamp_result
+from .run import ContractDrift
+
+# The arm this module simulates. Arm B is the pure trail and the arm the
+# pre-registered primary metric is computed on (contract ``metric.primary``).
+ARM_B = "B"
+
+# The two ways a trade can end. Recorded on the trade rather than inferred from its
+# prices, because a trail fill that happens to land on the stop is a different event
+# from a stop, and only one of them is evidence about the trail.
+EXIT_TRAIL = "trail"
+EXIT_STOP = "stop"
+
+# The trail mechanic this module implements, named exactly as the contract cell
+# names it. :func:`check_trail_mechanic` refuses a run whose cell says anything else.
+TRAIL_MECHANIC = "close_through_ma_signals_fill_next_open"
+
+# The band a trade's price scale must sit in to be trusted for absolute-price
+# comparisons, borrowed unchanged from the ``prototype-tightness`` spike (commit
+# ``233c008``) that first hit this. It is deliberately wide: it is looking for a
+# *rescale* — a factor of 10/11, of a split, of a rights issue — and not for a
+# price that moved. A real session-to-session move cannot leave this band; a
+# retroactive rescale leaves it immediately.
+PRICE_SCALE_MIN = 0.7
+PRICE_SCALE_MAX = 1.45
+
+
+@dataclass(frozen=True)
+class Decision:
+    """One price and the session it was decided on.
+
+    Every price on a :class:`SimulatedTrade` is one of these rather than a bare
+    float, so any trade can be audited back to its inputs (story 86). A price with
+    no session cannot be reconciled against the bars, which makes every figure
+    derived from it unfalsifiable.
+    """
+
+    session: date
+    price: float
+
+
+@dataclass(frozen=True)
+class SimulatedTrade:
+    """One detection, taken mechanically, on one exit arm.
+
+    The **simulated trade** CONTEXT.md names: a counterfactual built from the
+    detector's own decision, never an executed trade. ``trigger`` and ``stop`` are
+    shared by every arm by construction — #190's arms A and C differ from this one
+    in ``exit`` and in nothing else — which is the only reason running three arms
+    answers anything about exits.
+
+    ``exit`` is ``None`` when the bars run out before either the stop or the trail
+    fired. Such a trade is **open**, and an open trade has no R: closing it at the
+    last available close would invent an exit the rules never gave, systematically,
+    for every name still running at the end of the window.
+    """
+
+    market: str
+    symbol: str
+    arm: str
+    detection_session: date
+    trigger: Decision
+    breakout: Decision
+    entry: Decision
+    stop: Decision
+    # The R denominator in price units: the detection's stop width in ADR, priced
+    # off the bars at the deciding session. See the module docstring.
+    risk: float
+    exit_signal: Decision | None
+    exit: Decision | None
+    exit_reason: str | None
+    price_scale: float
+    price_scale_ok: bool
+
+    @property
+    def open_at_end(self) -> bool:
+        """True when the bars ran out before the trade closed."""
+        return self.exit is None
+
+    @property
+    def r_multiple(self) -> float | None:
+        """The result in R, or ``None`` while the trade is still open.
+
+        Both terms are prices from the bar series — the exit and the entry are bar
+        prices, and :attr:`risk` was priced off the bars' own ADR — so a constant
+        rescale of the whole series cancels and R does not move.
+        """
+        if self.exit is None or self.risk <= 0:
+            return None
+        return (self.exit.price - self.entry.price) / self.risk
+
+
+def trail_ma(bars: Sequence[Bar], window: int) -> float | None:
+    """The trail's moving average: the mean **unadjusted** close over ``window``
+    bars ending at the last one given.
+
+    Distinct from :func:`screener.indicators.sma`, which averages ``adj_close`` for
+    returns. The trail is compared against a close and lives in the same price the
+    trigger and the stop do — see the module docstring. ``None`` until the window is
+    full: an average of four closes is not a 10MA, and approximating one would let a
+    trade exit on a level that never existed.
+    """
+    if window <= 0 or len(bars) < window:
+        return None
+    return sum(b.close for b in bars[-window:]) / window
+
+
+def trail_ma_window(contract: RunContract) -> int:
+    """Arm B's trail window, read from the contract's ``exit.arm_b`` cell.
+
+    The 10 in "10MA" belongs to the contract, not to this module, so a later run
+    that sweeps it changes one cell and this code is untouched.
+    """
+    return int(contract.value(EXIT_ARM_B_KEY)["trail_ma"])
+
+
+def check_trail_mechanic(contract: RunContract) -> None:
+    """Refuse a contract whose trail mechanic is not the one implemented here.
+
+    The mechanic is recorded as *arbitrary* precisely so a later run can vary it
+    deliberately (story 39). Varying the cell without varying the code would leave a
+    run whose contract and behaviour disagree while both look right — the failure
+    :func:`backtest.run.check_detection_gate` exists to prevent for the gate, in the
+    one other place a contract cell and this package's code have to agree.
+    """
+    declared = contract.value(EXIT_TRAIL_MECHANIC_KEY)
+    if declared != TRAIL_MECHANIC:
+        raise ContractDrift(
+            f"contract {EXIT_TRAIL_MECHANIC_KEY!r} is {declared!r} but "
+            f"backtest.simulate implements {TRAIL_MECHANIC!r}; a changed mechanic "
+            "is a new run recorded beside the old one, not a reinterpretation of "
+            "this one"
+        )
+
+
+def simulate_arm_b(
+    bars: Sequence[Bar],
+    detection: Detection,
+    *,
+    market: str,
+    contract: RunContract,
+) -> SimulatedTrade | None:
+    """Take one detection mechanically on arm B, or return ``None`` if it never broke.
+
+    ``bars`` is the symbol's whole history; this function slices it to the deciding
+    session at every step rather than trusting the caller to have cut it, so a
+    caller that passes more bars than existed at the time cannot change the answer.
+    That is the property ``test_appending_later_sessions_never_moves_a_settled_trade``
+    pins.
+
+    Returns ``None`` — never a trade with an empty entry — when the setup produced
+    no trade at all: the detection's session is not in the bars, the ADR that
+    denominates R is undefined, the next session did not close through the trigger,
+    or the market never opened again to fill it.
+    """
+    check_trail_mechanic(contract)
+    window = trail_ma_window(contract)
+
+    idx = bar_index(bars, detection.session)
+    if idx is None:
+        return None
+
+    # Everything that denominates the trade is measured at the detection's own
+    # session, on the bars that existed then.
+    at_decision = trailing_bars(bars, detection.session, ADR_WINDOW)
+    a = adr_abs(at_decision)
+    if a is None or a <= 0:
+        return None
+    risk = detection.stopw_adr * a
+    if risk <= 0:
+        return None
+
+    # The one absolute-price comparison the ADR geometry cannot make immune: a
+    # close persisted with the detection against the close on the bar it names.
+    bar_close = bars[idx].close
+    price_scale = detection.close / bar_close if bar_close else 0.0
+
+    # The break: the app's own definition, on the session after the detection.
+    if idx + 1 >= len(bars):
+        return None
+    break_bar = bars[idx + 1]
+    if break_bar.close <= detection.trigger:
+        return None
+
+    # The fill: the next session's open. A break with no session after it is a
+    # signal that never became a trade.
+    if idx + 2 >= len(bars):
+        return None
+    fill_bar = bars[idx + 2]
+
+    stop_price = detection.stop_price
+    exit_signal, exit_decision, reason = _walk_out(
+        bars, idx + 2, stop_price=stop_price, window=window
+    )
+
+    return SimulatedTrade(
+        market=market,
+        symbol=detection.symbol,
+        arm=ARM_B,
+        detection_session=detection.session,
+        trigger=Decision(session=detection.session, price=detection.trigger),
+        breakout=Decision(session=break_bar.session, price=break_bar.close),
+        entry=Decision(session=fill_bar.session, price=fill_bar.open),
+        stop=Decision(session=detection.session, price=stop_price),
+        risk=risk,
+        exit_signal=exit_signal,
+        exit=exit_decision,
+        exit_reason=reason,
+        price_scale=price_scale,
+        price_scale_ok=PRICE_SCALE_MIN <= price_scale <= PRICE_SCALE_MAX,
+    )
+
+
+def _walk_out(
+    bars: Sequence[Bar],
+    start: int,
+    *,
+    stop_price: float,
+    window: int,
+) -> tuple[Decision | None, Decision | None, str | None]:
+    """Walk forward from the fill and return ``(signal, exit, reason)``.
+
+    Within a session the **stop is checked first**. It rests in the market all day
+    and the trail is a decision taken at the close, so a bar that trades through the
+    stop and then closes back above the MA ended the trade — reading it the other
+    way would let a losing trade be rescued by the very bar that ended it.
+
+    A session that *opens* under the stop fills at the open, not at the stop. A stop
+    is an order, not a guarantee; filling at the stop price would credit the
+    simulation with liquidity that did not exist, and would do it precisely on the
+    trades a gap ran away from — the direction that flatters an equity curve.
+
+    Returns ``(None, None, None)`` when the bars run out with the trade still open.
+    """
+    for i in range(start, len(bars)):
+        bar = bars[i]
+        if bar.low <= stop_price:
+            fill = min(bar.open, stop_price)
+            decision = Decision(session=bar.session, price=fill)
+            return decision, decision, EXIT_STOP
+
+        ma = trail_ma(bars[: i + 1], window)
+        if ma is not None and bar.close < ma:
+            if i + 1 >= len(bars):
+                # Signalled, but the market never opened again to fill it. The
+                # trade is open: a signal is not a fill.
+                return None, None, None
+            nxt = bars[i + 1]
+            return (
+                Decision(session=bar.session, price=bar.close),
+                Decision(session=nxt.session, price=nxt.open),
+                EXIT_TRAIL,
+            )
+    return None, None, None
+
+
+def simulate_market(
+    store: Store,
+    denominator: DenominatorStore,
+    market: str,
+    contract: RunContract,
+    *,
+    include_burn_in: bool = False,
+) -> list[SimulatedTrade]:
+    """Every arm-B trade the persisted denominator produces for one market.
+
+    Reads the rows :mod:`backtest.run` wrote and the bars they were computed from.
+    Burn-in sessions are excluded by default for the reason they are flagged at all:
+    a warm-up session is persisted and never measured (story 76), so a trade taken
+    off one would be a result resting on an unsettled chain.
+
+    Bars are read once per symbol rather than once per detection — a fourteen-year
+    run names the same symbol on hundreds of sessions, and re-reading its whole
+    history each time is the difference between minutes and hours.
+    """
+    check_trail_mechanic(contract)
+    bars_by_symbol: dict[str, list[Bar]] = {}
+    trades: list[SimulatedTrade] = []
+    for row in denominator.sessions(market):
+        if row.burn_in and not include_burn_in:
+            continue
+        for scored in denominator.detections(market, row.session):
+            symbol = scored.detection.symbol
+            if symbol not in bars_by_symbol:
+                bars_by_symbol[symbol] = store.bars(market, symbol)
+            trade = simulate_arm_b(
+                bars_by_symbol[symbol],
+                scored.detection,
+                market=market,
+                contract=contract,
+            )
+            if trade is not None:
+                trades.append(trade)
+    return trades
+
+
+def price_scale_drops(trades: Sequence[SimulatedTrade]) -> int:
+    """How many trades the price-scale flag would drop.
+
+    A number rather than a filter, because the flag's whole purpose is to make the
+    absolute-price comparisons that are *not* rescale-immune visible (story 84). A
+    function that quietly removed them would hide the very quantity it exists to
+    report.
+    """
+    return sum(1 for t in trades if not t.price_scale_ok)
+
+
+def simulate_report(
+    contract: RunContract, trades: Sequence[SimulatedTrade]
+) -> dict[str, Any]:
+    """The arm's result as a stamped payload: the contract, the counts, the drops.
+
+    Stamped through :func:`backtest.result.stamp_result` like every other figure the
+    package emits, so the price-scale count travels with the result rather than in a
+    commit message — and so two runs under different contracts are distinguishable
+    from their serialised output alone.
+    """
+    closed = [t for t in trades if t.r_multiple is not None]
+    return stamp_result(
+        contract,
+        {
+            "arm": ARM_B,
+            "trail_ma": trail_ma_window(contract),
+            "trail_mechanic": TRAIL_MECHANIC,
+            "trades": len(trades),
+            "closed": len(closed),
+            "open_at_end": len(trades) - len(closed),
+            "price_scale_dropped": price_scale_drops(trades),
+            "total_r": sum(t.r_multiple for t in closed),
+        },
+    )

--- a/backend/backtest/simulate.py
+++ b/backend/backtest/simulate.py
@@ -78,18 +78,26 @@ then attributable to the exit alone.
 
 from __future__ import annotations
 
+import argparse
+import json
 from dataclasses import dataclass
 from datetime import date
+from pathlib import Path
 from typing import Any, Sequence
 
 from screener.bars import Bar
 from screener.detection import Detection
-from screener.indicators import ADR_WINDOW, adr_abs
+from screener.indicators import ADR_WINDOW, adr
 from screener.store import Store
 
 from .chain import bar_index, trailing_bars
-from .contract import EXIT_ARM_B_KEY, EXIT_TRAIL_MECHANIC_KEY, RunContract
-from .denominator import DenominatorStore
+from .contract import (
+    DEFAULT_CONTRACT,
+    EXIT_ARM_B_KEY,
+    EXIT_TRAIL_MECHANIC_KEY,
+    RunContract,
+)
+from .denominator import DenominatorStore, denominator_path
 from .result import stamp_result
 from .run import ContractDrift
 
@@ -152,12 +160,18 @@ class SimulatedTrade:
     arm: str
     detection_session: date
     trigger: Decision
-    breakout: Decision
+    break_signal: Decision
     entry: Decision
-    stop: Decision
-    # The R denominator in price units: the detection's stop width in ADR, priced
-    # off the bars at the deciding session. See the module docstring.
-    risk: float
+    stop_price: Decision
+    # The R denominator: the detection's own stop width, in price units. Named
+    # for the glossary's **Stop width** — never "risk", which CONTEXT.md
+    # reserves against precisely because a stop budget and the risk taken on a
+    # filled position are different quantities. Rebuilt from the detection's
+    # ``stopw_adr`` against the ADR of the *bars* at the deciding session, which
+    # is the detector's own formula on the same inputs — so it equals
+    # ``detection.stop`` whenever the two price scales agree, and stays in ADR
+    # units where they do not.
+    stop_width: float
     exit_signal: Decision | None
     exit: Decision | None
     exit_reason: str | None
@@ -174,12 +188,12 @@ class SimulatedTrade:
         """The result in R, or ``None`` while the trade is still open.
 
         Both terms are prices from the bar series — the exit and the entry are bar
-        prices, and :attr:`risk` was priced off the bars' own ADR — so a constant
+        prices, and :attr:`stop_width` was priced off the bars' own ADR — so a constant
         rescale of the whole series cancels and R does not move.
         """
-        if self.exit is None or self.risk <= 0:
+        if self.exit is None or self.stop_width <= 0:
             return None
-        return (self.exit.price - self.entry.price) / self.risk
+        return (self.exit.price - self.entry.price) / self.stop_width
 
 
 def trail_ma(bars: Sequence[Bar], window: int) -> float | None:
@@ -255,11 +269,11 @@ def simulate_arm_b(
     # Everything that denominates the trade is measured at the detection's own
     # session, on the bars that existed then.
     at_decision = trailing_bars(bars, detection.session, ADR_WINDOW)
-    a = adr_abs(at_decision)
+    a = adr(at_decision)
     if a is None or a <= 0:
         return None
-    risk = detection.stopw_adr * a
-    if risk <= 0:
+    stop_width = detection.stopw_adr * a * detection.trigger
+    if stop_width <= 0:
         return None
 
     # The one absolute-price comparison the ADR geometry cannot make immune: a
@@ -291,10 +305,10 @@ def simulate_arm_b(
         arm=ARM_B,
         detection_session=detection.session,
         trigger=Decision(session=detection.session, price=detection.trigger),
-        breakout=Decision(session=break_bar.session, price=break_bar.close),
+        break_signal=Decision(session=break_bar.session, price=break_bar.close),
         entry=Decision(session=fill_bar.session, price=fill_bar.open),
-        stop=Decision(session=detection.session, price=stop_price),
-        risk=risk,
+        stop_price=Decision(session=detection.session, price=stop_price),
+        stop_width=stop_width,
         exit_signal=exit_signal,
         exit=exit_decision,
         exit_reason=reason,
@@ -421,3 +435,74 @@ def simulate_report(
             "total_r": sum(t.r_multiple for t in closed),
         },
     )
+
+
+def format_trades(report: dict[str, Any]) -> str:
+    """The arm's result as a few lines a terminal can print.
+
+    The price-scale count is on its own line rather than folded into a total,
+    because it is the one figure here that is *about the data* rather than about
+    the method, and a reader who skims must not miss that some trades' absolute
+    prices could not be verified.
+    """
+    lines = [
+        f"arm {report['arm']} — {report['trail_ma']}MA trail "
+        f"({report['trail_mechanic']})",
+        f"  trades          {report['trades']}",
+        f"  closed          {report['closed']}",
+        f"  open at end     {report['open_at_end']}",
+        f"  total R         {report['total_r']:+.2f}",
+        f"  price-scale flag would drop {report['price_scale_dropped']} "
+        f"of {report['trades']}",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Simulate arm B over a persisted denominator and report the result.
+
+    The command that reproduces the arm::
+
+        python -m backtest.simulate --store data/backtest_us.duckdb \\
+            --market US --out-json references/backtest_arm_b_us.json
+
+    Reads the bar store and the denominator :mod:`backtest.run` wrote beside it.
+    Neither is written to: this phase consumes the denominator and produces
+    figures, so it has no reason to hold either file open for writing and every
+    reason not to.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the backtest bar store")
+    parser.add_argument("--market", required=True)
+    parser.add_argument(
+        "--include-burn-in", action="store_true",
+        help="also take trades off burn-in sessions (never for a measured result)",
+    )
+    parser.add_argument(
+        "--out-json", default=None,
+        help="where to write the machine-readable, contract-stamped result",
+    )
+    args = parser.parse_args(argv)
+
+    store = Store.open(args.store)
+    denominator = DenominatorStore.open(denominator_path(args.store))
+    try:
+        trades = simulate_market(
+            store, denominator, args.market, DEFAULT_CONTRACT,
+            include_burn_in=args.include_burn_in,
+        )
+    finally:
+        denominator.close()
+        store.close()
+
+    report = simulate_report(DEFAULT_CONTRACT, trades)
+    if args.out_json:
+        Path(args.out_json).write_text(json.dumps(report, indent=1) + "\n")
+    print(format_trades(report))
+    if args.out_json:
+        print(f"\nwrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -5211,3 +5211,539 @@ def test_the_detections_per_session_series_is_serialised(store, denominator):
 
     assert list(series) == [d.isoformat() for d in dates[-5:]]
     assert set(series.values()) == {1}
+
+
+# -- arm B, end to end, and the proof there is no look-ahead (issue #189) ------
+#
+# Phase 4 of PRD #182. The denominator says which setups the detector named; this
+# turns each of them into a trade and denominates the result in R.
+#
+# One entry and one stop are shared by every arm — #190 adds A and C onto exactly
+# these — so a difference between arms is attributable to the exit alone. Arm B is
+# the pure 10MA trail, and the arm the pre-registered primary metric is computed
+# on.
+#
+# The load-bearing test in this block is
+# ``test_shifting_a_future_bar_into_an_entry_decision_changes_nothing``. Every
+# other test here asserts that the simulator computes what the contract says; that
+# one asserts it cannot see what it must not see. A look-ahead bug produces a
+# beautiful equity curve and no error message, so it is the only bug in this phase
+# that no amount of reading the output would catch.
+
+from screener.indicators import ADR_WINDOW, adr_abs, sma
+
+from backtest.chain import trailing_bars
+from backtest.contract import EXIT_ARM_B_KEY, EXIT_TRAIL_MECHANIC_KEY
+from backtest.run import ContractDrift as SimContractDrift
+from backtest.simulate import (
+    ARM_B,
+    EXIT_STOP,
+    EXIT_TRAIL,
+    PRICE_SCALE_MAX,
+    PRICE_SCALE_MIN,
+    TRAIL_MECHANIC,
+    Decision,
+    SimulatedTrade,
+    check_trail_mechanic,
+    price_scale_drops,
+    simulate_arm_b,
+    simulate_market,
+    simulate_report,
+    trail_ma,
+    trail_ma_window,
+)
+
+
+def _sim_bar(session: date, o: float, h: float, l: float, c: float) -> Bar:
+    """One authored bar. ``adj_close`` is deliberately set *away* from ``close``:
+    the trail and the trigger live in the unadjusted series, so a simulator that
+    reached for ``adj_close`` would produce visibly different numbers here rather
+    than agreeing by coincidence on a fixture where the two were equal."""
+    return Bar(
+        session=session, open=o, high=h, low=l, close=c,
+        adj_close=c * 0.5, volume=1_000_000,
+    )
+
+
+def _flat_then(dates: list[date], closes: list[float]) -> list[Bar]:
+    """Bars whose every OHLC is driven by one close per session.
+
+    ``high``/``low`` straddle the close by 2%, which gives the 20-bar ADR a value
+    to be measured in without letting the intraday range reach a stop the closes
+    never approach — so a test that is about the trail is never quietly decided by
+    the stop.
+    """
+    return [
+        _sim_bar(d, c, c * 1.02, c * 0.98, c)
+        for d, c in zip(dates, closes)
+    ]
+
+
+# The authored trade every arm-B test below runs on.
+#
+# 40 bars flat at 100 give the ADR and the 10MA a settled history. The detection is
+# named on the last of them with a trigger of 102. The next session closes at 110 —
+# through the trigger, so it breaks — and the one after opens at 111, which is the
+# fill. Price then runs to 130 and rolls over, closing back under its own 10MA on a
+# session the test can name.
+SIM_TRIGGER = 102.0
+SIM_STOP_WIDTH = 6.0          # stop price 96.0, six under the trigger
+SIM_STOPW_ADR = 0.3
+_SIM_FLAT = [100.0] * 40
+_SIM_RUN = [110.0, 111.0, 118.0, 124.0, 130.0, 129.0, 128.0, 127.0]
+# Then a slide that drags the close under the rising 10MA.
+_SIM_FADE = [120.0, 112.0, 104.0, 100.0, 98.0, 97.0, 96.5, 96.2]
+
+
+def _sim_dates(n: int) -> list[date]:
+    return _daily(date(2021, 3, 1), n)
+
+
+def _sim_closes() -> list[float]:
+    return _SIM_FLAT + _SIM_RUN + _SIM_FADE
+
+
+def _sim_bars(closes: list[float] | None = None) -> list[Bar]:
+    closes = closes or _sim_closes()
+    return _flat_then(_sim_dates(len(closes)), closes)
+
+
+def _sim_detection(bars: list[Bar], *, close: float | None = None) -> Detection:
+    """The detection the simulator is handed: named on bar 39, trigger 102.
+
+    Hand-authored rather than detected, so the trigger, the stop and the stop width
+    in ADR are the fixture's own choices and every figure asserted below is
+    arithmetic a reader can check. ``close`` is the detection's *recorded* close,
+    which is what the price-scale flag compares against the bar.
+    """
+    return dataclasses.replace(
+        _det("BASE", 5),
+        session=bars[39].session,
+        trigger=SIM_TRIGGER,
+        stop=SIM_STOP_WIDTH,
+        stopw_adr=SIM_STOPW_ADR,
+        close=bars[39].close if close is None else close,
+        cluster_high=SIM_TRIGGER,
+    )
+
+
+def test_a_persisted_detection_becomes_a_trade_on_its_own_trigger_and_stop(store):
+    """The acceptance criterion, whole: trigger, fill, stop and 10MA trail.
+
+    The detection names a trigger of 102 on bar 39. Bar 40 closes at 110 — through
+    it — which is the break, and the fill is bar 41's open at 111. The stop is the
+    detection's own, unmodified: ``trigger − stop`` = 96. The trail then signals on
+    the first close under the 10MA and fills at the next open.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert trade is not None
+    assert trade.arm == ARM_B
+    assert trade.symbol == "BASE"
+    assert trade.trigger.price == SIM_TRIGGER
+    # The break is a close through the trigger, and the fill is the next open —
+    # the same signal-then-fill shape the trail uses, one session apart.
+    assert trade.breakout.session == bars[40].session
+    assert trade.breakout.price == 110.0
+    assert trade.entry.session == bars[41].session
+    assert trade.entry.price == bars[41].open == 111.0
+    # The detection's own stop, used unmodified: trigger less the stop budget.
+    assert trade.stop.price == det.stop_price == 96.0
+    assert trade.exit_reason == EXIT_TRAIL
+
+
+def test_the_trail_signals_on_a_close_through_the_ma_and_fills_at_the_next_open(store):
+    """The contract's trail mechanic, asserted against the fixture's own arithmetic.
+
+    The exit session is not asserted as a constant: it is recomputed here from the
+    same closes the fixture authors, so a test that agreed with the simulator by
+    copying its answer would disagree the moment either side moved.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    window = trail_ma_window(DEFAULT_CONTRACT)
+    assert window == 10
+    signal = next(
+        i for i in range(41, len(bars))
+        if (ma := trail_ma(bars[: i + 1], window)) is not None and bars[i].close < ma
+    )
+    assert trade.exit is not None
+    assert trade.exit.session == bars[signal + 1].session
+    assert trade.exit.price == bars[signal + 1].open
+    # The signal session is carried too, so the decision and its fill are separable.
+    assert trade.exit_signal.session == bars[signal].session
+
+
+def test_the_trail_reads_the_unadjusted_close_the_trigger_lives_in(store):
+    """The 10MA trails the same series the trigger and the stop are quoted in.
+
+    ``screener.indicators.sma`` averages **adjusted** closes, because returns need
+    a dividend-continuous series. A trail compared against a trigger must not: the
+    fixture's ``adj_close`` is half its ``close``, so a trail built on the adjusted
+    series would sit permanently under every close and never signal at all.
+    """
+    bars = _sim_bars()
+
+    assert trail_ma(bars[:41], 10) == sum(b.close for b in bars[31:41]) / 10
+    assert trail_ma(bars[:41], 10) != sma(bars[:41], 10)
+    # And it is undefined rather than approximated before the window is full.
+    assert trail_ma(bars[:9], 10) is None
+
+
+def test_the_stop_is_the_detections_own_and_takes_precedence_within_a_session(store):
+    """A session that trades through the stop exits there, whatever its close does.
+
+    The stop is intraday and the trail is a closing decision, so a bar that touches
+    the stop and then closes back above the MA is a stopped-out trade, not a held
+    one. Deciding it the other way would let a losing trade be rescued by the very
+    bar that ended it.
+    """
+    closes = _SIM_FLAT + [110.0, 111.0]
+    bars = _sim_bars(closes)
+    # A session that dips to 95 — under the 96 stop — and recovers to close at 111.
+    bars.append(_sim_bar(_sim_dates(len(closes) + 1)[-1], 111.0, 112.0, 95.0, 111.0))
+    det = _sim_detection(bars)
+
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert trade.exit_reason == EXIT_STOP
+    assert trade.exit.session == bars[42].session
+    assert trade.exit.price == det.stop_price == 96.0
+
+
+def test_a_session_that_gaps_under_the_stop_fills_at_the_open_not_the_stop(store):
+    """A stop is an order, not a guarantee. A market that opens under it fills there.
+
+    Filling at the stop price would credit the simulation with liquidity that did
+    not exist, and it would do so precisely on the worst trades — the ones a gap
+    ran away from — which is the direction that flatters an equity curve.
+    """
+    closes = _SIM_FLAT + [110.0, 111.0]
+    bars = _sim_bars(closes)
+    bars.append(_sim_bar(_sim_dates(len(closes) + 1)[-1], 90.0, 91.0, 88.0, 89.0))
+    det = _sim_detection(bars)
+
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert trade.exit_reason == EXIT_STOP
+    assert trade.exit.price == 90.0 < det.stop_price
+
+
+def test_a_detection_whose_next_session_does_not_break_produces_no_trade(store):
+    """No break, no trade — and that is a measurement, not a dropped row.
+
+    The share of detections that trigger is one of the denominator figures the
+    whole exercise exists to produce (PRD Phase 5). Entering a setup that never
+    traded through its own trigger would put that figure at 100% by construction.
+    """
+    bars = _sim_bars(_SIM_FLAT + [101.0, 105.0, 110.0])
+    det = _sim_detection(bars)
+
+    assert simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT) is None
+
+
+def test_r_is_denominated_off_the_detections_own_stop_in_adr_units(store):
+    """R's denominator is the detection's stop width in ADR, priced off the bars.
+
+    ``stopw_adr`` is the detection's own stop expressed in the unit the whole
+    system is denominated in, and ADR is measured on the bars at the session that
+    decided the trade. Both terms of the ratio therefore live in the *bar* series,
+    so an unlabelled retroactive rescale moves them together and R is unchanged —
+    which is what "keep the geometry in ADR units" buys (story 83).
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    at_decision = trailing_bars(bars, det.session, ADR_WINDOW)
+    expected_risk = det.stopw_adr * adr_abs(at_decision)
+    assert trade.risk == pytest.approx(expected_risk)
+    assert trade.r_multiple == pytest.approx(
+        (trade.exit.price - trade.entry.price) / expected_risk
+    )
+
+
+def test_r_is_unchanged_when_the_whole_bar_series_is_rescaled(store):
+    """The rescale immunity the ADR denominator exists for, asserted directly.
+
+    Yahoo's rights-issue rescale multiplies a symbol's whole history by a constant
+    and says nothing. Under that transform every price in the trade moves and R
+    does not — because numerator and denominator are both prices from the same
+    series. This is the reason the denominator is not a stored absolute figure.
+    """
+    scale = 10 / 11
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+    rescaled = [
+        _sim_bar(b.session, b.open * scale, b.high * scale, b.low * scale, b.close * scale)
+        for b in bars
+    ]
+    rescaled_det = dataclasses.replace(
+        det,
+        trigger=det.trigger * scale,
+        stop=det.stop * scale,
+        close=det.close * scale,
+    )
+
+    plain = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+    shifted = simulate_arm_b(
+        rescaled, rescaled_det, market="US", contract=DEFAULT_CONTRACT
+    )
+
+    assert shifted.r_multiple == pytest.approx(plain.r_multiple)
+    assert shifted.exit.session == plain.exit.session
+
+
+def test_every_decision_carries_the_session_it_was_made_on(store):
+    """The audit trail (acceptance criterion): five decisions, five sessions.
+
+    A trade whose prices cannot be traced back to the sessions that produced them
+    cannot be reconciled against the bars, which makes every figure derived from it
+    unfalsifiable. The stop is stamped with the *detection's* session, because that
+    is when it was decided — not when it was hit.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert trade.detection_session == det.session
+    assert trade.trigger.session == det.session
+    assert trade.stop.session == det.session
+    assert trade.breakout.session == bars[40].session
+    assert trade.entry.session == bars[41].session
+    assert trade.exit.session > trade.entry.session
+    for decision in (trade.trigger, trade.stop, trade.breakout, trade.entry, trade.exit):
+        assert isinstance(decision, Decision)
+        assert isinstance(decision.session, date)
+
+
+def test_shifting_a_future_bar_into_an_entry_decision_changes_nothing(store):
+    """**The most important test in the run** (acceptance criterion, story 80/81).
+
+    A look-ahead bug produces a beautiful equity curve and no error message, so the
+    point-in-time claim is proved rather than cared about. Every bar after the fill
+    is replaced with an absurd one — a 10× spike — and the entry decision is
+    asserted identical. Anything that reached forward from the break or the fill
+    would move here and nowhere else.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+    plain = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    tampered = list(bars)
+    for i in range(42, len(tampered)):
+        b = tampered[i]
+        tampered[i] = _sim_bar(
+            b.session, b.open * 10, b.high * 10, b.low * 10, b.close * 10
+        )
+    shifted = simulate_arm_b(tampered, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert shifted.breakout == plain.breakout
+    assert shifted.entry == plain.entry
+    assert shifted.stop == plain.stop
+    assert shifted.trigger == plain.trigger
+    # The risk is measured at the decision session too, so it cannot move either.
+    assert shifted.risk == pytest.approx(plain.risk)
+
+
+def test_appending_later_sessions_never_moves_a_settled_trade(store):
+    """The same guard from the other side: a longer store, an identical trade.
+
+    Re-running the simulation months later reads a store that has grown. If any
+    decision were taken over the whole series rather than the part of it that
+    existed at the time, a settled trade would silently re-price — and the run
+    would stop being reproducible without ever failing.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+    plain = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    longer = _sim_bars(_sim_closes() + [200.0] * 30)
+    grown = simulate_arm_b(longer, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert grown == plain
+
+
+def test_a_trade_still_open_at_the_end_of_the_store_carries_no_r(store):
+    """A trade the bars run out under is open, and an open trade has no result.
+
+    Marking it closed at the last close would invent an exit the rules never gave
+    and would do it for every name still running at the end of the window — a
+    systematic bias toward whatever the last session happened to be.
+    """
+    bars = _sim_bars(_SIM_FLAT + _SIM_RUN)
+    det = _sim_detection(bars)
+
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert trade.open_at_end
+    assert trade.exit is None
+    assert trade.exit_reason is None
+    assert trade.r_multiple is None
+
+
+def test_the_price_scale_flag_rides_on_the_trade_and_its_drops_are_counted(store):
+    """The one absolute-price comparison the ADR geometry cannot make immune.
+
+    The trigger is imported from a detection persisted earlier; the bars are read
+    now. A rescale between the two leaves the two on different scales, and the
+    trigger-versus-close comparison that decides the break is then meaningless. It
+    is flagged rather than dropped — the prototype this borrows from does the same
+    — and the count it would drop is reported beside the result.
+    """
+    bars = _sim_bars()
+    ok = simulate_arm_b(
+        bars, _sim_detection(bars), market="US", contract=DEFAULT_CONTRACT
+    )
+    # A detection recorded at a tenth of the bar's price: a scale, not a move.
+    rescaled = _sim_detection(bars, close=bars[39].close / 10)
+    flagged = simulate_arm_b(bars, rescaled, market="US", contract=DEFAULT_CONTRACT)
+
+    assert ok.price_scale == pytest.approx(1.0)
+    assert ok.price_scale_ok
+    assert not flagged.price_scale_ok
+    assert PRICE_SCALE_MIN < ok.price_scale < PRICE_SCALE_MAX
+    assert price_scale_drops([ok, flagged]) == 1
+
+
+def test_the_report_carries_the_contract_and_the_dropped_count(store):
+    """Every figure the package emits carries the contract that produced it, and
+    the price-scale count travels with it rather than in a commit message."""
+    bars = _sim_bars()
+    trades = [
+        simulate_arm_b(
+            bars, _sim_detection(bars), market="US", contract=DEFAULT_CONTRACT
+        ),
+        simulate_arm_b(
+            bars, _sim_detection(bars, close=bars[39].close / 10),
+            market="US", contract=DEFAULT_CONTRACT,
+        ),
+    ]
+
+    report = simulate_report(DEFAULT_CONTRACT, trades)
+
+    assert report[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
+    assert report["arm"] == ARM_B
+    assert report["trades"] == 2
+    assert report["price_scale_dropped"] == 1
+
+
+def test_a_changed_trail_mechanic_is_contract_drift_not_a_silent_reinterpretation(store):
+    """The mechanic is a contract cell, and the code says which one it implements.
+
+    "Close through the MA, fill at the next open" is recorded as *arbitrary* so a
+    later run can vary it deliberately. Varying the cell without varying the code
+    would leave a run whose contract and behaviour disagree while both look right.
+    """
+    check_trail_mechanic(DEFAULT_CONTRACT)
+    assert DEFAULT_CONTRACT.value(EXIT_TRAIL_MECHANIC_KEY) == TRAIL_MECHANIC
+
+    drifted = RunContract(
+        contract_version=DEFAULT_CONTRACT.contract_version,
+        label=DEFAULT_CONTRACT.label,
+        cells=tuple(
+            Cell(
+                key=c.key,
+                value="close_through_ma_fills_same_close",
+                justification=c.justification,
+            )
+            if c.key == EXIT_TRAIL_MECHANIC_KEY else c
+            for c in DEFAULT_CONTRACT.cells
+        ),
+    )
+    with pytest.raises(SimContractDrift):
+        check_trail_mechanic(drifted)
+
+
+def test_arm_b_reads_its_window_from_the_contract_not_from_a_constant(store):
+    """The 10 in "10MA" belongs to the contract, so a sweep changes one cell."""
+    assert (
+        trail_ma_window(DEFAULT_CONTRACT)
+        == DEFAULT_CONTRACT.value(EXIT_ARM_B_KEY)["trail_ma"]
+    )
+
+
+def _breakout_tail_hlc():
+    """The base fixture, plus a tail that actually breaks and then rolls over.
+
+    ``_wide_base_hlc`` ends on a flat top at 100 under a cluster high of ~102, so a
+    denominator built on it names detections that never trade through their own
+    trigger. That is a fair fixture for #188, which is about the field, and a
+    useless one for #189, which is about what happens after: it would let the
+    end-to-end test pass on an empty list of trades.
+
+    So the tail here breaks through the top, runs to 130 and slides back under its
+    own 10MA — the whole life of an arm-B trade, in the same authored geometry.
+    """
+    hlc = _wide_base_hlc()
+    for c in (108.0, 115.0, 122.0, 130.0, 120.0, 110.0, 100.0, 95.0, 92.0, 90.0):
+        hlc.append((c * 1.02, c * 0.98, c))
+    return hlc
+
+
+def _seed_breakout_store(store: Store, *, market: str = "US"):
+    """The #188 seeder, over a series whose base breaks out near the end."""
+    hlc = _breakout_tail_hlc()
+    dates = _daily(date(2020, 1, 1), len(hlc))
+    store.append_bars(market, "BASE", _bars_from_hlc(dates, hlc))
+    store.append_bars(
+        market,
+        MARKET_INDEX[market],
+        _bars_from_hlc(dates, _flat_index_hlc(len(hlc))),
+    )
+    return dates
+
+
+def test_the_denominators_detections_simulate_end_to_end(store, denominator):
+    """The whole path the acceptance criterion names: persisted rows in, trades out.
+
+    Nothing here is hand-authored — the detector names the setup, ``run_denominator``
+    persists it, and the simulator reads it back out of the store. It is the only
+    test in this block that would notice the two halves disagreeing about what a
+    detection is.
+
+    The measured window deliberately straddles the break: the detections on the flat
+    top before it are measured too, and they produce nothing, because a detection
+    whose next session does not close through its trigger is not a trade. So this
+    also pins the count — a simulator that entered every detection would return
+    five trades here instead of one.
+    """
+    dates = _seed_breakout_store(store)
+    run = run_denominator(
+        store, denominator, "US", DEFAULT_CONTRACT,
+        start=dates[0], end=dates[-1], measured_start=dates[100],
+    )
+    measured_detections = sum(
+        len(denominator.detections("US", r.session)) for r in run.measured
+    )
+    assert measured_detections > 1
+
+    trades = simulate_market(store, denominator, "US", DEFAULT_CONTRACT)
+
+    # The one detection whose next session broke: bar 104's, filled at bar 106.
+    (trade,) = trades
+    assert isinstance(trade, SimulatedTrade)
+    assert trade.arm == ARM_B
+    assert trade.symbol == "BASE"
+    assert trade.detection_session == dates[104]
+    assert trade.breakout.session == dates[105]
+    assert trade.entry.session == dates[106]
+    assert trade.entry.price == 115.0
+    # The stop is the detection's own, and R comes off it.
+    (scored,) = denominator.detections("US", dates[104])
+    assert trade.stop.price == scored.detection.stop_price
+    assert trade.exit_reason == EXIT_TRAIL
+    assert trade.r_multiple is not None
+    assert trade.price_scale_ok
+
+    # Burn-in sessions are never traded off: a result resting on an unsettled
+    # chain is exactly what the burn-in flag exists to keep out of the measurement.
+    assert all(t.detection_session >= dates[100] for t in trades)

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -5230,11 +5230,10 @@ def test_the_detections_per_session_series_is_serialised(store, denominator):
 # beautiful equity curve and no error message, so it is the only bug in this phase
 # that no amount of reading the output would catch.
 
-from screener.indicators import ADR_WINDOW, adr_abs, sma
+from screener.indicators import ADR_WINDOW, adr, sma
 
 from backtest.chain import trailing_bars
 from backtest.contract import EXIT_ARM_B_KEY, EXIT_TRAIL_MECHANIC_KEY
-from backtest.run import ContractDrift as SimContractDrift
 from backtest.simulate import (
     ARM_B,
     EXIT_STOP,
@@ -5248,6 +5247,7 @@ from backtest.simulate import (
     price_scale_drops,
     simulate_arm_b,
     simulate_market,
+    format_trades,
     simulate_report,
     trail_ma,
     trail_ma_window,
@@ -5288,7 +5288,6 @@ def _flat_then(dates: list[date], closes: list[float]) -> list[Bar]:
 # session the test can name.
 SIM_TRIGGER = 102.0
 SIM_STOP_WIDTH = 6.0          # stop price 96.0, six under the trigger
-SIM_STOPW_ADR = 0.3
 _SIM_FLAT = [100.0] * 40
 _SIM_RUN = [110.0, 111.0, 118.0, 124.0, 130.0, 129.0, 128.0, 127.0]
 # Then a slide that drags the close under the rising 10MA.
@@ -5309,19 +5308,24 @@ def _sim_bars(closes: list[float] | None = None) -> list[Bar]:
 
 
 def _sim_detection(bars: list[Bar], *, close: float | None = None) -> Detection:
-    """The detection the simulator is handed: named on bar 39, trigger 102.
+    """The detection the simulator is handed: named on bar 39, trigger 102, stop 96.
 
-    Hand-authored rather than detected, so the trigger, the stop and the stop width
-    in ADR are the fixture's own choices and every figure asserted below is
-    arithmetic a reader can check. ``close`` is the detection's *recorded* close,
-    which is what the price-scale flag compares against the bar.
+    Hand-authored rather than detected, so every figure asserted below is arithmetic
+    a reader can check. ``stopw_adr`` is **derived** rather than chosen, because the
+    detector's own stop is ``stopw_adr × adr × trigger``: picking the width and the
+    ADR-normalised width independently would author a detection no detector could
+    emit, and a fixture that cannot exist proves nothing about code that reads real
+    ones. ``close`` is the detection's *recorded* close, which is what the
+    price-scale flag compares against the bar.
     """
+    a = adr(trailing_bars(bars, bars[39].session, ADR_WINDOW))
     return dataclasses.replace(
         _det("BASE", 5),
         session=bars[39].session,
         trigger=SIM_TRIGGER,
         stop=SIM_STOP_WIDTH,
-        stopw_adr=SIM_STOPW_ADR,
+        stopw_adr=SIM_STOP_WIDTH / (a * SIM_TRIGGER),
+        adr=a,
         close=bars[39].close if close is None else close,
         cluster_high=SIM_TRIGGER,
     )
@@ -5346,12 +5350,12 @@ def test_a_persisted_detection_becomes_a_trade_on_its_own_trigger_and_stop(store
     assert trade.trigger.price == SIM_TRIGGER
     # The break is a close through the trigger, and the fill is the next open —
     # the same signal-then-fill shape the trail uses, one session apart.
-    assert trade.breakout.session == bars[40].session
-    assert trade.breakout.price == 110.0
+    assert trade.break_signal.session == bars[40].session
+    assert trade.break_signal.price == 110.0
     assert trade.entry.session == bars[41].session
     assert trade.entry.price == bars[41].open == 111.0
     # The detection's own stop, used unmodified: trigger less the stop budget.
-    assert trade.stop.price == det.stop_price == 96.0
+    assert trade.stop_price.price == det.stop_price == 96.0
     assert trade.exit_reason == EXIT_TRAIL
 
 
@@ -5462,11 +5466,19 @@ def test_r_is_denominated_off_the_detections_own_stop_in_adr_units(store):
 
     trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
 
-    at_decision = trailing_bars(bars, det.session, ADR_WINDOW)
-    expected_risk = det.stopw_adr * adr_abs(at_decision)
-    assert trade.risk == pytest.approx(expected_risk)
+    # The invariant, not the formula: the width R is denominated by IS the
+    # detection's own stop. Restating the implementation's arithmetic here would
+    # agree with any drift in it, including a systematically wrong one.
+    assert trade.stop_width == pytest.approx(det.stop)
+    assert trade.stop_price.price == pytest.approx(det.trigger - trade.stop_width)
     assert trade.r_multiple == pytest.approx(
-        (trade.exit.price - trade.entry.price) / expected_risk
+        (trade.exit.price - trade.entry.price) / det.stop
+    )
+    # And it is rebuilt from the *bars* rather than read off the row, so it stays in
+    # ADR units: same number here, and an unrescaled one when the two scales differ.
+    at_decision = trailing_bars(bars, det.session, ADR_WINDOW)
+    assert trade.stop_width == pytest.approx(
+        det.stopw_adr * adr(at_decision) * det.trigger
     )
 
 
@@ -5516,11 +5528,13 @@ def test_every_decision_carries_the_session_it_was_made_on(store):
 
     assert trade.detection_session == det.session
     assert trade.trigger.session == det.session
-    assert trade.stop.session == det.session
-    assert trade.breakout.session == bars[40].session
+    assert trade.stop_price.session == det.session
+    assert trade.break_signal.session == bars[40].session
     assert trade.entry.session == bars[41].session
     assert trade.exit.session > trade.entry.session
-    for decision in (trade.trigger, trade.stop, trade.breakout, trade.entry, trade.exit):
+    for decision in (
+        trade.trigger, trade.stop_price, trade.break_signal, trade.entry, trade.exit,
+    ):
         assert isinstance(decision, Decision)
         assert isinstance(decision.session, date)
 
@@ -5546,12 +5560,47 @@ def test_shifting_a_future_bar_into_an_entry_decision_changes_nothing(store):
         )
     shifted = simulate_arm_b(tampered, det, market="US", contract=DEFAULT_CONTRACT)
 
-    assert shifted.breakout == plain.breakout
+    assert shifted.break_signal == plain.break_signal
     assert shifted.entry == plain.entry
-    assert shifted.stop == plain.stop
+    assert shifted.stop_price == plain.stop_price
     assert shifted.trigger == plain.trigger
     # The risk is measured at the decision session too, so it cannot move either.
-    assert shifted.risk == pytest.approx(plain.risk)
+    assert shifted.stop_width == pytest.approx(plain.stop_width)
+
+
+def test_tampering_with_bars_after_the_exit_never_moves_the_exit(store):
+    """The same guard carried all the way to the trail, not stopped at the entry.
+
+    Story 79 covers "trigger, fill, stop, **trail**" — every price derived from bars
+    at or before the session that decides it. The entry-side tamper above would pass
+    unchanged if the trail read one bar into the future, because it asserts nothing
+    about the exit. So this one tampers past the *exit* and requires the exit, its
+    signal and the resulting R to be identical.
+
+    Its companion is
+    ``test_the_trail_signals_on_a_close_through_the_ma_and_fills_at_the_next_open``,
+    which recomputes the signal session independently from ``bars[: i + 1]``: between
+    them, a trail that looked forward would have to move the signal without moving
+    the first session at which a point-in-time MA is broken.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+    plain = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+    assert plain.exit is not None
+
+    exit_at = next(i for i, b in enumerate(bars) if b.session == plain.exit.session)
+    tampered = list(bars)
+    for i in range(exit_at + 1, len(tampered)):
+        b = tampered[i]
+        tampered[i] = _sim_bar(
+            b.session, b.open / 10, b.high / 10, b.low / 10, b.close / 10
+        )
+    shifted = simulate_arm_b(tampered, det, market="US", contract=DEFAULT_CONTRACT)
+
+    assert shifted.exit_signal == plain.exit_signal
+    assert shifted.exit == plain.exit
+    assert shifted.exit_reason == plain.exit_reason
+    assert shifted.r_multiple == pytest.approx(plain.r_multiple)
 
 
 def test_appending_later_sessions_never_moves_a_settled_trade(store):
@@ -5636,6 +5685,31 @@ def test_the_report_carries_the_contract_and_the_dropped_count(store):
     assert report["price_scale_dropped"] == 1
 
 
+def test_the_printed_result_says_how_many_trades_the_price_scale_flag_drops(store):
+    """The count is *reported*, not merely computed (acceptance criterion).
+
+    A flag whose count lives only in a returned dict is a flag nobody reads. The
+    run's own output has to carry it, on its own line, because it is the one figure
+    here that is about the data rather than about the method.
+    """
+    bars = _sim_bars()
+    trades = [
+        simulate_arm_b(
+            bars, _sim_detection(bars), market="US", contract=DEFAULT_CONTRACT
+        ),
+        simulate_arm_b(
+            bars, _sim_detection(bars, close=bars[39].close / 10),
+            market="US", contract=DEFAULT_CONTRACT,
+        ),
+    ]
+
+    printed = format_trades(simulate_report(DEFAULT_CONTRACT, trades))
+
+    assert "price-scale flag would drop 1 of 2" in printed
+    assert "10MA trail" in printed
+    assert TRAIL_MECHANIC in printed
+
+
 def test_a_changed_trail_mechanic_is_contract_drift_not_a_silent_reinterpretation(store):
     """The mechanic is a contract cell, and the code says which one it implements.
 
@@ -5659,7 +5733,7 @@ def test_a_changed_trail_mechanic_is_contract_drift_not_a_silent_reinterpretatio
             for c in DEFAULT_CONTRACT.cells
         ),
     )
-    with pytest.raises(SimContractDrift):
+    with pytest.raises(ContractDrift):
         check_trail_mechanic(drifted)
 
 
@@ -5734,16 +5808,18 @@ def test_the_denominators_detections_simulate_end_to_end(store, denominator):
     assert trade.arm == ARM_B
     assert trade.symbol == "BASE"
     assert trade.detection_session == dates[104]
-    assert trade.breakout.session == dates[105]
+    assert trade.break_signal.session == dates[105]
     assert trade.entry.session == dates[106]
     assert trade.entry.price == 115.0
     # The stop is the detection's own, and R comes off it.
     (scored,) = denominator.detections("US", dates[104])
-    assert trade.stop.price == scored.detection.stop_price
+    assert trade.stop_price.price == scored.detection.stop_price
     assert trade.exit_reason == EXIT_TRAIL
     assert trade.r_multiple is not None
     assert trade.price_scale_ok
 
     # Burn-in sessions are never traded off: a result resting on an unsettled
     # chain is exactly what the burn-in flag exists to keep out of the measurement.
-    assert all(t.detection_session >= dates[100] for t in trades)
+    # The run's burn-in really does carry detections, so the exclusion has work to do.
+    assert any(denominator.detections("US", r.session) for r in run.burn_in)
+    assert trade.detection_session in {r.session for r in run.measured}


### PR DESCRIPTION
Phase 4 of PRD #182. The denominator says which setups the detector named; `backtest.simulate` says what happened to them.

## The mechanic

Entry is the detection's own trigger: a close through it on the session after the detection signals, and the next open fills — the same signal-then-fill shape the trail uses, so neither can read the bar that decides it. The stop is the detection's own, unmodified, checked intraday and taking precedence over the trail within a session, because a stop rests in the market all day and the trail is a decision taken at the close. Arm B trails a 10MA on the **unadjusted** close the trigger and the stop are quoted in — `indicators.sma` averages adjusted closes, and comparing a close against a level from a different series would call the difference a signal.

Every price is a `Decision` — a price and the session it was decided on — so any trade can be audited back to its inputs.

## R, and the two price scales

R is denominated by the detection's own stop width, rebuilt from `stopw_adr` against the ADR of the **bars** at the deciding session. That is the detector's own formula on the same inputs, so it equals `detection.stop` whenever the two price scales agree, and stays in ADR units where they do not — a rescale of the series moves numerator and denominator together and R does not move. Asserted directly by rescaling a whole fixture series by 10/11.

The one absolute comparison that is not immune — a trigger persisted earlier against a bar read now — rides on every trade as `price_scale_ok`. Flagged, never silently dropped, with the count it would drop printed on its own line by `python -m backtest.simulate`.

## The look-ahead proof

The load-bearing test replaces every bar after the fill with a 10× spike and requires the entry decision to be identical; a second tampers past the exit and requires the exit, its signal and R to be identical. Both were **mutation-tested**: a one-bar forward read in the trail and a one-session-late entry fill each fail the suite rather than passing quietly.

## One judgement call worth a look

The issue says "Entry is the detection's own trigger, filled at the next session's open." This implements it as *signal then fill*: the session after the detection must close through the trigger, and the next open fills. The alternative reading — fill unconditionally at the next open — leaves the trigger playing no role, and would enter below a level the setup never traded through, which is not the method the detector encodes. It also puts Phase 5's "share that trigger" at 100% by construction. Documented in the module docstring; happy to switch if you read the cell the other way.

## Not here, by design

Arms A and C (#190) and costs (#191) are separate tickets. The entry and the stop are computed once and the exit is the only per-arm step, which is what keeps the arms comparable when they land. Story 87 — listing simulated trades beside the trader's real ones over the 2019–2022 overlap — is Phase 4's done-when but not one of this issue's criteria, and still needs a home.

## Checks

`679 → 681 passed` on the full backend suite; both `python -m backtest.run` and `python -m backtest.simulate` run clean. New vocabulary recorded in CONTEXT.md (**Simulated trade**, **Exit arm**, **Price-scale validity**).

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Szec1ksibEfdUoB9VdQPjY
