### PR TITLE
Add exit arms A and C (#190)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -437,11 +437,23 @@ One of three exit rules — A, B and C — run off **one shared entry and one sh
 difference between them is attributable to the exit alone. **B is a pure 10MA trail** and the
 arm the pre-registered primary metric is computed on; A is the trader's documented behaviour
 (50% off at the close of the fifth session after entry, remainder trailed on a 10MA) and C a
-pure 20MA trail. A trail **signals on a close through the MA and fills at the next open**, and
-that mechanic — like "day 5" — is recorded as *arbitrary*, so a later run varies it
-deliberately instead of rediscovering it. The trail reads the **unadjusted** close the trigger
-and the stop are quoted in, never `indicators.sma`'s adjusted one.
+pure 20MA trail. B and C are the two directly comparable to the reference set's **simulated
+exits**, which is what keeps its anchors usable; **A has no counterpart there, so it is
+measured and never anchored**. A trail **signals on a close through the MA and fills at the
+next open**, and that mechanic — like "day 5" — is recorded as *arbitrary*, so a later run
+varies it deliberately instead of rediscovering it. The trail reads the **unadjusted** close
+the trigger and the stop are quoted in, never `indicators.sma`'s adjusted one.
 _Avoid_: exit strategy, variant.
+
+**Exit leg**:
+One part of a position coming off, carrying **the share of the position it was** (`ExitLeg`).
+Arm A takes its position off in two legs, so its R is **position-weighted per leg and
+summed** — half a position exiting at +2R contributes **1R**, not 2R and not the average of
+the legs. A trade whose legs do not add up to a whole position is still **open** and has no R:
+an equity curve built from the legs that happened to close is the same bias as marking an
+open trade at the last close, only harder to see, because the trade would look closed.
+_Avoid_: partial, tranche; and never call a **scale** an exit — it is a planned partial taken
+because the calendar said so, not because the market did anything.
 
 **Price-scale validity**:
 The per-trade flag saying whether a **simulated trade**'s absolute-price comparison can be

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -45,13 +45,17 @@ it as ``__main__`` — which Python reports as a ``RuntimeWarning`` on every
 invocation of the documented command. So the entry point is reached as
 ``backtest.run.run_denominator``.
 
-Issue #189 lands Phase 4's first arm: :mod:`backtest.simulate` turns each persisted
-detection into a trade. Entry is the detection's own trigger — a close through it
-signals, the next open fills — the stop is the detection's own unmodified, and arm B
-trails a 10MA on the same terms. The result is denominated in R off the detection's
-stop width **in ADR**, so a rescale of the bar series moves numerator and denominator
-together and R does not move at all; the one absolute-price comparison that is not
-immune rides on every trade as a price-scale flag whose dropped count is reported.
+Issues #189 and #190 land Phase 4: :mod:`backtest.simulate` turns each persisted
+detection into a trade on each of the three exit arms. Entry is the detection's own
+trigger — a close through it signals, the next open fills — and the stop is the
+detection's own unmodified. Both are computed once and shared, so the arms differ in
+the exit and in nothing else: B trails a 10MA, C a 20MA, and A takes 50% off at the
+close of the fifth session after entry and trails the remainder on a 10MA, its R
+position-weighted per leg and summed. The result is denominated in R off the
+detection's stop width **in ADR**, so a rescale of the bar series moves numerator and
+denominator together and R does not move at all; the one absolute-price comparison
+that is not immune rides on every trade as a price-scale flag whose dropped count is
+reported.
 
 :mod:`backtest.simulate`'s names are **not** re-exported here, and the mechanical
 reason is now doubled: it is a command in its own right

--- a/backend/backtest/contract.py
+++ b/backend/backtest/contract.py
@@ -334,11 +334,21 @@ _CELLS: tuple[Cell, ...] = (
     ),
     Cell(
         EXIT_ARM_A_KEY,
-        {"scale_fraction": 0.5, "scale_day": 5, "trail_ma": 10, "arbitrary_mechanics": True},
+        {
+            "scale_fraction": 0.5,
+            "scale_day": 5,
+            "trail_ma": 10,
+            "trail_live_from": "fill",
+            "arbitrary_mechanics": True,
+        },
         "Arm A scales 50% off at the close of the fifth session after entry and "
         "trails the remainder on a 10MA — the trader's documented behaviour; its "
         "R is two position-weighted legs summed, and 'day 5' and the trail are "
-        "recorded as arbitrary (stories 34, 36, 37, 39).",
+        "recorded as arbitrary (stories 34, 36, 37, 39). The trail is live from "
+        "the fill rather than from the scale day, so a runner that rolls over "
+        "before day 5 takes the whole position and the scale never happens; that "
+        "is a third arbitrary choice and is recorded here rather than left in the "
+        "code, so a later run can sweep it (story 39).",
     ),
     Cell(
         EXIT_ARM_B_KEY,

--- a/backend/backtest/simulate.py
+++ b/backend/backtest/simulate.py
@@ -148,20 +148,34 @@ ARM_B = "B"
 ARM_C = "C"
 ARMS = (ARM_A, ARM_B, ARM_C)
 
-# Which contract cell holds each arm's exit. The mapping is here rather than in the
-# contract because it is a fact about this code — the contract names the arms and
-# their numbers; this says which arm reads which cell.
-ARM_CELLS = {
-    ARM_A: EXIT_ARM_A_KEY,
-    ARM_B: EXIT_ARM_B_KEY,
-    ARM_C: EXIT_ARM_C_KEY,
-}
 
-# Arms B and C are directly comparable to the reference set's two simulated exits,
-# which is what keeps the reference anchors usable. Arm A has no counterpart there,
-# so it is measured and never anchored — a distinction that rides on the report
-# rather than living in a reader's memory.
-COMPARABLE_TO_REFERENCE = {ARM_A: False, ARM_B: True, ARM_C: True}
+@dataclass(frozen=True)
+class ArmSpec:
+    """What this module knows about an arm that the contract does not say.
+
+    Two things, kept together so a fourth arm is one entry rather than a hunt
+    through parallel tables:
+
+    - ``cell`` is which contract cell holds the arm's exit. The contract names the
+      arms and their numbers; which arm reads which cell is a fact about this code.
+    - ``comparable_to_reference`` is a fact about the **reference study**, not a
+      choice this run makes, which is why it is not a contract cell. Arms B and C
+      are directly comparable to the reference set's two simulated exits, which is
+      what keeps its anchors usable; arm A has no counterpart there, so it is
+      measured and never anchored. It rides on the report rather than living in a
+      reader's memory, because a figure whose comparability is remembered rather
+      than printed gets compared.
+    """
+
+    cell: str
+    comparable_to_reference: bool
+
+
+ARM_SPECS = {
+    ARM_A: ArmSpec(cell=EXIT_ARM_A_KEY, comparable_to_reference=False),
+    ARM_B: ArmSpec(cell=EXIT_ARM_B_KEY, comparable_to_reference=True),
+    ARM_C: ArmSpec(cell=EXIT_ARM_C_KEY, comparable_to_reference=True),
+}
 
 # The three ways a leg of a position can come off. Recorded on the leg rather than
 # inferred from its prices, because a trail fill that happens to land on the stop is
@@ -178,6 +192,14 @@ EXIT_SCALE = "scale"
 # (story 39). :func:`check_arm_mechanics` refuses a contract that says otherwise.
 TRAIL_MECHANIC = "close_through_ma_signals_fill_next_open"
 SCALE_MECHANIC = "close_of_nth_session_after_entry"
+
+# The third arbitrary mechanic, and the one that was nearly left as a code comment:
+# on a scaling arm the trail is live **from the fill**, not from the scale day. So a
+# runner that rolls over before day 5 takes the whole position out and the scale
+# never happens — which on a fast breakout degenerates arm A into arm B. Nothing
+# derives that reading either, so it is a contract cell (``trail_live_from``) like
+# the other two, and this is the only value implemented here.
+TRAIL_LIVE_FROM_FILL = "fill"
 
 # The band a trade's price scale must sit in to be trusted for absolute-price
 # comparisons, borrowed unchanged from the ``prototype-tightness`` spike (commit
@@ -232,11 +254,17 @@ class ExitPlan:
     of the ``scale_day``-th session after entry. A plan with ``scale_day`` of
     ``None`` is a pure trail, which is arms B and C — so the three arms are one
     mechanic parameterised, not three implementations to keep in agreement.
+
+    ``trail_live_from`` says when the trail starts watching. Only
+    :data:`TRAIL_LIVE_FROM_FILL` is implemented, and it matters only to a scaling
+    arm: it is what makes a runner that rolls over before the scale day take the
+    whole position out.
     """
 
     trail_ma: int
     scale_day: int | None = None
     scale_fraction: float = 0.0
+    trail_live_from: str = TRAIL_LIVE_FROM_FILL
 
 
 @dataclass(frozen=True)
@@ -297,9 +325,9 @@ class SimulatedTrade:
     def exit(self) -> Decision | None:
         """The decision that closed the trade, or ``None`` while it is still open.
 
-        The *last* leg, not the first: arm A's scale is a partial, and a trade whose
-        runner is still running has not exited. Reading the scale as the exit would
-        report half a trade as a whole one.
+        The *last* leg, not the first: arm A's scale takes off half a position, and
+        a trade whose runner is still running has not exited. Reading the scale as
+        the exit would report half a trade as a whole one.
         """
         return self.legs[-1].exit if self.closed else None
 
@@ -310,7 +338,12 @@ class SimulatedTrade:
 
     @property
     def exit_reason(self) -> str | None:
-        """Why the trade ended: :data:`EXIT_TRAIL` or :data:`EXIT_STOP`."""
+        """Why the trade ended: :data:`EXIT_TRAIL` or :data:`EXIT_STOP`.
+
+        Never :data:`EXIT_SCALE`, and not by filtering: a scale takes a *fraction*
+        of the position, so a trade whose last leg is a scale has not closed and
+        reports ``None`` here.
+        """
         return self.legs[-1].reason if self.closed else None
 
     @property
@@ -359,41 +392,51 @@ def exit_plan(contract: RunContract, arm: str) -> ExitPlan:
     produced no trades would report a clean zero, which is indistinguishable from a
     correctly-run arm that nothing triggered.
     """
-    if arm not in ARM_CELLS:
+    if arm not in ARM_SPECS:
         raise ValueError(
-            f"unknown exit arm {arm!r}; the contract names {sorted(ARM_CELLS)}"
+            f"unknown exit arm {arm!r}; the contract names {sorted(ARM_SPECS)}"
         )
-    cell = contract.value(ARM_CELLS[arm])
+    cell = contract.value(ARM_SPECS[arm].cell)
     scale_day = cell.get("scale_day")
     return ExitPlan(
         trail_ma=int(cell["trail_ma"]),
         scale_day=None if scale_day is None else int(scale_day),
         scale_fraction=float(cell.get("scale_fraction", 0.0)),
+        trail_live_from=str(cell.get("trail_live_from", TRAIL_LIVE_FROM_FILL)),
     )
 
 
 def check_arm_mechanics(contract: RunContract, arm: str) -> None:
     """Refuse a contract whose exit mechanics are not the ones implemented here.
 
-    Two things are checked, and the second only for an arm that scales. The trail
-    mechanic must be the one this module implements
-    (:func:`check_trail_mechanic`), and an arm with a scale day must still record
-    its mechanics as **arbitrary**. Both mechanics are arbitrary in fact; a contract
-    that has quietly dropped the admission describes a run whose exits look
-    principled, and a run whose exits look principled is one whose sweep nobody
-    thinks to do.
+    The trail mechanic must be the one this module implements
+    (:func:`check_trail_mechanic`). The rest applies only to an arm that scales,
+    and is two claims: the trail is live from the fill, and the arm still records
+    its mechanics as **arbitrary**. All three mechanics are arbitrary in fact; a
+    contract that has quietly dropped the admission describes a run whose exits
+    look principled, and a run whose exits look principled is one whose sweep
+    nobody thinks to do.
     """
     check_trail_mechanic(contract)
     plan = exit_plan(contract, arm)
     if plan.scale_day is None:
         return
-    cell = contract.value(ARM_CELLS[arm])
-    if cell.get("arbitrary_mechanics") is not True:
+    key = ARM_SPECS[arm].cell
+    if plan.trail_live_from != TRAIL_LIVE_FROM_FILL:
         raise ContractDrift(
-            f"contract {ARM_CELLS[arm]!r} scales at session {plan.scale_day} on the "
+            f"contract {key!r} says the trail is live from "
+            f"{plan.trail_live_from!r} but backtest.simulate implements "
+            f"{TRAIL_LIVE_FROM_FILL!r}; a trail that starts watching somewhere "
+            "else is a different arm recorded beside this one, not a "
+            "reinterpretation of it"
+        )
+    if contract.value(key).get("arbitrary_mechanics") is not True:
+        raise ContractDrift(
+            f"contract {key!r} scales at session {plan.scale_day} on the "
             f"{SCALE_MECHANIC!r} mechanic but does not record its mechanics as "
-            "arbitrary; neither the scale day nor the trail fill derives from "
-            "anything, and recording that is what lets a later run vary them"
+            "arbitrary; neither the scale day, nor the trail fill, nor the trail "
+            "being live from the fill derives from anything, and recording that "
+            "is what lets a later run vary them"
         )
 
 
@@ -649,7 +692,7 @@ def arm_report(
         "arm": arm,
         "trail_ma": plan.trail_ma,
         "trail_mechanic": TRAIL_MECHANIC,
-        "comparable_to_reference": COMPARABLE_TO_REFERENCE[arm],
+        "comparable_to_reference": ARM_SPECS[arm].comparable_to_reference,
         "trades": len(mine),
         "closed": len(closed),
         "open_at_end": len(mine) - len(closed),
@@ -664,7 +707,10 @@ def arm_report(
 
 
 def simulate_report(
-    contract: RunContract, trades: Sequence[SimulatedTrade]
+    contract: RunContract,
+    trades: Sequence[SimulatedTrade],
+    *,
+    arms: Sequence[str] = ARMS,
 ) -> dict[str, Any]:
     """Every arm's result as one stamped payload: the contract, the counts, the drops.
 
@@ -673,15 +719,21 @@ def simulate_report(
     *is* the finding and splitting it across payloads would make a reader
     reassemble it. Arms appear in :data:`ARMS` order, so the output is diff-stable.
 
+    ``arms`` is the arms that were **run**, not the arms that produced something. An
+    arm that ran and triggered nothing reports zeros; an arm that never ran is
+    absent. Reporting only the arms present in ``trades`` would collapse those two
+    into the same output, which is the confusion :func:`exit_plan` refuses an
+    unknown arm to avoid.
+
     Stamped through :func:`backtest.result.stamp_result` like every other figure the
     package emits, so the price-scale count travels with the result rather than in a
     commit message — and so two runs under different contracts are distinguishable
     from their serialised output alone.
     """
-    present = [arm for arm in ARMS if any(t.arm == arm for t in trades)]
+    ran = [arm for arm in ARMS if arm in arms]
     return stamp_result(
         contract,
-        {"arms": [arm_report(contract, arm, trades) for arm in present]},
+        {"arms": [arm_report(contract, arm, trades) for arm in ran]},
     )
 
 
@@ -697,15 +749,18 @@ def format_trades(report: dict[str, Any]) -> str:
     """
     lines: list[str] = []
     for body in report["arms"]:
-        exit_rule = f"{body['trail_ma']}MA trail"
-        if "scale_day" in body:
-            exit_rule = (
-                f"{body['scale_fraction']:.0%} at the close of session "
-                f"{body['scale_day']}, remainder on a {exit_rule}"
-            )
-        anchored = "" if body["comparable_to_reference"] else " — measured, not anchored"
+        trail = f"{body['trail_ma']}MA trail"
+        exit_rule = (
+            f"{body['scale_fraction']:.0%} at the close of session "
+            f"{body['scale_day']}, remainder on a {trail}"
+            if "scale_day" in body
+            else trail
+        )
+        anchor_note = (
+            "" if body["comparable_to_reference"] else " — measured, not anchored"
+        )
         lines += [
-            f"arm {body['arm']} — {exit_rule} ({body['trail_mechanic']}){anchored}",
+            f"arm {body['arm']} — {exit_rule} ({body['trail_mechanic']}){anchor_note}",
             f"  trades          {body['trades']}",
             f"  closed          {body['closed']}",
             f"  open at end     {body['open_at_end']}",
@@ -750,19 +805,20 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    arms = tuple(args.arm) if args.arm else ARMS
     store = Store.open(args.store)
     denominator = DenominatorStore.open(denominator_path(args.store))
     try:
         trades = simulate_market(
             store, denominator, args.market, DEFAULT_CONTRACT,
-            arms=tuple(args.arm) if args.arm else ARMS,
+            arms=arms,
             include_burn_in=args.include_burn_in,
         )
     finally:
         denominator.close()
         store.close()
 
-    report = simulate_report(DEFAULT_CONTRACT, trades)
+    report = simulate_report(DEFAULT_CONTRACT, trades, arms=arms)
     if args.out_json:
         Path(args.out_json).write_text(json.dumps(report, indent=1) + "\n")
     print(format_trades(report))

--- a/backend/backtest/simulate.py
+++ b/backend/backtest/simulate.py
@@ -1,4 +1,5 @@
-"""Arm B: turning a persisted detection into a trade (issue #189, PRD #182 Phase 4).
+"""The three exit arms: turning a persisted detection into trades (issues #189 and
+#190, PRD #182 Phase 4).
 
 The denominator (:mod:`backtest.denominator`) says which setups the detector named
 over the window. This module says what happened to them. One detection becomes at
@@ -26,10 +27,39 @@ Every step is a contract cell, not a code decision (:mod:`backtest.contract`):
    resting in the market and the trail is a decision taken at the close.
 5. **The trail** is a simple moving average of ``trail_ma`` sessions. A close
    through it signals; the next open fills.
+6. **The scale**, on arm A only, takes ``scale_fraction`` of the position off at
+   the close of the ``scale_day``-th session after entry.
 
 A detection whose next session does not break produces **no trade**, and that is a
 measurement rather than a dropped row: the share of detections that trigger is one
 of the figures the denominator exists to produce.
+
+The three arms, and why there are three
+---------------------------------------
+Steps 1 to 4 are computed once and shared. The exit is the only per-arm step, so a
+difference between the arms' results is attributable to the exit alone — which is
+the only thing running three of them can answer, and the reason
+``test_the_three_arms_share_one_entry_and_one_stop`` asserts the sharing rather
+than trusting it.
+
+- **Arm A** is the trader's documented behaviour: 50% off at the close of the
+  fifth session after entry, remainder on a 10MA trail. Its R is **two-legged**,
+  position-weighted per leg and summed, so half a position exiting at +2R
+  contributes 1R. It has no counterpart in the reference set, so it is measured and
+  never anchored — a fact its report carries rather than a reader remembering it.
+- **Arm B** is a pure 10MA trail, and the arm the pre-registered primary metric is
+  computed on.
+- **Arm C** is a pure 20MA trail. B and C are the two directly comparable to the
+  reference set's simulated exits, which is what keeps the reference anchors usable.
+
+Two arbitrary mechanics, recorded as arbitrary
+----------------------------------------------
+Nothing derives "the fifth session" (:data:`SCALE_MECHANIC`) or "a close through
+the MA signals and the next open fills" (:data:`TRAIL_MECHANIC`). Both are choices,
+both are recorded in the contract as such, and :func:`check_arm_mechanics` refuses
+a run whose cells have dropped the admission — because a mechanic that looks
+principled is one nobody thinks to sweep, and a later run should vary these
+deliberately rather than rediscover them.
 
 Why the trail reads the unadjusted close
 ----------------------------------------
@@ -70,10 +100,10 @@ so it is the one defect here that reading the output can never catch.
 
 What this module does not do
 ----------------------------
-Arms A and C (#190) and costs (#191) are not here. The shape is built for them
-anyway: the entry and the stop are computed once and the exit is the only per-arm
-step, which is the whole reason to run three arms — a difference between them is
-then attributable to the exit alone.
+Costs (#191) are not here: every figure this module reports is before commission
+and slippage, and the contract's ``costs`` cell is applied by the phase that
+computes the primary metric. So ``total_r`` here is not the headline and must not
+be read as one.
 """
 
 from __future__ import annotations
@@ -93,7 +123,9 @@ from screener.store import Store
 from .chain import bar_index, trailing_bars
 from .contract import (
     DEFAULT_CONTRACT,
+    EXIT_ARM_A_KEY,
     EXIT_ARM_B_KEY,
+    EXIT_ARM_C_KEY,
     EXIT_TRAIL_MECHANIC_KEY,
     RunContract,
 )
@@ -101,19 +133,51 @@ from .denominator import DenominatorStore, denominator_path
 from .result import stamp_result
 from .run import ContractDrift
 
-# The arm this module simulates. Arm B is the pure trail and the arm the
-# pre-registered primary metric is computed on (contract ``metric.primary``).
+# The three arms. They share one entry and one stop by construction and differ in
+# the exit alone, which is the only reason running three of them says anything
+# about exits.
+#
+# - **A** is the trader's documented behaviour: 50% off at the close of the fifth
+#   session after entry, remainder on a 10MA trail. It has no counterpart in the
+#   reference set, so it is measured and never anchored.
+# - **B** is the pure 10MA trail, and the arm the pre-registered primary metric is
+#   computed on (contract ``metric.primary``).
+# - **C** is a pure 20MA trail.
+ARM_A = "A"
 ARM_B = "B"
+ARM_C = "C"
+ARMS = (ARM_A, ARM_B, ARM_C)
 
-# The two ways a trade can end. Recorded on the trade rather than inferred from its
-# prices, because a trail fill that happens to land on the stop is a different event
-# from a stop, and only one of them is evidence about the trail.
+# Which contract cell holds each arm's exit. The mapping is here rather than in the
+# contract because it is a fact about this code — the contract names the arms and
+# their numbers; this says which arm reads which cell.
+ARM_CELLS = {
+    ARM_A: EXIT_ARM_A_KEY,
+    ARM_B: EXIT_ARM_B_KEY,
+    ARM_C: EXIT_ARM_C_KEY,
+}
+
+# Arms B and C are directly comparable to the reference set's two simulated exits,
+# which is what keeps the reference anchors usable. Arm A has no counterpart there,
+# so it is measured and never anchored — a distinction that rides on the report
+# rather than living in a reader's memory.
+COMPARABLE_TO_REFERENCE = {ARM_A: False, ARM_B: True, ARM_C: True}
+
+# The three ways a leg of a position can come off. Recorded on the leg rather than
+# inferred from its prices, because a trail fill that happens to land on the stop is
+# a different event from a stop — and only one of them is evidence about the trail.
+# ``EXIT_SCALE`` is the odd one out: it is a *planned* partial, taken because the
+# calendar said so and not because the market did anything.
 EXIT_TRAIL = "trail"
 EXIT_STOP = "stop"
+EXIT_SCALE = "scale"
 
-# The trail mechanic this module implements, named exactly as the contract cell
-# names it. :func:`check_trail_mechanic` refuses a run whose cell says anything else.
+# The two exit mechanics this module implements. Both are recorded in the contract
+# as **arbitrary** — nothing derives "the fifth session" or "fill at the next open"
+# — so that a later run varies them deliberately instead of rediscovering them
+# (story 39). :func:`check_arm_mechanics` refuses a contract that says otherwise.
 TRAIL_MECHANIC = "close_through_ma_signals_fill_next_open"
+SCALE_MECHANIC = "close_of_nth_session_after_entry"
 
 # The band a trade's price scale must sit in to be trusted for absolute-price
 # comparisons, borrowed unchanged from the ``prototype-tightness`` spike (commit
@@ -140,19 +204,58 @@ class Decision:
 
 
 @dataclass(frozen=True)
+class ExitLeg:
+    """One part of a position coming off, and the share of the position it was.
+
+    A leg is the unit R is computed in, because arm A takes its position off in
+    two pieces at two prices and the result is neither of them: half a position
+    exiting at +2R contributes 1R, not 2R and not the average of the legs. Making
+    the weight a field rather than a convention means the arithmetic cannot be got
+    right in one place and wrong in another.
+
+    ``signal`` and ``exit`` are the same decision for a stop and for a scale — both
+    are filled on the session that decides them — and one session apart for a
+    trail, which signals on a close and fills at the next open.
+    """
+
+    weight: float
+    signal: Decision
+    exit: Decision
+    reason: str
+
+
+@dataclass(frozen=True)
+class ExitPlan:
+    """One arm's exit, read off the contract: a trail, and optionally a scale.
+
+    Every arm trails; arm A additionally takes ``scale_fraction`` off at the close
+    of the ``scale_day``-th session after entry. A plan with ``scale_day`` of
+    ``None`` is a pure trail, which is arms B and C — so the three arms are one
+    mechanic parameterised, not three implementations to keep in agreement.
+    """
+
+    trail_ma: int
+    scale_day: int | None = None
+    scale_fraction: float = 0.0
+
+
+@dataclass(frozen=True)
 class SimulatedTrade:
     """One detection, taken mechanically, on one exit arm.
 
     The **simulated trade** CONTEXT.md names: a counterfactual built from the
-    detector's own decision, never an executed trade. ``trigger`` and ``stop`` are
-    shared by every arm by construction — #190's arms A and C differ from this one
-    in ``exit`` and in nothing else — which is the only reason running three arms
-    answers anything about exits.
+    detector's own decision, never an executed trade. Everything down to the fill is
+    shared by every arm by construction — the arms differ in :attr:`legs` and in
+    nothing else — which is the only reason running three arms answers anything
+    about exits.
 
-    ``exit`` is ``None`` when the bars run out before either the stop or the trail
-    fired. Such a trade is **open**, and an open trade has no R: closing it at the
-    last available close would invent an exit the rules never gave, systematically,
-    for every name still running at the end of the window.
+    A trade is **open** while any of the position is still on: the bars ran out
+    before the stop or the trail fired, or arm A scaled and its runner never
+    exited. An open trade has no R, because closing it at the last available close
+    would invent an exit the rules never gave — systematically, for every name
+    still running at the end of the window. Half of one is no better: an equity
+    curve built from the legs that happened to close is the same bias, harder to
+    see, because the trade would look closed.
     """
 
     market: str
@@ -172,28 +275,63 @@ class SimulatedTrade:
     # ``detection.stop`` whenever the two price scales agree, and stays in ADR
     # units where they do not.
     stop_width: float
-    exit_signal: Decision | None
-    exit: Decision | None
-    exit_reason: str | None
+    # The position coming off, in order. One leg for arms B and C and for any trade
+    # the stop ended; two for an arm A that reached its scale day. A trade whose
+    # legs do not add up to a whole position is still running — the bars ran out
+    # under it — and that is how :attr:`open_at_end` reads it.
+    legs: tuple[ExitLeg, ...]
     price_scale: float
     price_scale_ok: bool
 
     @property
+    def closed(self) -> bool:
+        """True when the whole position has come off."""
+        return abs(sum(leg.weight for leg in self.legs) - 1.0) < 1e-9
+
+    @property
     def open_at_end(self) -> bool:
-        """True when the bars ran out before the trade closed."""
-        return self.exit is None
+        """True when the bars ran out with any of the position still on."""
+        return not self.closed
+
+    @property
+    def exit(self) -> Decision | None:
+        """The decision that closed the trade, or ``None`` while it is still open.
+
+        The *last* leg, not the first: arm A's scale is a partial, and a trade whose
+        runner is still running has not exited. Reading the scale as the exit would
+        report half a trade as a whole one.
+        """
+        return self.legs[-1].exit if self.closed else None
+
+    @property
+    def exit_signal(self) -> Decision | None:
+        """The decision behind :attr:`exit` — one session earlier for a trail."""
+        return self.legs[-1].signal if self.closed else None
+
+    @property
+    def exit_reason(self) -> str | None:
+        """Why the trade ended: :data:`EXIT_TRAIL` or :data:`EXIT_STOP`."""
+        return self.legs[-1].reason if self.closed else None
 
     @property
     def r_multiple(self) -> float | None:
-        """The result in R, or ``None`` while the trade is still open.
+        """The result in R, or ``None`` while any of the position is still on.
 
-        Both terms are prices from the bar series — the exit and the entry are bar
-        prices, and :attr:`stop_width` was priced off the bars' own ADR — so a constant
-        rescale of the whole series cancels and R does not move.
+        **Position-weighted per leg and summed**, which is the whole of what a
+        two-legged exit means: half a position exiting at +2R contributes 1R. The
+        obvious alternatives are both wrong in ways the output cannot show — summing
+        the legs' R doubles a scaled trade, averaging them mis-weights any exit that
+        is not a clean half.
+
+        Every term is a price from the bar series — the exits and the entry are bar
+        prices, and :attr:`stop_width` was priced off the bars' own ADR — so a
+        constant rescale of the whole series cancels and R does not move.
         """
-        if self.exit is None or self.stop_width <= 0:
+        if not self.closed or self.stop_width <= 0:
             return None
-        return (self.exit.price - self.entry.price) / self.stop_width
+        return sum(
+            leg.weight * (leg.exit.price - self.entry.price) for leg in self.legs
+        ) / self.stop_width
 
 
 def trail_ma(bars: Sequence[Bar], window: int) -> float | None:
@@ -211,13 +349,52 @@ def trail_ma(bars: Sequence[Bar], window: int) -> float | None:
     return sum(b.close for b in bars[-window:]) / window
 
 
-def trail_ma_window(contract: RunContract) -> int:
-    """Arm B's trail window, read from the contract's ``exit.arm_b`` cell.
+def exit_plan(contract: RunContract, arm: str) -> ExitPlan:
+    """One arm's exit, read from its own contract cell.
 
-    The 10 in "10MA" belongs to the contract, not to this module, so a later run
-    that sweeps it changes one cell and this code is untouched.
+    Every number in an exit — the 10 in "10MA", the 5 in "day 5", the 50% — belongs
+    to the contract and not to this module, so a later run that sweeps any of them
+    changes one cell and leaves this code untouched. An arm the contract does not
+    name is a hard error rather than an empty plan: an unknown arm that simply
+    produced no trades would report a clean zero, which is indistinguishable from a
+    correctly-run arm that nothing triggered.
     """
-    return int(contract.value(EXIT_ARM_B_KEY)["trail_ma"])
+    if arm not in ARM_CELLS:
+        raise ValueError(
+            f"unknown exit arm {arm!r}; the contract names {sorted(ARM_CELLS)}"
+        )
+    cell = contract.value(ARM_CELLS[arm])
+    scale_day = cell.get("scale_day")
+    return ExitPlan(
+        trail_ma=int(cell["trail_ma"]),
+        scale_day=None if scale_day is None else int(scale_day),
+        scale_fraction=float(cell.get("scale_fraction", 0.0)),
+    )
+
+
+def check_arm_mechanics(contract: RunContract, arm: str) -> None:
+    """Refuse a contract whose exit mechanics are not the ones implemented here.
+
+    Two things are checked, and the second only for an arm that scales. The trail
+    mechanic must be the one this module implements
+    (:func:`check_trail_mechanic`), and an arm with a scale day must still record
+    its mechanics as **arbitrary**. Both mechanics are arbitrary in fact; a contract
+    that has quietly dropped the admission describes a run whose exits look
+    principled, and a run whose exits look principled is one whose sweep nobody
+    thinks to do.
+    """
+    check_trail_mechanic(contract)
+    plan = exit_plan(contract, arm)
+    if plan.scale_day is None:
+        return
+    cell = contract.value(ARM_CELLS[arm])
+    if cell.get("arbitrary_mechanics") is not True:
+        raise ContractDrift(
+            f"contract {ARM_CELLS[arm]!r} scales at session {plan.scale_day} on the "
+            f"{SCALE_MECHANIC!r} mechanic but does not record its mechanics as "
+            "arbitrary; neither the scale day nor the trail fill derives from "
+            "anything, and recording that is what lets a later run vary them"
+        )
 
 
 def check_trail_mechanic(contract: RunContract) -> None:
@@ -239,14 +416,21 @@ def check_trail_mechanic(contract: RunContract) -> None:
         )
 
 
-def simulate_arm_b(
+def simulate_arm(
     bars: Sequence[Bar],
     detection: Detection,
     *,
     market: str,
     contract: RunContract,
+    arm: str,
 ) -> SimulatedTrade | None:
-    """Take one detection mechanically on arm B, or return ``None`` if it never broke.
+    """Take one detection mechanically on one arm, or ``None`` if it never broke.
+
+    The arm is a parameter of the *exit* and of nothing else: everything down to
+    the fill is computed the same way for all three, which is what makes a
+    difference between their results attributable to the exit alone. Running the
+    arms separately therefore cannot make them disagree about an entry — the
+    property ``test_the_three_arms_share_one_entry_and_one_stop`` pins.
 
     ``bars`` is the symbol's whole history; this function slices it to the deciding
     session at every step rather than trusting the caller to have cut it, so a
@@ -259,8 +443,8 @@ def simulate_arm_b(
     denominates R is undefined, the next session did not close through the trigger,
     or the market never opened again to fill it.
     """
-    check_trail_mechanic(contract)
-    window = trail_ma_window(contract)
+    check_arm_mechanics(contract, arm)
+    plan = exit_plan(contract, arm)
 
     idx = bar_index(bars, detection.session)
     if idx is None:
@@ -295,23 +479,19 @@ def simulate_arm_b(
     fill_bar = bars[idx + 2]
 
     stop_price = detection.stop_price
-    exit_signal, exit_decision, reason = _walk_out(
-        bars, idx + 2, stop_price=stop_price, window=window
-    )
+    legs = _walk_out(bars, idx + 2, stop_price=stop_price, plan=plan)
 
     return SimulatedTrade(
         market=market,
         symbol=detection.symbol,
-        arm=ARM_B,
+        arm=arm,
         detection_session=detection.session,
         trigger=Decision(session=detection.session, price=detection.trigger),
         break_signal=Decision(session=break_bar.session, price=break_bar.close),
         entry=Decision(session=fill_bar.session, price=fill_bar.open),
         stop_price=Decision(session=detection.session, price=stop_price),
         stop_width=stop_width,
-        exit_signal=exit_signal,
-        exit=exit_decision,
-        exit_reason=reason,
+        legs=legs,
         price_scale=price_scale,
         price_scale_ok=PRICE_SCALE_MIN <= price_scale <= PRICE_SCALE_MAX,
     )
@@ -322,42 +502,71 @@ def _walk_out(
     start: int,
     *,
     stop_price: float,
-    window: int,
-) -> tuple[Decision | None, Decision | None, str | None]:
-    """Walk forward from the fill and return ``(signal, exit, reason)``.
+    plan: ExitPlan,
+) -> tuple[ExitLeg, ...]:
+    """Walk forward from the fill and return the legs the position came off in.
 
-    Within a session the **stop is checked first**. It rests in the market all day
-    and the trail is a decision taken at the close, so a bar that trades through the
-    stop and then closes back above the MA ended the trade — reading it the other
-    way would let a losing trade be rescued by the very bar that ended it.
+    ``start`` is the fill session — day 0 — so the plan's scale day counts from it:
+    "day 5" is the close of the fifth session *after* entry, which is
+    ``bars[start + 5]``. That is :data:`SCALE_MECHANIC`, and it is arbitrary.
 
-    A session that *opens* under the stop fills at the open, not at the stop. A stop
-    is an order, not a guarantee; filling at the stop price would credit the
-    simulation with liquidity that did not exist, and would do it precisely on the
-    trades a gap ran away from — the direction that flatters an equity curve.
+    Within a session the order is **stop, then scale, then trail**, and each step is
+    a claim about when the decision was taken:
 
-    Returns ``(None, None, None)`` when the bars run out with the trade still open.
+    - The **stop** rests in the market all day, so a bar that trades through it and
+      then closes back above the MA ended the trade. Reading it the other way would
+      let a losing trade be rescued by the very bar that ended it. A session that
+      *opens* under the stop fills at the open, not at the stop: a stop is an order,
+      not a guarantee, and filling at the stop price would credit the simulation
+      with liquidity that did not exist on precisely the trades a gap ran away from.
+      It takes whatever is left of the position, which is the whole of it before the
+      scale day — a plan that has not executed holds no position.
+    - The **scale** is taken at that session's close, by the calendar.
+    - The **trail** signals at the same close and fills at the next open. It is live
+      from the fill rather than from the scale day, so a runner that rolls over
+      before day 5 takes the whole position out and the scale never happens. That
+      reading is a third arbitrary choice and is asserted rather than assumed
+      (``test_arm_as_stop_takes_the_whole_position_when_it_fires_before_day_five``
+      and its trail counterpart).
+
+    Returns the legs taken, which may be empty (the bars ran out with the position
+    whole) or short of a whole position (they ran out with the runner still on).
     """
+    remaining = 1.0
+    legs: list[ExitLeg] = []
     for i in range(start, len(bars)):
         bar = bars[i]
         if bar.low <= stop_price:
             fill = min(bar.open, stop_price)
             decision = Decision(session=bar.session, price=fill)
-            return decision, decision, EXIT_STOP
+            legs.append(ExitLeg(remaining, decision, decision, EXIT_STOP))
+            return tuple(legs)
 
-        ma = trail_ma(bars[: i + 1], window)
+        if plan.scale_day is not None and i == start + plan.scale_day:
+            # A planned partial: decided and filled on the same close, because
+            # nothing about the market triggered it and there is no signal to wait
+            # a session on.
+            decision = Decision(session=bar.session, price=bar.close)
+            legs.append(ExitLeg(plan.scale_fraction, decision, decision, EXIT_SCALE))
+            remaining -= plan.scale_fraction
+
+        ma = trail_ma(bars[: i + 1], plan.trail_ma)
         if ma is not None and bar.close < ma:
             if i + 1 >= len(bars):
-                # Signalled, but the market never opened again to fill it. The
-                # trade is open: a signal is not a fill.
-                return None, None, None
+                # Signalled, but the market never opened again to fill it. Whatever
+                # is left is still on: a signal is not a fill.
+                return tuple(legs)
             nxt = bars[i + 1]
-            return (
-                Decision(session=bar.session, price=bar.close),
-                Decision(session=nxt.session, price=nxt.open),
-                EXIT_TRAIL,
+            legs.append(
+                ExitLeg(
+                    remaining,
+                    Decision(session=bar.session, price=bar.close),
+                    Decision(session=nxt.session, price=nxt.open),
+                    EXIT_TRAIL,
+                )
             )
-    return None, None, None
+            return tuple(legs)
+    return tuple(legs)
 
 
 def simulate_market(
@@ -366,9 +575,15 @@ def simulate_market(
     market: str,
     contract: RunContract,
     *,
+    arms: Sequence[str] = ARMS,
     include_burn_in: bool = False,
 ) -> list[SimulatedTrade]:
-    """Every arm-B trade the persisted denominator produces for one market.
+    """Every trade the persisted denominator produces for one market, on every arm.
+
+    A detection appears **once per arm** and never more: the arms are exits taken on
+    one entry, so three arms over one detection is three trades and not three
+    detections. ``arms`` narrows which exits run and nothing else — the entry each
+    of them is taken on does not depend on which arms ran beside it.
 
     Reads the rows :mod:`backtest.run` wrote and the bars they were computed from.
     Burn-in sessions are excluded by default for the reason they are flagged at all:
@@ -379,7 +594,8 @@ def simulate_market(
     run names the same symbol on hundreds of sessions, and re-reading its whole
     history each time is the difference between minutes and hours.
     """
-    check_trail_mechanic(contract)
+    for arm in arms:
+        check_arm_mechanics(contract, arm)
     bars_by_symbol: dict[str, list[Bar]] = {}
     trades: list[SimulatedTrade] = []
     for row in denominator.sessions(market):
@@ -389,14 +605,16 @@ def simulate_market(
             symbol = scored.detection.symbol
             if symbol not in bars_by_symbol:
                 bars_by_symbol[symbol] = store.bars(market, symbol)
-            trade = simulate_arm_b(
-                bars_by_symbol[symbol],
-                scored.detection,
-                market=market,
-                contract=contract,
-            )
-            if trade is not None:
-                trades.append(trade)
+            for arm in arms:
+                trade = simulate_arm(
+                    bars_by_symbol[symbol],
+                    scored.detection,
+                    market=market,
+                    contract=contract,
+                    arm=arm,
+                )
+                if trade is not None:
+                    trades.append(trade)
     return trades
 
 
@@ -411,60 +629,104 @@ def price_scale_drops(trades: Sequence[SimulatedTrade]) -> int:
     return sum(1 for t in trades if not t.price_scale_ok)
 
 
+def arm_report(
+    contract: RunContract, arm: str, trades: Sequence[SimulatedTrade]
+) -> dict[str, Any]:
+    """One arm's figures, and the exit they came from.
+
+    ``trades`` may span arms; only this arm's are counted. The exit is named in the
+    body rather than left to the arm letter, because a sweep that moved a window
+    would otherwise leave two runs' figures labelled identically — and the whole
+    point of three arms is that the exit is the only thing that differs.
+
+    Not stamped with the contract: :func:`simulate_report` stamps the collection
+    once, and a result cannot claim two contracts.
+    """
+    plan = exit_plan(contract, arm)
+    mine = [t for t in trades if t.arm == arm]
+    closed = [t for t in mine if t.r_multiple is not None]
+    body: dict[str, Any] = {
+        "arm": arm,
+        "trail_ma": plan.trail_ma,
+        "trail_mechanic": TRAIL_MECHANIC,
+        "comparable_to_reference": COMPARABLE_TO_REFERENCE[arm],
+        "trades": len(mine),
+        "closed": len(closed),
+        "open_at_end": len(mine) - len(closed),
+        "price_scale_dropped": price_scale_drops(mine),
+        "total_r": sum(t.r_multiple for t in closed),
+    }
+    if plan.scale_day is not None:
+        body["scale_day"] = plan.scale_day
+        body["scale_fraction"] = plan.scale_fraction
+        body["scale_mechanic"] = SCALE_MECHANIC
+    return body
+
+
 def simulate_report(
     contract: RunContract, trades: Sequence[SimulatedTrade]
 ) -> dict[str, Any]:
-    """The arm's result as a stamped payload: the contract, the counts, the drops.
+    """Every arm's result as one stamped payload: the contract, the counts, the drops.
+
+    All three arms in one result rather than three files, because the arms are only
+    interesting beside each other: they share an entry and a stop, so the comparison
+    *is* the finding and splitting it across payloads would make a reader
+    reassemble it. Arms appear in :data:`ARMS` order, so the output is diff-stable.
 
     Stamped through :func:`backtest.result.stamp_result` like every other figure the
     package emits, so the price-scale count travels with the result rather than in a
     commit message — and so two runs under different contracts are distinguishable
     from their serialised output alone.
     """
-    closed = [t for t in trades if t.r_multiple is not None]
+    present = [arm for arm in ARMS if any(t.arm == arm for t in trades)]
     return stamp_result(
         contract,
-        {
-            "arm": ARM_B,
-            "trail_ma": trail_ma_window(contract),
-            "trail_mechanic": TRAIL_MECHANIC,
-            "trades": len(trades),
-            "closed": len(closed),
-            "open_at_end": len(trades) - len(closed),
-            "price_scale_dropped": price_scale_drops(trades),
-            "total_r": sum(t.r_multiple for t in closed),
-        },
+        {"arms": [arm_report(contract, arm, trades) for arm in present]},
     )
 
 
 def format_trades(report: dict[str, Any]) -> str:
-    """The arm's result as a few lines a terminal can print.
+    """The arms' results as a few lines a terminal can print.
 
     The price-scale count is on its own line rather than folded into a total,
     because it is the one figure here that is *about the data* rather than about
     the method, and a reader who skims must not miss that some trades' absolute
-    prices could not be verified.
+    prices could not be verified. Arm A carries "measured, not anchored" on its
+    heading for the same reason: it has no counterpart in the reference set, and a
+    figure whose comparability is remembered rather than printed gets compared.
     """
-    lines = [
-        f"arm {report['arm']} — {report['trail_ma']}MA trail "
-        f"({report['trail_mechanic']})",
-        f"  trades          {report['trades']}",
-        f"  closed          {report['closed']}",
-        f"  open at end     {report['open_at_end']}",
-        f"  total R         {report['total_r']:+.2f}",
-        f"  price-scale flag would drop {report['price_scale_dropped']} "
-        f"of {report['trades']}",
-    ]
+    lines: list[str] = []
+    for body in report["arms"]:
+        exit_rule = f"{body['trail_ma']}MA trail"
+        if "scale_day" in body:
+            exit_rule = (
+                f"{body['scale_fraction']:.0%} at the close of session "
+                f"{body['scale_day']}, remainder on a {exit_rule}"
+            )
+        anchored = "" if body["comparable_to_reference"] else " — measured, not anchored"
+        lines += [
+            f"arm {body['arm']} — {exit_rule} ({body['trail_mechanic']}){anchored}",
+            f"  trades          {body['trades']}",
+            f"  closed          {body['closed']}",
+            f"  open at end     {body['open_at_end']}",
+            f"  total R         {body['total_r']:+.2f}",
+            f"  price-scale flag would drop {body['price_scale_dropped']} "
+            f"of {body['trades']}",
+        ]
     return "\n".join(lines)
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Simulate arm B over a persisted denominator and report the result.
+    """Simulate every exit arm over a persisted denominator and report the results.
 
-    The command that reproduces the arm::
+    The command that reproduces the arms::
 
         python -m backtest.simulate --store data/backtest_us.duckdb \\
-            --market US --out-json references/backtest_arm_b_us.json
+            --market US --out-json references/backtest_arms_us.json
+
+    All three arms run by default, because they are only interesting beside each
+    other. ``--arm`` narrows the run to one; it changes which exits are taken and
+    nothing about the entry they are taken on.
 
     Reads the bar store and the denominator :mod:`backtest.run` wrote beside it.
     Neither is written to: this phase consumes the denominator and produces
@@ -474,6 +736,10 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--store", required=True, help="path to the backtest bar store")
     parser.add_argument("--market", required=True)
+    parser.add_argument(
+        "--arm", action="append", choices=ARMS, default=None,
+        help="run one arm rather than all three (repeatable)",
+    )
     parser.add_argument(
         "--include-burn-in", action="store_true",
         help="also take trades off burn-in sessions (never for a measured result)",
@@ -489,6 +755,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         trades = simulate_market(
             store, denominator, args.market, DEFAULT_CONTRACT,
+            arms=tuple(args.arm) if args.arm else ARMS,
             include_burn_in=args.include_burn_in,
         )
     finally:

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -5245,13 +5245,25 @@ from backtest.simulate import (
     SimulatedTrade,
     check_trail_mechanic,
     price_scale_drops,
-    simulate_arm_b,
+    simulate_arm,
     simulate_market,
     format_trades,
     simulate_report,
     trail_ma,
-    trail_ma_window,
+    exit_plan,
 )
+
+
+def simulate_arm_b(bars, detection, *, market, contract):
+    """Arm B by name, which is how every test below this line asks for it.
+
+    #190 made the arm a parameter of :func:`simulate_arm` — the arms share one
+    entry and one stop, and only the exit differs — so this is what "arm B" now
+    spells. Kept as a test-local shim rather than a second production entry point:
+    two names for one function in the module itself is exactly the drift the arms
+    were unified to remove.
+    """
+    return simulate_arm(bars, detection, market=market, contract=contract, arm=ARM_B)
 
 
 def _sim_bar(session: date, o: float, h: float, l: float, c: float) -> Bar:
@@ -5371,7 +5383,7 @@ def test_the_trail_signals_on_a_close_through_the_ma_and_fills_at_the_next_open(
 
     trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
 
-    window = trail_ma_window(DEFAULT_CONTRACT)
+    window = exit_plan(DEFAULT_CONTRACT, ARM_B).trail_ma
     assert window == 10
     signal = next(
         i for i in range(41, len(bars))
@@ -5680,9 +5692,9 @@ def test_the_report_carries_the_contract_and_the_dropped_count(store):
     report = simulate_report(DEFAULT_CONTRACT, trades)
 
     assert report[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
-    assert report["arm"] == ARM_B
-    assert report["trades"] == 2
-    assert report["price_scale_dropped"] == 1
+    (arm_b,) = [r for r in report["arms"] if r["arm"] == ARM_B]
+    assert arm_b["trades"] == 2
+    assert arm_b["price_scale_dropped"] == 1
 
 
 def test_the_printed_result_says_how_many_trades_the_price_scale_flag_drops(store):
@@ -5740,7 +5752,7 @@ def test_a_changed_trail_mechanic_is_contract_drift_not_a_silent_reinterpretatio
 def test_arm_b_reads_its_window_from_the_contract_not_from_a_constant(store):
     """The 10 in "10MA" belongs to the contract, so a sweep changes one cell."""
     assert (
-        trail_ma_window(DEFAULT_CONTRACT)
+        exit_plan(DEFAULT_CONTRACT, ARM_B).trail_ma
         == DEFAULT_CONTRACT.value(EXIT_ARM_B_KEY)["trail_ma"]
     )
 
@@ -5800,7 +5812,7 @@ def test_the_denominators_detections_simulate_end_to_end(store, denominator):
     )
     assert measured_detections > 1
 
-    trades = simulate_market(store, denominator, "US", DEFAULT_CONTRACT)
+    trades = simulate_market(store, denominator, "US", DEFAULT_CONTRACT, arms=(ARM_B,))
 
     # The one detection whose next session broke: bar 104's, filled at bar 106.
     (trade,) = trades
@@ -5823,3 +5835,326 @@ def test_the_denominators_detections_simulate_end_to_end(store, denominator):
     # The run's burn-in really does carry detections, so the exclusion has work to do.
     assert any(denominator.detections("US", r.session) for r in run.burn_in)
     assert trade.detection_session in {r.session for r in run.measured}
+
+
+# -- arms A and C, on arm B's entry and stop (issue #190) ----------------------
+#
+# The remaining two exits, sharing arm B's entry and stop *by construction* rather
+# than by agreement: the entry and the stop are computed once and the exit is the
+# only per-arm step, which is the only reason running three arms answers anything
+# about exits at all.
+#
+# Arm A is the trader's documented behaviour — 50% off at the close of the fifth
+# session after entry, remainder on a 10MA trail — and has no counterpart in the
+# reference set, so it is measured and never anchored. Arm C is a pure 20MA trail;
+# B and C are the two directly comparable to the reference set's simulated exits,
+# which is what keeps the anchors usable.
+
+from backtest.chain import bar_index
+from backtest.contract import EXIT_ARM_A_KEY, EXIT_ARM_C_KEY
+from backtest.simulate import (
+    ARM_A,
+    ARM_C,
+    ARMS,
+    EXIT_SCALE,
+    SCALE_MECHANIC,
+    ExitLeg,
+    arm_report,
+    check_arm_mechanics,
+)
+
+
+def _arm(bars, det, arm, *, market="US"):
+    return simulate_arm(bars, det, market=market, contract=DEFAULT_CONTRACT, arm=arm)
+
+
+def test_the_three_arms_share_one_entry_and_one_stop(store):
+    """The premise of running three arms, asserted rather than assumed.
+
+    If the arms differed anywhere before the exit, a difference between their
+    results would be attributable to that difference too, and the whole comparison
+    would say nothing about exits. So every field decided at or before the fill is
+    required to be identical across all three.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+
+    trades = {arm: _arm(bars, det, arm) for arm in ARMS}
+
+    assert set(trades) == {ARM_A, ARM_B, ARM_C}
+    shared = {
+        (t.trigger, t.break_signal, t.entry, t.stop_price, t.stop_width, t.price_scale)
+        for t in trades.values()
+    }
+    assert len(shared) == 1
+    # And the exit really is the only thing that moved: C's 20MA holds a trade B's
+    # 10MA has already let go of, so the fixture would notice arms that agreed.
+    assert trades[ARM_C].exit != trades[ARM_B].exit
+
+
+def test_arm_a_scales_half_at_the_close_of_the_fifth_session_after_entry(store):
+    """The trader's documented behaviour, as the contract's own numbers.
+
+    "Day 5" is the *close of the fifth session after entry* — the fill session is
+    day 0 — and the remainder then trails a 10MA on the same signal-then-fill terms
+    arm B uses. The scale session is recomputed from the fill here rather than
+    written as a constant, so a test that agreed with the simulator by copying its
+    answer would disagree the moment either side moved.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+
+    trade = _arm(bars, det, ARM_A)
+
+    plan = exit_plan(DEFAULT_CONTRACT, ARM_A)
+    assert (plan.scale_day, plan.scale_fraction, plan.trail_ma) == (5, 0.5, 10)
+    fill = bar_index(bars, trade.entry.session)
+    scale_bar = bars[fill + plan.scale_day]
+
+    scale, runner = trade.legs
+    assert scale.reason == EXIT_SCALE
+    assert scale.weight == pytest.approx(0.5)
+    # A planned partial is decided and filled on the same close: there is no signal
+    # to wait a session on, because nothing about the market triggered it.
+    assert scale.signal.session == scale.exit.session == scale_bar.session
+    assert scale.exit.price == scale_bar.close
+    # The remainder is the rest of the position, exited on arm B's own trail.
+    assert runner.reason == EXIT_TRAIL
+    assert runner.weight == pytest.approx(0.5)
+    assert runner.exit == _arm(bars, det, ARM_B).exit
+
+
+def test_arm_as_r_is_position_weighted_per_leg_and_summed(store):
+    """Half a position exiting at +2R contributes 1R, not 2R (acceptance criterion).
+
+    This is the whole of what "two-legged R" means, and it is the one arithmetic in
+    the module that a plausible implementation gets wrong by averaging the legs'
+    R instead of weighting them — a mistake that is invisible in the output,
+    because the wrong number is the same order of magnitude as the right one.
+    """
+    bars = _sim_bars()
+    session = bars[45].session
+
+    def at(price):
+        return Decision(session=session, price=price)
+
+    trade = dataclasses.replace(
+        _arm(bars, _sim_detection(bars), ARM_A),
+        entry=Decision(session=bars[41].session, price=100.0),
+        stop_width=10.0,
+        legs=(
+            # Half out at 120 — ten points is one R, so this leg is +2R on half a
+            # position, and it must contribute exactly 1R.
+            ExitLeg(weight=0.5, signal=at(120.0), exit=at(120.0), reason=EXIT_SCALE),
+            # The remainder out flat, contributing nothing.
+            ExitLeg(weight=0.5, signal=at(100.0), exit=at(100.0), reason=EXIT_TRAIL),
+        ),
+    )
+
+    assert trade.r_multiple == pytest.approx(1.0)
+    # The same exit taken in one leg is the two-legged one's ceiling: a simulator
+    # that summed its legs unweighted would report 2R here too.
+    whole = dataclasses.replace(
+        trade,
+        legs=(ExitLeg(weight=1.0, signal=at(120.0), exit=at(120.0), reason=EXIT_TRAIL),),
+    )
+    assert whole.r_multiple == pytest.approx(2.0)
+
+
+def test_arm_c_trails_a_twenty_session_ma_and_reads_it_from_the_contract(store):
+    """Arm C is arm B with one number changed, and the number is a contract cell.
+
+    The 20 belongs to the contract, so a later run that sweeps it changes one cell
+    and no code. The exit session is recomputed from the fixture's own closes for
+    the same reason arm B's is.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+
+    trade = _arm(bars, det, ARM_C)
+
+    window = exit_plan(DEFAULT_CONTRACT, ARM_C).trail_ma
+    assert window == DEFAULT_CONTRACT.value(EXIT_ARM_C_KEY)["trail_ma"] == 20
+    signal = next(
+        i for i in range(41, len(bars))
+        if (ma := trail_ma(bars[: i + 1], window)) is not None and bars[i].close < ma
+    )
+    (leg,) = trade.legs
+    assert leg.reason == EXIT_TRAIL
+    assert leg.weight == pytest.approx(1.0)
+    assert leg.signal.session == bars[signal].session
+    assert trade.exit.session == bars[signal + 1].session
+    assert trade.exit.price == bars[signal + 1].open
+
+
+def test_arm_as_stop_takes_the_whole_position_when_it_fires_before_day_five(store):
+    """A stop before the scale ends the trade whole, not half.
+
+    The scale is a *plan*, and a plan that has not executed holds no position. An
+    implementation that booked the scale leg regardless would credit arm A with an
+    exit at a price it never traded, on precisely the trades that went against it.
+    """
+    # Break, fill, then straight through the stop at 96 on the next session.
+    closes = _SIM_FLAT + [110.0, 111.0, 90.0, 89.0, 88.0, 87.0, 86.0, 85.0]
+    bars = _sim_bars(closes)
+    det = _sim_detection(bars)
+
+    trade = _arm(bars, det, ARM_A)
+
+    (leg,) = trade.legs
+    assert leg.reason == EXIT_STOP
+    assert leg.weight == pytest.approx(1.0)
+    assert trade.r_multiple == pytest.approx(
+        (trade.exit.price - trade.entry.price) / trade.stop_width
+    )
+
+
+def test_a_scaled_trade_whose_remainder_never_exits_is_open_and_carries_no_r(store):
+    """Half a result is not a result.
+
+    The bars run out with the runner still running. Reporting the realised half
+    would be an equity curve made of the legs that happened to close, which is the
+    same bias marking an open trade at the last close would introduce — only harder
+    to see, because the trade would look closed.
+    """
+    bars = _sim_bars(_SIM_FLAT + _SIM_RUN)
+    det = _sim_detection(bars)
+
+    trade = _arm(bars, det, ARM_A)
+
+    (scale,) = trade.legs
+    assert scale.reason == EXIT_SCALE
+    assert trade.open_at_end
+    assert trade.exit is None
+    assert trade.exit_reason is None
+    assert trade.r_multiple is None
+
+
+def test_arm_a_is_measured_and_never_anchored(store):
+    """Arm A has no counterpart in the reference set, and says so in its own report.
+
+    B and C are the two directly comparable to the reference set's simulated exits;
+    A is the trader's own behaviour and has nothing to be compared against. A report
+    that did not carry that distinction would let a later phase anchor A against a
+    figure that was never measured on A's rules.
+    """
+    bars = _sim_bars()
+    trades = [_arm(bars, _sim_detection(bars), arm) for arm in ARMS]
+
+    report = simulate_report(DEFAULT_CONTRACT, trades)
+    by_arm = {r["arm"]: r for r in report["arms"]}
+
+    assert by_arm[ARM_A]["comparable_to_reference"] is False
+    assert by_arm[ARM_B]["comparable_to_reference"] is True
+    assert by_arm[ARM_C]["comparable_to_reference"] is True
+    assert "arm A — 50% at the close of session 5" in format_trades(report)
+
+
+def test_the_day_five_and_trail_mechanics_are_recorded_as_arbitrary(store):
+    """Both mechanics are contract cells that say they were chosen arbitrarily.
+
+    Neither "the fifth session" nor "fill at the next open" is derived from
+    anything. Recording that is what lets a later run vary them deliberately rather
+    than rediscover them, and the code refuses a contract that has quietly dropped
+    the admission — a run whose mechanics look principled is a run whose sweep
+    nobody thinks to do.
+    """
+    check_arm_mechanics(DEFAULT_CONTRACT, ARM_A)
+    assert DEFAULT_CONTRACT.value(EXIT_ARM_A_KEY)["arbitrary_mechanics"] is True
+    assert DEFAULT_CONTRACT.value(EXIT_TRAIL_MECHANIC_KEY) == TRAIL_MECHANIC
+    assert SCALE_MECHANIC == "close_of_nth_session_after_entry"
+
+    principled = RunContract(
+        contract_version=DEFAULT_CONTRACT.contract_version,
+        label=DEFAULT_CONTRACT.label,
+        cells=tuple(
+            Cell(
+                key=c.key,
+                value={**c.value, "arbitrary_mechanics": False},
+                justification=c.justification,
+            )
+            if c.key == EXIT_ARM_A_KEY else c
+            for c in DEFAULT_CONTRACT.cells
+        ),
+    )
+    with pytest.raises(ContractDrift):
+        check_arm_mechanics(principled, ARM_A)
+
+
+def test_a_detection_appears_once_per_arm(store, denominator):
+    """One trade per arm per detection (acceptance criterion), end to end.
+
+    Run over the persisted denominator rather than a hand-authored detection, so a
+    simulator that produced three arms in isolation and duplicated them over the
+    store's rows would still be caught.
+    """
+    dates = _seed_breakout_store(store)
+    run_denominator(
+        store, denominator, "US", DEFAULT_CONTRACT,
+        start=dates[0], end=dates[-1], measured_start=dates[100],
+    )
+
+    trades = simulate_market(store, denominator, "US", DEFAULT_CONTRACT)
+
+    keyed = {(t.symbol, t.detection_session, t.arm) for t in trades}
+    assert len(keyed) == len(trades) == 3
+    assert {t.arm for t in trades} == set(ARMS)
+    # One detection, three arms, one shared entry — the store's own rows, not the
+    # authored fixture's.
+    assert len({(t.detection_session, t.entry, t.stop_price) for t in trades}) == 1
+
+
+def test_one_arm_can_be_simulated_alone_without_moving_the_others(store, denominator):
+    """Restricting the arms is a filter on which exits run, never on what they read.
+
+    The arms share their entry, so simulating one alone must produce exactly the
+    trade the full run produced for it — otherwise the per-arm figures a sweep
+    reports would depend on which arms happened to be run beside them.
+    """
+    dates = _seed_breakout_store(store)
+    run_denominator(
+        store, denominator, "US", DEFAULT_CONTRACT,
+        start=dates[0], end=dates[-1], measured_start=dates[100],
+    )
+
+    every = simulate_market(store, denominator, "US", DEFAULT_CONTRACT)
+    alone = simulate_market(store, denominator, "US", DEFAULT_CONTRACT, arms=(ARM_C,))
+
+    assert alone == [t for t in every if t.arm == ARM_C]
+
+
+def test_each_arms_report_carries_its_own_exit_and_the_one_contract(store):
+    """Three arms, three sets of figures, one stamped contract.
+
+    The arms differ only in the exit, so the report has to name the exit each figure
+    came from; a set of totals labelled only "arm A/B/C" would be unreadable the
+    moment a sweep changed a window.
+    """
+    bars = _sim_bars()
+    trades = [_arm(bars, _sim_detection(bars), arm) for arm in ARMS]
+
+    report = simulate_report(DEFAULT_CONTRACT, trades)
+
+    assert report[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
+    assert [r["arm"] for r in report["arms"]] == list(ARMS)
+    by_arm = {r["arm"]: r for r in report["arms"]}
+    assert by_arm[ARM_A]["scale_day"] == 5
+    assert by_arm[ARM_A]["scale_fraction"] == 0.5
+    assert by_arm[ARM_A]["scale_mechanic"] == SCALE_MECHANIC
+    assert by_arm[ARM_B]["trail_ma"] == 10
+    assert by_arm[ARM_C]["trail_ma"] == 20
+    assert all(r["trades"] == 1 for r in report["arms"])
+    # And a single arm's body is the same shape whether or not the others ran.
+    assert arm_report(DEFAULT_CONTRACT, ARM_C, trades) == by_arm[ARM_C]
+
+
+def test_an_arm_the_contract_does_not_name_is_refused(store):
+    """A typo in an arm name is a hard error, not an empty result set.
+
+    An unknown arm that returned no trades would report a clean zero — the shape a
+    real, correctly-run arm takes when nothing triggered — and there is no way to
+    tell those two apart after the fact.
+    """
+    bars = _sim_bars()
+    with pytest.raises(ValueError):
+        _arm(bars, _sim_detection(bars), "D")

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -5858,6 +5858,7 @@ from backtest.simulate import (
     ARMS,
     EXIT_SCALE,
     SCALE_MECHANIC,
+    TRAIL_LIVE_FROM_FILL,
     ExitLeg,
     arm_report,
     check_arm_mechanics,
@@ -6158,3 +6159,74 @@ def test_an_arm_the_contract_does_not_name_is_refused(store):
     bars = _sim_bars()
     with pytest.raises(ValueError):
         _arm(bars, _sim_detection(bars), "D")
+
+
+def test_the_trail_is_live_from_the_fill_and_the_contract_says_so(store):
+    """The third arbitrary mechanic, in the contract rather than in a comment.
+
+    On a scaling arm the trail watches from the fill, not from the scale day — so a
+    runner that rolls over before day 5 takes the *whole* position out and the scale
+    never happens. On a fast breakout that degenerates arm A into arm B, which is a
+    material claim about what arm A measures and exactly the kind of thing the
+    issue means by "the mechanics are contract, not code comments".
+    """
+    # Break, fill, then a slide that closes under the 10MA well before day 5.
+    closes = _SIM_FLAT + [110.0, 111.0, 99.0, 98.5, 98.0, 97.5, 97.2, 97.0]
+    bars = _sim_bars(closes)
+    det = _sim_detection(bars)
+
+    trade = _arm(bars, det, ARM_A)
+
+    (leg,) = trade.legs
+    assert leg.reason == EXIT_TRAIL
+    assert leg.weight == pytest.approx(1.0)
+    # Degenerate is the point: with the trail live from the fill, arm A took the
+    # same trade arm B did.
+    assert trade.legs == _arm(bars, det, ARM_B).legs
+
+    assert exit_plan(DEFAULT_CONTRACT, ARM_A).trail_live_from == TRAIL_LIVE_FROM_FILL
+    assert (
+        DEFAULT_CONTRACT.value(EXIT_ARM_A_KEY)["trail_live_from"]
+        == TRAIL_LIVE_FROM_FILL
+    )
+
+
+def test_a_trail_the_contract_starts_elsewhere_is_drift_not_a_reinterpretation(store):
+    """Varying the cell without varying the code would leave a run whose contract
+    and behaviour disagree while both look right — the same refusal the trail's own
+    fill mechanic already carries."""
+    elsewhere = RunContract(
+        contract_version=DEFAULT_CONTRACT.contract_version,
+        label=DEFAULT_CONTRACT.label,
+        cells=tuple(
+            Cell(
+                key=c.key,
+                value={**c.value, "trail_live_from": "scale_day"},
+                justification=c.justification,
+            )
+            if c.key == EXIT_ARM_A_KEY else c
+            for c in DEFAULT_CONTRACT.cells
+        ),
+    )
+    with pytest.raises(ContractDrift):
+        check_arm_mechanics(elsewhere, ARM_A)
+
+
+def test_an_arm_that_ran_and_traded_nothing_reports_zeros_rather_than_vanishing(store):
+    """An arm that triggered nothing is a measurement; an arm that never ran is not.
+
+    A report built from the arms *present in the trades* collapses the two into the
+    same output — a missing section — and there is no way to tell them apart after
+    the fact. So the report covers the arms that were run.
+    """
+    bars = _sim_bars()
+    trades = [_arm(bars, _sim_detection(bars), ARM_B)]
+
+    ran_all = simulate_report(DEFAULT_CONTRACT, trades)
+    ran_one = simulate_report(DEFAULT_CONTRACT, trades, arms=(ARM_B,))
+
+    assert [r["arm"] for r in ran_all["arms"]] == list(ARMS)
+    quiet = {r["arm"]: r for r in ran_all["arms"]}[ARM_C]
+    assert (quiet["trades"], quiet["closed"], quiet["total_r"]) == (0, 0, 0)
+    # And an arm that never ran is absent, which is the distinction being kept.
+    assert [r["arm"] for r in ran_one["arms"]] == [ARM_B]

--- a/references/backtest_run_contract.json
+++ b/references/backtest_run_contract.json
@@ -124,9 +124,10 @@
         "scale_fraction": 0.5,
         "scale_day": 5,
         "trail_ma": 10,
+        "trail_live_from": "fill",
         "arbitrary_mechanics": true
       },
-      "justification": "Arm A scales 50% off at the close of the fifth session after entry and trails the remainder on a 10MA \u2014 the trader's documented behaviour; its R is two position-weighted legs summed, and 'day 5' and the trail are recorded as arbitrary (stories 34, 36, 37, 39)."
+      "justification": "Arm A scales 50% off at the close of the fifth session after entry and trails the remainder on a 10MA \u2014 the trader's documented behaviour; its R is two position-weighted legs summed, and 'day 5' and the trail are recorded as arbitrary (stories 34, 36, 37, 39). The trail is live from the fill rather than from the scale day, so a runner that rolls over before day 5 takes the whole position and the scale never happens; that is a third arbitrary choice and is recorded here rather than left in the code, so a later run can sweep it (story 39)."
     },
     {
       "key": "exit.arm_b",


### PR DESCRIPTION
Closes #190. Phase 4 of PRD #182, on top of #189's arm B.

## What landed

The remaining two exits, on arm B's entry and stop. Both arms were already Phase 0
contract cells, so this is entirely about the simulator learning to read them —
`simulate_arm(..., arm=)` parameterises the exit and nothing else.

- **Arm A** — 50% off at the close of the fifth session after entry (`bars[fill + 5]`;
  the fill session is day 0), remainder on a 10MA trail.
- **Arm C** — a pure 20MA trail, window read from `exit.arm_c`.
- **Two-legged R** — a trade now carries `legs`, each with the share of the position
  it was, and R is the weighted sum. Half a position exiting at +2R contributes 1R —
  not 2R (summing the legs) and not the average (which mis-weights any scale that is
  not a clean half). Both wrong answers are the same order of magnitude as the right
  one, so the test asserts the number.
- **Open means open** — a trade whose scale filled and whose runner never exited has
  no R. Reporting the realised half would build an equity curve out of the legs that
  happened to close: the same bias as marking an open trade at the last close, and
  harder to see, because the trade would look closed.

## Acceptance criteria

| Criterion | Test |
| --- | --- |
| Arm A scales 50% at the close of the fifth session after entry, trails a 10MA | `test_arm_a_scales_half_at_the_close_of_the_fifth_session_after_entry` |
| R position-weighted per leg and summed; half a position at +2R gives 1R | `test_arm_as_r_is_position_weighted_per_leg_and_summed` |
| Arm C trails on a 20MA | `test_arm_c_trails_a_twenty_session_ma_and_reads_it_from_the_contract` |
| All three arms share one entry and one stop | `test_the_three_arms_share_one_entry_and_one_stop` |
| A trade appears once per arm | `test_a_detection_appears_once_per_arm` |
| Day-5 and trail-fill mechanics recorded as arbitrary contract choices | `test_the_day_five_and_trail_mechanics_are_recorded_as_arbitrary` |

## The one contract change

Review found a **third** arbitrary mechanic the first commit left in a docstring:
on a scaling arm the trail is live from the fill rather than from the scale day, so
a runner that rolls over before day 5 takes the whole position and the scale never
happens — on a fast breakout, arm A degenerates into arm B. `exit.arm_a` gains
`trail_live_from: "fill"` and `check_arm_mechanics` refuses any other value.

`contract_version` stays at 1 on purpose: the cell gains a key that makes
already-implemented behaviour explicit and changes no number the run produces, and
no result is committed under it. A cell whose *value* moved would be a new run
recorded beside the old one.

## Verification

696 backend tests green. #189's arm B behaviour is unchanged — `exit`,
`exit_signal` and `exit_reason` became properties over the closing leg, so every
one of its tests still asserts the same numbers, including the shifted-bar
look-ahead test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GTgWDRxmXHgZnJdHUgxWw
