### PR TITLE
The denominator figures — precision, at last (#193)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -385,9 +385,25 @@ label; `mfe10smaPct` is the label used to calibrate the detector, because it mea
 whether the setup worked independently of how the trade was managed.
 
 **Recall**:
-The share of executed trades the app would have surfaced. Measurable. Its counterpart,
-precision, is not — the reference set records no setup he declined, so there is no true
-control group and no false-positive rate. Recall is never optimised on its own.
+The share of executed trades the app would have surfaced. Measurable. Recall is never
+optimised on its own. Its counterpart **precision** is not measurable *against the
+reference set* — it records no setup he declined, so there is no control group there and
+no false-positive rate. It is measurable against the **denominator**, which is what that
+was built for.
+
+**Precision**:
+The share of the setups the detector named that reached a favourable outcome — R above
+zero on a closed **simulated trade** (PRD #182 Phase 5, `backtest.figures`). The figure no
+prior study in this repo could produce, and the one #141 and #149 both had to substitute
+field-volume proxies for. Its denominator is every **answered** detection, the ones that
+never triggered included, which is what makes it a figure about the *detector*. Not the
+**win rate**, whose denominator is only the trades taken and which is therefore a figure
+about the *exit* — reporting one as the other quotes a detector's precision as a trader's
+hit rate. Reported per market, per year and per exit arm, always with the coverage count
+beside it, and always **before costs** until #191 applies them. A detection the bars could
+not answer is **undecided**, never a miss, and a trade still running is **open**, never a
+loss: both would deflate the figure in the direction nobody investigates.
+_Avoid_: hit rate, accuracy — and never quote it without its coverage.
 
 **Replayed field**:
 The full candidate list reconstructed for one past session, from a cold-started forward

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -65,6 +65,19 @@ reason is now doubled: it is a command in its own right
 documented command warn on every invocation. The entry point is reached as
 ``backtest.simulate.simulate_market``.
 
+Issue #193 lands the first of Phase 5: :mod:`backtest.figures`, the three figures the
+denominator was built to produce. Detections per session, the share that trigger, and
+the share that reach a favourable outcome — precision, which the reference study can
+report no value for at all because every result in it is conditioned on trades the
+trader took. Reported per market and per year and never pooled only, plotted across
+the window so a year whose count collapses is visible as the data hole it is, and every
+rate carrying the coverage count it was measured against.
+
+:mod:`backtest.figures`'s names are **not** re-exported here either, and for the same
+mechanical reason as :mod:`backtest.simulate`'s: it is a command
+(``python -m backtest.figures``) and it imports that module, so the entry point is
+reached as ``backtest.figures.figures_for_market``.
+
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean
 something else one import away (:mod:`screener.universe`, :mod:`replay.reference`),

--- a/backend/backtest/figures.py
+++ b/backend/backtest/figures.py
@@ -81,16 +81,24 @@ A count that collapses in a given year is a data hole, and it reads as a quiet
 market until someone looks (story 77). Two flags, because two different things
 collapse and only one of them is about the field:
 
-- :attr:`YearFigures.sessions_collapsed` — the year holds far fewer sessions than
-  the market's median year. A hole in the *store*: a rate computed over it is a
-  rate over a year that never happened.
+- :attr:`YearFigures.sessions_collapsed` — the year holds far fewer sessions per
+  day of window than the market's median year. A hole in the *store*: a rate
+  computed over it is a rate over a year that never happened.
 - :attr:`YearFigures.detections_collapsed` — the year's detections-per-session sits
   far under the market's median year. A hole in the *field*, with the calendar
   intact.
 
-The window opens and closes mid-year by design, so its first and last years are
-short on purpose and are never session-flagged. Flagging them would cry wolf on
-every run and teach a reader to skip the one flag that means something.
+Sessions are judged as a **density** — per day of the year the window actually
+covers — so the window's first and last years, which are short by design, are
+flagged on the same rule as every other year rather than exempted from it. The
+exemption is the tempting shortcut and it is a hole: a store that lost a quarter of
+the window's opening year drops that year's sessions and its detections together,
+so the rate barely moves and neither flag fires.
+
+Every year between the window's first session and its last gets a row, including
+one the store missed **entirely**. Such a year would otherwise produce no row, no
+flag and no contribution to the median — the worst hole the report exists to catch
+would be the one case it could not.
 
 Neither fraction is a contract cell, and that is deliberate. The contract holds
 the choices that decide a *measurement*, and these decide only which rows get a
@@ -102,6 +110,7 @@ the result rather than trusted.
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import json
 from collections import Counter
 from dataclasses import dataclass
@@ -117,8 +126,11 @@ from .denominator import DenominatorStore, denominator_path
 from .result import stamp_result
 from .simulate import (
     ARMS,
+    ENTRY_UNFILLED,
     DetectionOutcome,
     SimulatedTrade,
+    closed_trades,
+    price_scale_drops,
     walk_detections,
 )
 
@@ -151,6 +163,11 @@ SESSION_COLLAPSE_FRACTION = 0.5
 # and looks like a slow year.
 BARS = "▁▂▃▄▅▆▇█"
 HOLE_MARK = "·"
+# A measured zero, drawn so it cannot be mistaken for an unmeasured span. The year
+# the field went to zero is the row a reader is scanning for, and an empty cell
+# beside an empty cell hides it. A sliver rather than a digit, because it sits in
+# the bar column and a "0" there reads as the rate printed twice.
+ZERO_MARK = "▏"
 PLOT_WIDTH = 34
 
 
@@ -189,21 +206,34 @@ def favourable(trade: SimulatedTrade) -> bool:
     ``False`` for a trade still running, which is the honest reading and not a
     convenience — an open trade has no R at all, and the caller keeps it out of
     precision's denominator rather than letting this function decide it lost.
+
+    A function here rather than a property on :class:`SimulatedTrade`, though it
+    reads only that trade's ``r_multiple``. The rule is a **measurement decision**
+    and this is the phase that makes it; the simulator deliberately emits values
+    and no verdicts about them, the same separation the score breakdown keeps when
+    it stores a dimension's value and never one rubric's judgement of it (#154).
+    Putting the threshold on the trade would let a later phase that wanted a
+    different one find it already decided.
     """
     r = trade.r_multiple
     return r is not None and r > 0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ArmFigures:
     """One arm's outcome figures over one market and one span.
 
-    The counts are a funnel and they add up: of the entries that ``filled``, each
-    is either ``closed`` or still ``open_at_end``, and of the closed ones
+    The counts are a funnel and they reconcile: of the entries that ``filled``,
+    each is either ``closed`` or still ``open_at_end``, and of the closed ones
     ``favourable`` made money. ``answered`` is the count precision is measured
-    against and includes the detections that never broke — a setup that failed to
-    trigger is an answer, and leaving it out would measure only the setups that got
-    far enough to be judged.
+    against — the ``closed`` ones plus every detection that was asked and never
+    triggered, which :attr:`Figures.no_break` holds. A setup that failed to trigger
+    *is* an answer, and leaving it out would measure only the setups that got far
+    enough to be judged.
+
+    ``filled`` is this module's name for what :func:`~backtest.simulate.arm_report`
+    calls ``trades``. The two are the same count; the names differ because here it
+    is one stage of an entry funnel and there it is the whole population.
     """
 
     arm: str
@@ -235,20 +265,37 @@ class ArmFigures:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Figures:
     """The three figures over one span: a year, or a whole market's window.
 
     ``sessions`` and ``detections`` are the coverage everything else is measured
     against, which is why they are fields rather than something a reader derives.
-    ``undecided`` is the detections the bars could not answer — reported, never
-    folded into the trigger share's miss.
+
+    **Every detection is in exactly one of four buckets, and all four are
+    reported**, because a bucket with no count is a population that quietly leaves
+    the arithmetic:
+
+    - ``no_break`` — asked, and the market said no. A resolved miss, and it is in
+      precision's denominator on every arm.
+    - ``unfilled`` — it triggered, and the window ended before a session opened to
+      fill it. In the trigger share (it *did* trigger) and in no precision
+      denominator, because no position was ever taken.
+    - ``undecided`` — the bars could not answer: the window ended on it, or the
+      store never covered its session. In no denominator at all.
+    - filled — became a position, and each arm then reports it as ``closed`` or
+      ``open_at_end`` (:class:`ArmFigures`).
+
+    ``detections == no_break + unfilled + undecided + filled``, and
+    :attr:`reconciles` asserts it rather than leaving a reader to add up.
     """
 
     sessions: int
     detections: int
     triggered: Share
     undecided: int
+    no_break: int
+    unfilled: int
     arms: dict[str, ArmFigures]
 
     @property
@@ -256,30 +303,58 @@ class Figures:
         """The headline count, or ``None`` over a span holding no sessions."""
         return self.detections / self.sessions if self.sessions else None
 
+    def reconciles(self, arm: str) -> bool:
+        """Whether every detection lands in exactly one bucket, on this arm.
+
+        The arithmetic the docstring above claims, checkable rather than asserted.
+        A run where this is false has a population going somewhere unreported,
+        which is the failure the four buckets exist to make impossible.
+        """
+        a = self.arms[arm]
+        return (
+            self.no_break + self.unfilled + self.undecided + a.filled
+            == self.detections
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "sessions": self.sessions,
             "detections": self.detections,
             "detections_per_session": self.detections_per_session,
             "triggered": self.triggered.to_dict(),
+            "no_break": self.no_break,
+            "unfilled": self.unfilled,
             "undecided": self.undecided,
             "arms": [self.arms[a].to_dict() for a in ARMS if a in self.arms],
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class YearFigures(Figures):
     """One year's figures, and whether its counts collapsed.
 
     The unit the PRD requires every result be reported in — per market and per
     year, never pooled only, so that a window holding a crash and a mania is not
     described by a single number that fits neither.
+
+    ``covered_days`` is how much of the calendar year the measured window actually
+    spans, and it is what the session count is judged against. Judging against the
+    whole year instead would flag the window's first and last years on every run,
+    since they are short by design — and exempting them from the flag instead, as
+    this first did, leaves a real hole at either end of the window catchable by
+    nothing. A density handles both without an exemption.
     """
 
-    market: str = ""
-    year: int = 0
+    market: str
+    year: int
+    covered_days: int
     sessions_collapsed: bool = False
     detections_collapsed: bool = False
+
+    @property
+    def sessions_per_covered_day(self) -> float | None:
+        """The session density: what a hole in the store actually moves."""
+        return self.sessions / self.covered_days if self.covered_days else None
 
     @property
     def flags(self) -> tuple[str, ...]:
@@ -304,13 +379,15 @@ class YearFigures(Figures):
             "market": self.market,
             "year": self.year,
             **super().to_dict(),
+            "covered_days": self.covered_days,
+            "sessions_per_covered_day": self.sessions_per_covered_day,
             "sessions_collapsed": self.sessions_collapsed,
             "detections_collapsed": self.detections_collapsed,
             "flags": list(self.flags),
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MonthPoint:
     """One month of the plotted series, and whether the store covered it at all.
 
@@ -334,8 +411,14 @@ class MonthPoint:
         return self.detections / self.sessions if self.sessions else None
 
     def to_dict(self) -> dict[str, Any]:
+        # ``year`` and ``month`` ride as numbers as well as in the label. The
+        # label alone would make every reader of the payload — the plot included —
+        # split a string back into the two integers that produced it, which is a
+        # parse that can fail on a value that cannot.
         return {
             "month": f"{self.year:04d}-{self.month:02d}",
+            "year": self.year,
+            "month_of_year": self.month,
             "sessions": self.sessions,
             "detections": self.detections,
             "detections_per_session": self.per_session,
@@ -343,16 +426,22 @@ class MonthPoint:
         }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class MarketFigures(Figures):
     """One market's whole window: its totals, its years, and its monthly series.
 
     Reported per market and never pooled with the other, because findings §8
     measured that magnitudes do not transfer between them — a US figure averaged
     with a Jakarta one describes neither market.
+
+    ``price_scale_dropped`` is the count of this market's trades whose one
+    absolute-price comparison could not be verified. It rides here because the
+    house rule is that the flag is reported beside **every** result built on it,
+    and precision is built on entries priced in absolute terms.
     """
 
-    market: str = ""
+    market: str
+    price_scale_dropped: int
     years: tuple[YearFigures, ...] = ()
     months: tuple[MonthPoint, ...] = ()
 
@@ -361,6 +450,7 @@ class MarketFigures(Figures):
             "market": self.market,
             "sma50_overlap": SMA50_OVERLAP_NOTE,
             **super().to_dict(),
+            "price_scale_dropped": self.price_scale_dropped,
             "years": [y.to_dict() for y in self.years],
             "months": [m.to_dict() for m in self.months],
         }
@@ -368,32 +458,46 @@ class MarketFigures(Figures):
 
 def _tally(
     outcomes: Sequence[DetectionOutcome], sessions: int, arms: Sequence[str]
-) -> tuple[int, Share, int, dict[str, ArmFigures]]:
-    """The counts behind one span's figures, from its detections' outcomes.
+) -> Figures:
+    """One span's figures, from its detections' outcomes.
 
     One pass, because the three figures share a population and computing them
-    apart would let them disagree about which detections were in the span.
+    apart would let them disagree about which detections were in the span. Returns
+    the :class:`Figures` rather than the counts behind it: the four values *are*
+    that type, and handing them back as a tuple only to be unpacked into it at each
+    call site is the same object spelled twice.
     """
     decided = [o for o in outcomes if o.entry.decided]
     triggered = Share(sum(1 for o in decided if o.entry.triggered), len(decided))
     # An answer that is not a trade: the setup never broke. It belongs in
     # precision's denominator on every arm, because the detector named it and the
     # market said no.
-    no_trade = sum(1 for o in decided if not o.entry.triggered)
+    no_break = sum(1 for o in decided if not o.entry.triggered)
+    # It triggered and the window ended before a session opened to fill it. In the
+    # trigger share, and in no precision denominator: no position was taken, so
+    # there is no outcome to be favourable or otherwise.
+    unfilled = sum(1 for o in decided if o.entry.outcome == ENTRY_UNFILLED)
     figures: dict[str, ArmFigures] = {}
     for arm in arms:
         trades = [o.trades[arm] for o in outcomes if arm in o.trades]
-        closed = [t for t in trades if t.r_multiple is not None]
-        hits = sum(1 for t in closed if favourable(t))
+        closed = closed_trades(trades)
         figures[arm] = ArmFigures(
             arm=arm,
             filled=len(trades),
             closed=len(closed),
             open_at_end=len(trades) - len(closed),
-            favourable=hits,
-            answered=no_trade + len(closed),
+            favourable=sum(1 for t in closed if favourable(t)),
+            answered=no_break + len(closed),
         )
-    return len(outcomes), triggered, len(outcomes) - len(decided), figures
+    return Figures(
+        sessions=sessions,
+        detections=len(outcomes),
+        triggered=triggered,
+        undecided=len(outcomes) - len(decided),
+        no_break=no_break,
+        unfilled=unfilled,
+        arms=figures,
+    )
 
 
 def _months(session_dates: Sequence[date], by_session: Counter) -> tuple[MonthPoint, ...]:
@@ -451,6 +555,12 @@ def figures_for_market(
     from the detections, so a year in which nothing detected still contributes its
     calendar — which is the whole of how a collapsed field is told apart from a
     short year.
+
+    Every year between the window's first session and its last gets a row, whether
+    the store covered it or not. A year the store missed **entirely** would
+    otherwise produce no row, no flag and no contribution to the median — so the
+    worst hole the report exists to catch would be the one case it could not, and
+    it would survive only as a blank line in the monthly grid.
     """
     headers = denominator.sessions(
         market, burn_in=None if include_burn_in else False
@@ -469,24 +579,63 @@ def figures_for_market(
         by_year_outcomes.setdefault(o.session.year, []).append(o)
 
     years: list[YearFigures] = []
-    for year in sorted(by_year_sessions):
-        n, triggered, undecided, arm_figures = _tally(
-            by_year_outcomes.get(year, []), by_year_sessions[year], ran
-        )
+    for year in _window_years(session_dates):
+        span = _tally(by_year_outcomes.get(year, []), by_year_sessions[year], ran)
         years.append(
             YearFigures(
-                sessions=by_year_sessions[year], detections=n, triggered=triggered,
-                undecided=undecided, arms=arm_figures, market=market, year=year,
+                **_fields(span), market=market, year=year,
+                covered_days=_covered_days(year, session_dates),
             )
         )
-    years = _flag_collapses(years)
 
-    n, triggered, undecided, arm_figures = _tally(outcomes, len(session_dates), ran)
+    span = _tally(outcomes, len(session_dates), ran)
     return MarketFigures(
-        sessions=len(session_dates), detections=n, triggered=triggered,
-        undecided=undecided, arms=arm_figures, market=market,
-        years=tuple(years), months=_months(session_dates, by_session),
+        **_fields(span), market=market,
+        price_scale_dropped=sum(
+            price_scale_drops(list(o.trades.values())) for o in outcomes
+        ),
+        years=tuple(_flag_collapses(years)),
+        months=_months(session_dates, by_session),
     )
+
+
+def _fields(span: Figures) -> dict[str, Any]:
+    """A :class:`Figures`'s own fields, for a subclass that extends it.
+
+    Named rather than ``dataclasses.asdict``, which would recurse into ``Share``
+    and ``ArmFigures`` and hand back dicts where the constructor wants values.
+    """
+    return {
+        "sessions": span.sessions,
+        "detections": span.detections,
+        "triggered": span.triggered,
+        "undecided": span.undecided,
+        "no_break": span.no_break,
+        "unfilled": span.unfilled,
+        "arms": span.arms,
+    }
+
+
+def _window_years(session_dates: Sequence[date]) -> list[int]:
+    """Every year the window touches, including the ones the store never covered."""
+    if not session_dates:
+        return []
+    return list(range(session_dates[0].year, session_dates[-1].year + 1))
+
+
+def _covered_days(year: int, session_dates: Sequence[date]) -> int:
+    """How many days of ``year`` the measured window actually spans.
+
+    The denominator the session count is judged against. A year the window only
+    half-covers should be half as long, and a year it covers whole should not — so
+    comparing raw session counts would flag the window's first and last years on
+    every single run, which is how a flag becomes noise.
+    """
+    if not session_dates:
+        return 0
+    start = max(session_dates[0], date(year, 1, 1))
+    end = min(session_dates[-1], date(year, 12, 31))
+    return max(0, (end - start).days + 1)
 
 
 def _flag_collapses(years: Sequence[YearFigures]) -> list[YearFigures]:
@@ -497,41 +646,58 @@ def _flag_collapses(years: Sequence[YearFigures]) -> list[YearFigures]:
     calendar and a Jakarta one do not hold the same number of sessions, and a floor
     that fitted one would fire every year on the other.
 
-    The first and last years are never session-flagged: the window opens and
-    closes mid-year by design, so they are short on purpose. Their *field* is still
-    flagged if it collapses, because a partial year with a full calendar and no
-    detections is a hole wherever it sits.
+    Sessions are judged as a **density** — sessions per day of the year the window
+    actually covers — and not as a raw count. That is what lets the window's first
+    and last years be flagged like any other: they hold fewer sessions because they
+    are shorter, and dividing by their own span removes exactly that difference and
+    nothing else. The obvious alternative, exempting the two edge years from the
+    flag, leaves a real hole at either end of the window catchable by neither flag —
+    a missing quarter drops sessions and detections together, so the rate barely
+    moves and the detections flag stays silent too.
     """
     if len(years) < 2:
         # One year has nothing to collapse relative to, and a median of itself
         # would flag nothing however empty it was. Better no claim than a false one.
         return list(years)
-    session_median = median(y.sessions for y in years)
-    rates = [y.detections_per_session for y in years]
-    detection_median = median(r for r in rates if r is not None) if any(
-        r is not None for r in rates
-    ) else None
-    out: list[YearFigures] = []
-    for i, y in enumerate(years):
-        interior = 0 < i < len(years) - 1
-        sessions_collapsed = bool(
-            interior and y.sessions < SESSION_COLLAPSE_FRACTION * session_median
+    session_median = _median_of(y.sessions_per_covered_day for y in years)
+    detection_median = _median_of(y.detections_per_session for y in years)
+    return [
+        dataclasses.replace(
+            y,
+            sessions_collapsed=_under(
+                y.sessions_per_covered_day, session_median,
+                SESSION_COLLAPSE_FRACTION,
+            ),
+            detections_collapsed=_under(
+                y.detections_per_session, detection_median,
+                DETECTION_COLLAPSE_FRACTION,
+            ),
         )
-        rate = y.detections_per_session
-        detections_collapsed = bool(
-            detection_median
-            and rate is not None
-            and rate < DETECTION_COLLAPSE_FRACTION * detection_median
-        )
-        out.append(
-            YearFigures(
-                sessions=y.sessions, detections=y.detections, triggered=y.triggered,
-                undecided=y.undecided, arms=y.arms, market=y.market, year=y.year,
-                sessions_collapsed=sessions_collapsed,
-                detections_collapsed=detections_collapsed,
-            )
-        )
-    return out
+        for y in years
+    ]
+
+
+def _median_of(values: Any) -> float | None:
+    """The median of the values that exist, or ``None`` if none do.
+
+    ``None`` is absent — a year with no covered days has no density, and a year
+    with no sessions has no detection rate — and averaging absence in as a zero
+    would drag the median down until nothing could clear a quarter of it.
+    """
+    present = [v for v in values if v is not None]
+    return median(present) if present else None
+
+
+def _under(value: float | None, reference: float | None, fraction: float) -> bool:
+    """Whether ``value`` collapsed against ``reference``.
+
+    ``False`` when either is absent: a span nothing was measured over has not
+    collapsed, it is simply unmeasured, and a flag that cannot tell the two apart
+    is a flag that fires on the window's own edges.
+    """
+    if value is None or not reference:
+        return False
+    return value < fraction * reference
 
 
 def figures_report(
@@ -572,10 +738,19 @@ def figures_report(
 
 
 def _bar(value: float | None, peak: float | None) -> str:
-    """One year's bar, scaled to the tallest year in the market."""
-    if not value or not peak:
+    """One year's bar, scaled to the tallest year in the market.
+
+    A measured zero draws as :data:`ZERO_MARK` and an unmeasured year as nothing at
+    all. Drawing both as an empty cell would put the module's own rule — that a
+    ``0`` and an absent value are different claims — on the wrong side of its most
+    visible output, and the year where the field went to zero is precisely the row
+    a reader is scanning for.
+    """
+    if value is None or not peak:
         return ""
-    return "█" * max(1, round(PLOT_WIDTH * value / peak))
+    if value <= 0:
+        return ZERO_MARK
+    return BARS[-1] * max(1, round(PLOT_WIDTH * value / peak))
 
 
 def _sparkline(months: Sequence[dict[str, Any]]) -> list[str]:
@@ -602,7 +777,7 @@ def _sparkline(months: Sequence[dict[str, Any]]) -> list[str]:
     peak = max((r for r in rates if r is not None), default=0.0)
     drawn: dict[tuple[int, int], str] = {}
     for m in months:
-        year, month = (int(p) for p in m["month"].split("-"))
+        year, month = m["year"], m["month_of_year"]
         if m["hole"]:
             drawn[(year, month)] = HOLE_MARK
             continue
@@ -700,9 +875,15 @@ def format_figures(report: dict[str, Any]) -> str:
             "",
             f"  sessions measured   {market['sessions']}",
             f"  detections          {market['detections']}",
-            f"  triggered           {Share(**_share(market['triggered']))}",
+            f"  triggered           {_share(market['triggered'])}",
+            f"  never broke         {market['no_break']}  "
+            "(asked, and the market said no — in precision's denominator)",
+            f"  unfilled            {market['unfilled']}  "
+            "(triggered, and the window ended before a fill)",
             f"  undecided           {market['undecided']}  "
             "(the bars could not answer these; they are not misses)",
+            f"  price-scale flag would drop {market['price_scale_dropped']} of the "
+            "trades behind these figures",
             "",
         ]
         for arm in market["arms"]:
@@ -712,22 +893,22 @@ def format_figures(report: dict[str, Any]) -> str:
                 f"    closed            {arm['closed']}",
                 f"    open at end       {arm['open_at_end']}  "
                 "(no outcome — never counted as a loss)",
-                f"    precision         {Share(**_share(arm['precision']))}"
+                f"    precision         {_share(arm['precision'])}"
                 "  — of every answered detection",
-                f"    win rate          {Share(**_share(arm['win_rate']))}"
+                f"    win rate          {_share(arm['win_rate'])}"
                 "  — of the trades taken",
             ]
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
 
 
-def _share(body: dict[str, Any]) -> dict[str, int]:
-    """A serialised :class:`Share` back into the fields the value takes.
+def _share(body: dict[str, Any]) -> Share:
+    """A serialised :class:`Share` back into the value, for printing.
 
-    The rate is recomputed rather than read back: a rate and its counts arriving
-    from a file could disagree, and the counts are the record.
+    The rate is rebuilt from the counts rather than read back: a rate and its
+    counts arriving from a file could disagree, and the counts are the record.
     """
-    return {"hits": body["hits"], "of": body["of"]}
+    return Share(body["hits"], body["of"])
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/backend/backtest/figures.py
+++ b/backend/backtest/figures.py
@@ -1,0 +1,785 @@
+"""The denominator figures: precision, at last (issue #193, PRD #182 Phase 5).
+
+The figures no prior study in this repo could produce. `references/qullamaggie-replay-findings.md`
+measures 828 executed entries, and every one of them is a trade a trader **took** —
+so §9 states plainly that the study can report no precision and no false-positive
+rate. It has a numerator and no denominator. #149 hit the same wall from the other
+side and had to record 27,323 detections as *volume carrying no verdict*, which is
+the honest limit of a study with no control group.
+
+Those detections are exactly the population this module measures. Three figures,
+per market and per year:
+
+- **Detections per session** — the count, and the plot across the window.
+- **The share that trigger** — a close through the detection's own trigger.
+- **The share that reach a favourable outcome** — precision, per exit arm.
+
+Every rate carries its coverage
+-------------------------------
+A rate whose denominator is not printed is a rate nobody can check, so every one
+here is a :class:`Share` — a numerator, the count it was measured against, and a
+``rate`` that is ``None`` rather than ``0.0`` when nothing was measured at all. A
+``0/0`` reported as zero is a claim the data never made, and it is the shape a
+thin regime cell or an empty year takes.
+
+Two ways to deflate a rate silently, and what stops each
+---------------------------------------------------------
+Both errors push in the same direction — they make the method look worse — which
+is the direction nobody investigates, so neither would be caught by reading the
+output:
+
+- **A detection the bars cannot answer is not a miss.** A detection sitting on the
+  last session of the window has not failed to trigger; nothing has asked it yet.
+  The trigger share's denominator is the *decided* detections only
+  (:data:`~backtest.simulate.ENTRY_DECIDED`), and the rest are reported as
+  :attr:`Figures.undecided` rather than folded into the miss.
+- **A trade still running is not a loss.** Closing it at the last available close
+  would invent an exit the rules never gave, systematically, for every name still
+  running when the window ends. An open trade leaves precision's denominator and
+  is reported as :attr:`ArmFigures.open_at_end`.
+
+Precision and the win rate are different questions
+---------------------------------------------------
+They differ in the denominator and the difference is the whole point:
+
+- **Precision** is favourable outcomes over every *answered* detection — the ones
+  that never broke included. It is a figure about the **detector**: of everything
+  it named, what share paid.
+- **The win rate** is favourable outcomes over the trades that were actually
+  taken. It is a figure about the **exit**, and it is the one directly comparable
+  to the reference set's shape — 22.7% of his trades made money and the mean R was
+  positive anyway, which is why a low win rate is judged against its right tail
+  rather than on its own.
+
+Reporting one as the other would quote a detector's precision as a trader's hit
+rate, so both are computed and both are labelled.
+
+Both are per arm, and the trigger share is not. The arms share one entry and one
+stop, so what triggered cannot differ between them; what an exit then makes of the
+position is exactly what differs, and a single precision figure would be a claim
+about an exit it never named.
+
+Before costs, and it says so
+-----------------------------
+Costs are #191's. A precision figure computed before commission and slippage
+**overstates**, and by more on IDX than on US, where the contract's fees and
+spread are an order of magnitude larger. The payload carries ``costs_applied:
+false`` and the formatter prints it beside the number, because a caveat a reader
+has to remember is a caveat a reader forgets.
+
+The SMA50 overlap, stated wherever counts are reported
+-------------------------------------------------------
+The contract's universe gate is ``close > SMA50`` and the detector carries its own
+trend logic, so the two overlap and detection counts fall against an unfiltered
+run. **That is the gate working, not the detector becoming more selective** — and
+the two effects get conflated by any reader not told. :data:`SMA50_OVERLAP_NOTE`
+rides on the payload and prints in every market's section (PRD story 20).
+
+A year that collapses is flagged rather than quietly reported
+--------------------------------------------------------------
+A count that collapses in a given year is a data hole, and it reads as a quiet
+market until someone looks (story 77). Two flags, because two different things
+collapse and only one of them is about the field:
+
+- :attr:`YearFigures.sessions_collapsed` — the year holds far fewer sessions than
+  the market's median year. A hole in the *store*: a rate computed over it is a
+  rate over a year that never happened.
+- :attr:`YearFigures.detections_collapsed` — the year's detections-per-session sits
+  far under the market's median year. A hole in the *field*, with the calendar
+  intact.
+
+The window opens and closes mid-year by design, so its first and last years are
+short on purpose and are never session-flagged. Flagging them would cry wolf on
+every run and teach a reader to skip the one flag that means something.
+
+Neither fraction is a contract cell, and that is deliberate. The contract holds
+the choices that decide a *measurement*, and these decide only which rows get a
+mark beside them — no figure moves either way. They are named constants whose
+values ride on the payload (``collapse_rule``) so a flag's rule is readable off
+the result rather than trusted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from statistics import median
+from typing import Any, Sequence
+
+from screener.store import Store
+
+from .contract import DEFAULT_CONTRACT, RunContract
+from .denominator import DenominatorStore, denominator_path
+from .result import stamp_result
+from .simulate import (
+    ARMS,
+    DetectionOutcome,
+    SimulatedTrade,
+    walk_detections,
+)
+
+# The overlap the PRD requires stated wherever counts are reported (story 20). It
+# is a fact about how two gates interact, not a choice the run makes, which is why
+# it is a constant here rather than a contract cell — the same call
+# ``ARM_SPECS.comparable_to_reference`` makes.
+SMA50_OVERLAP_NOTE = (
+    "the contract's close > SMA50 universe gate overlaps the detector's own trend "
+    "logic, so these counts sit below an unfiltered run — the gate working, not "
+    "the detector becoming more selective"
+)
+
+# What counts as favourable. The zero line is the contract's own — ``decision.kill``
+# draws it at 0.0 R — so the run does not invent a second one, and R is the
+# detection's own stop width by construction, which is the unit the app denominates
+# in. Stated on the result rather than left in this docstring, because a threshold
+# nobody can read off the output is a threshold a later run can quietly move.
+FAVOURABLE_RULE = "R > 0 on a closed trade, before costs"
+
+# When a year's count is a hole rather than a quiet market. Both are diagnostic:
+# they decide which rows get a mark, and no reported figure moves either way. See
+# the module docstring for why they are not contract cells.
+DETECTION_COLLAPSE_FRACTION = 0.25
+SESSION_COLLAPSE_FRACTION = 0.5
+
+# The plot's alphabet. ``HOLE_MARK`` is deliberately not the lowest bar: a month
+# the store never covered and a month that traded and detected nothing are
+# different facts, and a yearly mean hides the first one — it drops by a twelfth
+# and looks like a slow year.
+BARS = "▁▂▃▄▅▆▇█"
+HOLE_MARK = "·"
+PLOT_WIDTH = 34
+
+
+@dataclass(frozen=True)
+class Share:
+    """A count, the coverage it was measured against, and the rate between them.
+
+    Every rate this module reports is one of these. A bare float would be a figure
+    a reader cannot check and — worse — would report ``0/0`` as ``0.0``, which is a
+    claim the data never made and exactly the shape an empty year or a thin cell
+    takes. :attr:`rate` is ``None`` there instead, and the formatter prints the
+    coverage beside every percentage rather than under it.
+    """
+
+    hits: int
+    of: int
+
+    @property
+    def rate(self) -> float | None:
+        """The share, or ``None`` when nothing was measured."""
+        return self.hits / self.of if self.of else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"hits": self.hits, "of": self.of, "rate": self.rate}
+
+    def __str__(self) -> str:
+        """``42.9% (3 of 7)`` — never a percentage without the count under it."""
+        rate = self.rate
+        shown = "n/a" if rate is None else f"{rate:.1%}"
+        return f"{shown} ({self.hits} of {self.of})"
+
+
+def favourable(trade: SimulatedTrade) -> bool:
+    """Whether a trade reached a favourable outcome: :data:`FAVOURABLE_RULE`.
+
+    ``False`` for a trade still running, which is the honest reading and not a
+    convenience — an open trade has no R at all, and the caller keeps it out of
+    precision's denominator rather than letting this function decide it lost.
+    """
+    r = trade.r_multiple
+    return r is not None and r > 0
+
+
+@dataclass(frozen=True)
+class ArmFigures:
+    """One arm's outcome figures over one market and one span.
+
+    The counts are a funnel and they add up: of the entries that ``filled``, each
+    is either ``closed`` or still ``open_at_end``, and of the closed ones
+    ``favourable`` made money. ``answered`` is the count precision is measured
+    against and includes the detections that never broke — a setup that failed to
+    trigger is an answer, and leaving it out would measure only the setups that got
+    far enough to be judged.
+    """
+
+    arm: str
+    filled: int
+    closed: int
+    open_at_end: int
+    favourable: int
+    answered: int
+
+    @property
+    def precision(self) -> Share:
+        """Favourable outcomes over every answered detection — the detector's figure."""
+        return Share(self.favourable, self.answered)
+
+    @property
+    def win_rate(self) -> Share:
+        """Favourable outcomes over the trades taken — the exit's figure."""
+        return Share(self.favourable, self.closed)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "arm": self.arm,
+            "filled": self.filled,
+            "closed": self.closed,
+            "open_at_end": self.open_at_end,
+            "favourable": self.favourable,
+            "precision": self.precision.to_dict(),
+            "win_rate": self.win_rate.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class Figures:
+    """The three figures over one span: a year, or a whole market's window.
+
+    ``sessions`` and ``detections`` are the coverage everything else is measured
+    against, which is why they are fields rather than something a reader derives.
+    ``undecided`` is the detections the bars could not answer — reported, never
+    folded into the trigger share's miss.
+    """
+
+    sessions: int
+    detections: int
+    triggered: Share
+    undecided: int
+    arms: dict[str, ArmFigures]
+
+    @property
+    def detections_per_session(self) -> float | None:
+        """The headline count, or ``None`` over a span holding no sessions."""
+        return self.detections / self.sessions if self.sessions else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sessions": self.sessions,
+            "detections": self.detections,
+            "detections_per_session": self.detections_per_session,
+            "triggered": self.triggered.to_dict(),
+            "undecided": self.undecided,
+            "arms": [self.arms[a].to_dict() for a in ARMS if a in self.arms],
+        }
+
+
+@dataclass(frozen=True)
+class YearFigures(Figures):
+    """One year's figures, and whether its counts collapsed.
+
+    The unit the PRD requires every result be reported in — per market and per
+    year, never pooled only, so that a window holding a crash and a mania is not
+    described by a single number that fits neither.
+    """
+
+    market: str = ""
+    year: int = 0
+    sessions_collapsed: bool = False
+    detections_collapsed: bool = False
+
+    @property
+    def flags(self) -> tuple[str, ...]:
+        """The year's collapse flags in words, for a reader rather than a query."""
+        out: list[str] = []
+        if self.sessions_collapsed:
+            out.append(
+                f"sessions collapsed — {self.sessions} in the year, under "
+                f"{SESSION_COLLAPSE_FRACTION:.0%} of this market's median year: a "
+                "hole in the store, and a rate over a year that never happened"
+            )
+        if self.detections_collapsed:
+            out.append(
+                "detections collapsed — under "
+                f"{DETECTION_COLLAPSE_FRACTION:.0%} of this market's median year "
+                "with the calendar intact: a hole in the field, not a quiet market"
+            )
+        return tuple(out)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "year": self.year,
+            **super().to_dict(),
+            "sessions_collapsed": self.sessions_collapsed,
+            "detections_collapsed": self.detections_collapsed,
+            "flags": list(self.flags),
+        }
+
+
+@dataclass(frozen=True)
+class MonthPoint:
+    """One month of the plotted series, and whether the store covered it at all.
+
+    ``sessions`` of zero is a **hole**: the store held no session that month, which
+    a yearly mean cannot show — it drops by a twelfth and reads as a slow year. A
+    month with sessions and no detections is a different fact and draws differently
+    (:data:`HOLE_MARK`).
+    """
+
+    year: int
+    month: int
+    sessions: int
+    detections: int
+
+    @property
+    def hole(self) -> bool:
+        return self.sessions == 0
+
+    @property
+    def per_session(self) -> float | None:
+        return self.detections / self.sessions if self.sessions else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "month": f"{self.year:04d}-{self.month:02d}",
+            "sessions": self.sessions,
+            "detections": self.detections,
+            "detections_per_session": self.per_session,
+            "hole": self.hole,
+        }
+
+
+@dataclass(frozen=True)
+class MarketFigures(Figures):
+    """One market's whole window: its totals, its years, and its monthly series.
+
+    Reported per market and never pooled with the other, because findings §8
+    measured that magnitudes do not transfer between them — a US figure averaged
+    with a Jakarta one describes neither market.
+    """
+
+    market: str = ""
+    years: tuple[YearFigures, ...] = ()
+    months: tuple[MonthPoint, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "sma50_overlap": SMA50_OVERLAP_NOTE,
+            **super().to_dict(),
+            "years": [y.to_dict() for y in self.years],
+            "months": [m.to_dict() for m in self.months],
+        }
+
+
+def _tally(
+    outcomes: Sequence[DetectionOutcome], sessions: int, arms: Sequence[str]
+) -> tuple[int, Share, int, dict[str, ArmFigures]]:
+    """The counts behind one span's figures, from its detections' outcomes.
+
+    One pass, because the three figures share a population and computing them
+    apart would let them disagree about which detections were in the span.
+    """
+    decided = [o for o in outcomes if o.entry.decided]
+    triggered = Share(sum(1 for o in decided if o.entry.triggered), len(decided))
+    # An answer that is not a trade: the setup never broke. It belongs in
+    # precision's denominator on every arm, because the detector named it and the
+    # market said no.
+    no_trade = sum(1 for o in decided if not o.entry.triggered)
+    figures: dict[str, ArmFigures] = {}
+    for arm in arms:
+        trades = [o.trades[arm] for o in outcomes if arm in o.trades]
+        closed = [t for t in trades if t.r_multiple is not None]
+        hits = sum(1 for t in closed if favourable(t))
+        figures[arm] = ArmFigures(
+            arm=arm,
+            filled=len(trades),
+            closed=len(closed),
+            open_at_end=len(trades) - len(closed),
+            favourable=hits,
+            answered=no_trade + len(closed),
+        )
+    return len(outcomes), triggered, len(outcomes) - len(decided), figures
+
+
+def _months(session_dates: Sequence[date], by_session: Counter) -> tuple[MonthPoint, ...]:
+    """The monthly series across the window, holes included.
+
+    Every month between the first session and the last gets a point, whether the
+    store covered it or not — a series that simply omitted the empty months would
+    plot a hole as a shorter line, which is the one thing the plot exists to make
+    visible.
+    """
+    if not session_dates:
+        return ()
+    first, last = session_dates[0], session_dates[-1]
+    per_month: Counter = Counter()
+    detections_per_month: Counter = Counter()
+    for d in session_dates:
+        per_month[(d.year, d.month)] += 1
+        detections_per_month[(d.year, d.month)] += by_session[d]
+    points: list[MonthPoint] = []
+    year, month = first.year, first.month
+    while (year, month) <= (last.year, last.month):
+        points.append(
+            MonthPoint(
+                year=year, month=month,
+                sessions=per_month[(year, month)],
+                detections=detections_per_month[(year, month)],
+            )
+        )
+        year, month = (year + 1, 1) if month == 12 else (year, month + 1)
+    return tuple(points)
+
+
+def figures_for_market(
+    store: Store,
+    denominator: DenominatorStore,
+    market: str,
+    contract: RunContract = DEFAULT_CONTRACT,
+    *,
+    arms: Sequence[str] = ARMS,
+    include_burn_in: bool = False,
+) -> MarketFigures:
+    """One market's denominator figures, per year and across the window.
+
+    The single entry point for Phase 5's counts. Reads the rows
+    :mod:`backtest.run` persisted and the bars they were computed from, walks each
+    detection through the shared entry and every arm's exit
+    (:func:`~backtest.simulate.walk_detections`), and reduces the result per year
+    and over the whole window.
+
+    Burn-in sessions are excluded by default, from the session spine and from the
+    detections alike: a warm-up session is persisted and never measured (story
+    76), and a figure that counted one would rest on an unsettled chain.
+
+    The session count comes from the persisted **session headers** rather than
+    from the detections, so a year in which nothing detected still contributes its
+    calendar — which is the whole of how a collapsed field is told apart from a
+    short year.
+    """
+    headers = denominator.sessions(
+        market, burn_in=None if include_burn_in else False
+    )
+    session_dates = [h.session for h in headers]
+    outcomes = walk_detections(
+        store, denominator, market, contract,
+        arms=arms, include_burn_in=include_burn_in,
+    )
+    ran = [a for a in ARMS if a in arms]
+
+    by_year_sessions = Counter(d.year for d in session_dates)
+    by_session = Counter(o.session for o in outcomes)
+    by_year_outcomes: dict[int, list[DetectionOutcome]] = {}
+    for o in outcomes:
+        by_year_outcomes.setdefault(o.session.year, []).append(o)
+
+    years: list[YearFigures] = []
+    for year in sorted(by_year_sessions):
+        n, triggered, undecided, arm_figures = _tally(
+            by_year_outcomes.get(year, []), by_year_sessions[year], ran
+        )
+        years.append(
+            YearFigures(
+                sessions=by_year_sessions[year], detections=n, triggered=triggered,
+                undecided=undecided, arms=arm_figures, market=market, year=year,
+            )
+        )
+    years = _flag_collapses(years)
+
+    n, triggered, undecided, arm_figures = _tally(outcomes, len(session_dates), ran)
+    return MarketFigures(
+        sessions=len(session_dates), detections=n, triggered=triggered,
+        undecided=undecided, arms=arm_figures, market=market,
+        years=tuple(years), months=_months(session_dates, by_session),
+    )
+
+
+def _flag_collapses(years: Sequence[YearFigures]) -> list[YearFigures]:
+    """Mark the years whose counts collapsed against this market's median year.
+
+    Measured against the market's **own** median rather than an absolute floor,
+    because a year is short or empty relative to the market it sits in — a US
+    calendar and a Jakarta one do not hold the same number of sessions, and a floor
+    that fitted one would fire every year on the other.
+
+    The first and last years are never session-flagged: the window opens and
+    closes mid-year by design, so they are short on purpose. Their *field* is still
+    flagged if it collapses, because a partial year with a full calendar and no
+    detections is a hole wherever it sits.
+    """
+    if len(years) < 2:
+        # One year has nothing to collapse relative to, and a median of itself
+        # would flag nothing however empty it was. Better no claim than a false one.
+        return list(years)
+    session_median = median(y.sessions for y in years)
+    rates = [y.detections_per_session for y in years]
+    detection_median = median(r for r in rates if r is not None) if any(
+        r is not None for r in rates
+    ) else None
+    out: list[YearFigures] = []
+    for i, y in enumerate(years):
+        interior = 0 < i < len(years) - 1
+        sessions_collapsed = bool(
+            interior and y.sessions < SESSION_COLLAPSE_FRACTION * session_median
+        )
+        rate = y.detections_per_session
+        detections_collapsed = bool(
+            detection_median
+            and rate is not None
+            and rate < DETECTION_COLLAPSE_FRACTION * detection_median
+        )
+        out.append(
+            YearFigures(
+                sessions=y.sessions, detections=y.detections, triggered=y.triggered,
+                undecided=y.undecided, arms=y.arms, market=y.market, year=y.year,
+                sessions_collapsed=sessions_collapsed,
+                detections_collapsed=detections_collapsed,
+            )
+        )
+    return out
+
+
+def figures_report(
+    contract: RunContract, markets: Sequence[MarketFigures]
+) -> dict[str, Any]:
+    """Every market's figures as one stamped payload.
+
+    The rules that qualify the numbers ride at the top of the result rather than in
+    a companion document: what counts as favourable, that costs are not applied
+    yet, how a collapse is decided, and the SMA50 overlap. Each of them changes how
+    a figure below should be read, and a qualification a reader has to fetch is a
+    qualification a reader skips.
+
+    Markets appear in the order given rather than sorted, and never merged: US and
+    IDX are reported separately throughout, so findings §8's result that magnitudes
+    do not transfer is honoured rather than averaged away.
+    """
+    return stamp_result(
+        contract,
+        {
+            "sma50_overlap": SMA50_OVERLAP_NOTE,
+            "favourable_rule": FAVOURABLE_RULE,
+            "costs_applied": False,
+            "costs_note": (
+                "these are before costs — commission and slippage are applied by "
+                "the phase that computes the pre-registered primary metric, and "
+                "precision computed before them overstates"
+            ),
+            "collapse_rule": {
+                "detections_fraction": DETECTION_COLLAPSE_FRACTION,
+                "sessions_fraction": SESSION_COLLAPSE_FRACTION,
+                "basis": "the market's own median year",
+                "edges_exempt_from_sessions_flag": True,
+            },
+            "markets": [m.to_dict() for m in markets],
+        },
+    )
+
+
+def _bar(value: float | None, peak: float | None) -> str:
+    """One year's bar, scaled to the tallest year in the market."""
+    if not value or not peak:
+        return ""
+    return "█" * max(1, round(PLOT_WIDTH * value / peak))
+
+
+def _sparkline(months: Sequence[dict[str, Any]]) -> list[str]:
+    """The monthly series as a calendar grid: one row per year, twelve columns.
+
+    A single line across the window would run past 160 columns on a fourteen-year
+    run and lose its own axis. A grid keeps every row twelve wide, so the months
+    line up under each other and a hole that recurs every August is a *column* — a
+    shape one line of 168 glyphs cannot show at all.
+
+    Three marks, and the third is the point: a bar is a month that traded, a
+    :data:`HOLE_MARK` is a month inside the window the store never covered, and a
+    blank is a month outside the window, which is not a hole but the edge. Folding
+    the last two together would put a permanent hole at each end of every run and
+    teach a reader to ignore the mark.
+
+    Eight levels is all a terminal glyph gives, which is plenty: the grid is read
+    for *shape* — where the field thins and where it stops — and the table above it
+    carries the numbers.
+    """
+    if not months:
+        return []
+    rates = [m["detections_per_session"] for m in months if not m["hole"]]
+    peak = max((r for r in rates if r is not None), default=0.0)
+    drawn: dict[tuple[int, int], str] = {}
+    for m in months:
+        year, month = (int(p) for p in m["month"].split("-"))
+        if m["hole"]:
+            drawn[(year, month)] = HOLE_MARK
+            continue
+        rate = m["detections_per_session"] or 0.0
+        level = 0 if not peak else round(rate / peak * (len(BARS) - 1))
+        drawn[(year, month)] = BARS[min(len(BARS) - 1, level)]
+    years = sorted({y for y, _ in drawn})
+    return [
+        f"    {year}  " + "".join(drawn.get((year, m), " ") for m in range(1, 13))
+        for year in years
+    ]
+
+
+def _outcomes_table(years: Sequence[dict[str, Any]]) -> list[str]:
+    """The trigger share and each arm's precision, per year.
+
+    Every cell is ``n / m`` rather than a percentage, and that is the point at this
+    width: the counts *are* the coverage, so a year whose figures rest on four
+    detections cannot be read as one resting on four hundred. A percentage would
+    fit more comfortably and would hide exactly that.
+
+    Per year and not only per market, because a window holding a crash and a mania
+    is not described by a single number that fits neither (story 88).
+    """
+    if not years:
+        return []
+    arms = [a["arm"] for a in years[0]["arms"]]
+    head = "  year  detections  decided  triggered" + "".join(
+        f"  precision {a}" for a in arms
+    )
+    rows = [head]
+    for y in years:
+        decided = y["triggered"]["of"]
+        cells = "".join(
+            f"  {a['precision']['hits']:>5} /{a['precision']['of']:>4}"
+            for a in y["arms"]
+        )
+        rows.append(
+            f"  {y['year']}  {y['detections']:10d}  {decided:7d}  "
+            f"{y['triggered']['hits']:4d} /{decided:4d}{cells}"
+        )
+    return rows
+
+
+def format_figures(report: dict[str, Any]) -> str:
+    """The denominator figures as a page a terminal can print.
+
+    Per market: the overlap note, the per-year table with its plot in the same
+    rows, the monthly series, and the arms' precision. The plot shares the table's
+    rows rather than sitting under it, because a bar beside its own numbers is read
+    together with them and a chart below a table is read instead of it.
+
+    Every rate prints as ``x% (n of m)``. The coverage is not a footnote here: it
+    is the difference between a precision figure and a precision figure nobody can
+    check.
+    """
+    lines: list[str] = [
+        f"favourable outcome: {report['favourable_rule']}",
+        f"note: {report['costs_note']}",
+        "",
+    ]
+    for market in report["markets"]:
+        years = market["years"]
+        span = (
+            f"{years[0]['year']}–{years[-1]['year']}" if years else "no sessions"
+        )
+        peak = max(
+            (y["detections_per_session"] or 0.0 for y in years), default=0.0
+        )
+        lines += [
+            f"{market['market']} — detections per session, {span}",
+            f"  {report['sma50_overlap']}",
+            "",
+            "  year  sessions  detections  per session",
+        ]
+        for y in years:
+            rate = y["detections_per_session"]
+            shown = "    n/a" if rate is None else f"{rate:7.3f}"
+            lines.append(
+                f"  {y['year']}  {y['sessions']:8d}  {y['detections']:10d}  "
+                f"{shown}  {_bar(rate, peak)}".rstrip()
+            )
+            # On its own line rather than trailing the row: a flag is a sentence,
+            # and a sentence appended to a fixed-width table pushes the row past
+            # any terminal and takes the columns with it.
+            lines += [f"          ⚠ {f}" for f in y["flags"]]
+        lines += ["", *_outcomes_table(years)]
+        lines += [
+            "",
+            "  detections per session by month  (JFMAMJJASOND)",
+            f"    {HOLE_MARK} is a month inside the window the store never "
+            "covered — a hole, not a quiet month",
+            "",
+            *_sparkline(market["months"]),
+            "",
+            f"  sessions measured   {market['sessions']}",
+            f"  detections          {market['detections']}",
+            f"  triggered           {Share(**_share(market['triggered']))}",
+            f"  undecided           {market['undecided']}  "
+            "(the bars could not answer these; they are not misses)",
+            "",
+        ]
+        for arm in market["arms"]:
+            lines += [
+                f"  arm {arm['arm']}",
+                f"    filled            {arm['filled']}",
+                f"    closed            {arm['closed']}",
+                f"    open at end       {arm['open_at_end']}  "
+                "(no outcome — never counted as a loss)",
+                f"    precision         {Share(**_share(arm['precision']))}"
+                "  — of every answered detection",
+                f"    win rate          {Share(**_share(arm['win_rate']))}"
+                "  — of the trades taken",
+            ]
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _share(body: dict[str, Any]) -> dict[str, int]:
+    """A serialised :class:`Share` back into the fields the value takes.
+
+    The rate is recomputed rather than read back: a rate and its counts arriving
+    from a file could disagree, and the counts are the record.
+    """
+    return {"hits": body["hits"], "of": body["of"]}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Report the denominator figures off a persisted denominator.
+
+    The command that reproduces them::
+
+        python -m backtest.figures --store data/backtest.duckdb \\
+            --market US --market IDX --out-json references/backtest_figures.json
+
+    Both markets in one invocation and one payload, reported separately
+    throughout — never pooled, and never averaged into a summary figure that fits
+    neither. Reads the bar store and the denominator beside it; writes to neither.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the backtest bar store")
+    parser.add_argument(
+        "--market", action="append", required=True,
+        help="a market to report (repeatable; each is reported separately)",
+    )
+    parser.add_argument(
+        "--include-burn-in", action="store_true",
+        help="also measure burn-in sessions (never for a reported result)",
+    )
+    parser.add_argument(
+        "--out-json", default=None,
+        help="where to write the machine-readable, contract-stamped result",
+    )
+    args = parser.parse_args(argv)
+
+    store = Store.open(args.store)
+    denominator = DenominatorStore.open(denominator_path(args.store))
+    try:
+        markets = [
+            figures_for_market(
+                store, denominator, market, DEFAULT_CONTRACT,
+                include_burn_in=args.include_burn_in,
+            )
+            for market in args.market
+        ]
+    finally:
+        denominator.close()
+        store.close()
+
+    report = figures_report(DEFAULT_CONTRACT, markets)
+    if args.out_json:
+        Path(args.out_json).write_text(json.dumps(report, indent=1) + "\n")
+    print(format_figures(report))
+    if args.out_json:
+        print(f"wrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/backtest/simulate.py
+++ b/backend/backtest/simulate.py
@@ -36,11 +36,19 @@ of the figures the denominator exists to produce.
 
 The three arms, and why there are three
 ---------------------------------------
-Steps 1 to 4 are computed once and shared. The exit is the only per-arm step, so a
-difference between the arms' results is attributable to the exit alone — which is
+Steps 1 to 4 are computed once and shared, as an :class:`Entry` — one value the
+arms are handed rather than a stretch of code three arms happen to agree about. So
+a difference between the arms' results is attributable to the exit alone, which is
 the only thing running three of them can answer, and the reason
 ``test_the_three_arms_share_one_entry_and_one_stop`` asserts the sharing rather
 than trusting it.
+
+The entry also carries the answer a trade cannot give: **why** a detection produced
+nothing. :func:`simulate_arm` collapses every non-fill into ``None``, which is
+right for a simulator and useless for a figure — "the next session did not break"
+is a resolved miss and "the bars end here" is the window's edge, and
+:mod:`backtest.figures` has to tell them apart to report the share of detections
+that trigger at all (issue #193). See :data:`ENTRY_FILLED` and its neighbours.
 
 - **Arm A** is the trader's documented behaviour: 50% off at the close of the
   fifth session after entry, remainder on a 10MA trail. Its R is **two-legged**,
@@ -225,6 +233,46 @@ class Decision:
     price: float
 
 
+# The five ways an entry can end, and they are not interchangeable (issue #193).
+#
+# :func:`simulate_arm` collapses all four of the non-fills into ``None``, which is
+# right for a simulator — none of them is a trade — and useless for a figure. The
+# share of detections that trigger is one of the denominator's headline numbers,
+# and it has a *denominator*: only the detections something actually asked belong
+# in it.
+#
+# - :data:`ENTRY_FILLED` — it broke and the next session opened to fill it.
+# - :data:`ENTRY_NO_BREAK` — the deciding session closed under the trigger. A
+#   **resolved miss**, and the only one of these four that belongs in the trigger
+#   denominator.
+# - :data:`ENTRY_PENDING` — the bars end on the detection itself, so nothing has
+#   decided the break yet. The window's edge, not a failure.
+# - :data:`ENTRY_UNFILLED` — it broke, and the market never opened again. The
+#   window's edge again: a signal that never became a trade.
+# - :data:`ENTRY_UNDECIDABLE` — the detection's own session is not in the bars, or
+#   the ADR that denominates R is undefined. A fact about the store's coverage.
+#
+# Folding the three non-answers into the miss would deflate the trigger share by
+# however many detections the window happened to end on — in the direction that
+# makes the detector look worse, which is the direction nobody investigates.
+ENTRY_FILLED = "filled"
+ENTRY_NO_BREAK = "no_break"
+ENTRY_PENDING = "pending"
+ENTRY_UNFILLED = "unfilled"
+ENTRY_UNDECIDABLE = "undecidable"
+
+# The outcomes in which the detection's own trigger was actually traded through.
+# Both are a **trigger**; they differ in whether the window lasted long enough to
+# fill one.
+ENTRY_BROKE = (ENTRY_FILLED, ENTRY_UNFILLED)
+
+# The outcomes something asked and got an answer to. The trigger share's
+# denominator, and the reason it is a tuple here rather than a negation at each
+# call site: "which outcomes count" is one decision, and a second copy of it is a
+# second place for it to drift.
+ENTRY_DECIDED = (ENTRY_FILLED, ENTRY_NO_BREAK, ENTRY_UNFILLED)
+
+
 @dataclass(frozen=True)
 class ExitLeg:
     """One part of a position coming off, and the share of the position it was.
@@ -244,6 +292,136 @@ class ExitLeg:
     signal: Decision
     exit: Decision
     reason: str
+
+
+@dataclass(frozen=True)
+class Entry:
+    """Everything the three arms share, and why it did or did not become a trade.
+
+    Steps 1 to 4 of the mechanic — trigger, break, fill and stop — are computed
+    once and handed to every arm, which is the whole reason a difference between
+    the arms is attributable to the exit alone. Making that a **value** rather than
+    a stretch of :func:`simulate_arm` is what lets the sharing be a fact about the
+    code instead of three code paths that happen to agree
+    (``test_a_filled_entry_carries_the_prices_every_arm_shares``).
+
+    It also carries the answer :mod:`backtest.figures` needs and a trade cannot
+    give: :attr:`outcome` says *why* a detection produced nothing, and the four
+    non-fills mean four different things (see :data:`ENTRY_FILLED` and its
+    neighbours). Every price field is ``None`` on an outcome that never reached the
+    step that would have set it — absent, never a zero standing in for a price the
+    session did not have.
+    """
+
+    outcome: str
+    symbol: str
+    detection_session: date
+    trigger: Decision | None = None
+    break_signal: Decision | None = None
+    fill: Decision | None = None
+    stop_price: Decision | None = None
+    stop_width: float | None = None
+    price_scale: float | None = None
+
+    @property
+    def filled(self) -> bool:
+        """True when the entry became a position. The one outcome an arm can run."""
+        return self.outcome == ENTRY_FILLED
+
+    @property
+    def triggered(self) -> bool:
+        """True when the detection's own trigger was traded through.
+
+        Includes the break that never got a session to fill on: it triggered, and
+        the window ended. The two facts are different and only one of them is about
+        the detector.
+        """
+        return self.outcome in ENTRY_BROKE
+
+    @property
+    def decided(self) -> bool:
+        """True when something asked whether this detection would trigger.
+
+        The trigger share's denominator. A detection the bars end on has not failed
+        to trigger — nothing has asked it yet — and one whose session the store
+        never covered was never askable at all.
+        """
+        return self.outcome in ENTRY_DECIDED
+
+    @property
+    def price_scale_ok(self) -> bool:
+        """True when the entry's one absolute-price comparison sits in the band.
+
+        ``False`` where the scale is unknown, which is the safe direction: an
+        unmeasured comparison is not a verified one.
+        """
+        return (
+            self.price_scale is not None
+            and PRICE_SCALE_MIN <= self.price_scale <= PRICE_SCALE_MAX
+        )
+
+
+def entry(bars: Sequence[Bar], detection: Detection) -> Entry:
+    """The entry every arm shares, and the reason it did or did not fill.
+
+    Steps 1 to 4 of the module's mechanic, computed once: the detection's own
+    trigger, the break on the session after it, the fill at the next open, and the
+    detection's own stop. Nothing here depends on the arm, and nothing here reads a
+    bar after the session that decides it — every slice goes through
+    :func:`~backtest.chain.trailing_bars` or an index at or before the decision.
+
+    ``bars`` is the symbol's whole history; this function cuts it itself rather
+    than trusting the caller to have cut it, so a caller holding more bars than
+    existed at the time cannot change the answer.
+    """
+    idx = bar_index(bars, detection.session)
+    if idx is None:
+        return Entry(ENTRY_UNDECIDABLE, detection.symbol, detection.session)
+
+    # Everything that denominates the trade is measured at the detection's own
+    # session, on the bars that existed then.
+    at_decision = trailing_bars(bars, detection.session, ADR_WINDOW)
+    a = adr(at_decision)
+    if a is None or a <= 0:
+        return Entry(ENTRY_UNDECIDABLE, detection.symbol, detection.session)
+    stop_width = detection.stopw_adr * a * detection.trigger
+    if stop_width <= 0:
+        return Entry(ENTRY_UNDECIDABLE, detection.symbol, detection.session)
+
+    # The one absolute-price comparison the ADR geometry cannot make immune: a
+    # close persisted with the detection against the close on the bar it names.
+    bar_close = bars[idx].close
+    price_scale = detection.close / bar_close if bar_close else 0.0
+    trigger = Decision(session=detection.session, price=detection.trigger)
+    stop_price = Decision(session=detection.session, price=detection.stop_price)
+    partial = {
+        "symbol": detection.symbol,
+        "detection_session": detection.session,
+        "trigger": trigger,
+        "stop_price": stop_price,
+        "stop_width": stop_width,
+        "price_scale": price_scale,
+    }
+
+    # The break: the app's own definition, on the session after the detection.
+    if idx + 1 >= len(bars):
+        return Entry(ENTRY_PENDING, **partial)
+    break_bar = bars[idx + 1]
+    if break_bar.close <= detection.trigger:
+        return Entry(ENTRY_NO_BREAK, **partial)
+    break_signal = Decision(session=break_bar.session, price=break_bar.close)
+
+    # The fill: the next session's open. A break with no session after it is a
+    # signal that never became a trade.
+    if idx + 2 >= len(bars):
+        return Entry(ENTRY_UNFILLED, break_signal=break_signal, **partial)
+    fill_bar = bars[idx + 2]
+    return Entry(
+        ENTRY_FILLED,
+        break_signal=break_signal,
+        fill=Decision(session=fill_bar.session, price=fill_bar.open),
+        **partial,
+    )
 
 
 @dataclass(frozen=True)
@@ -487,56 +665,48 @@ def simulate_arm(
     or the market never opened again to fill it.
     """
     check_arm_mechanics(contract, arm)
+    return take_entry(bars, entry(bars, detection), market=market,
+                      contract=contract, arm=arm)
+
+
+def take_entry(
+    bars: Sequence[Bar],
+    e: Entry,
+    *,
+    market: str,
+    contract: RunContract,
+    arm: str,
+) -> SimulatedTrade | None:
+    """Run one arm's exit off an already-computed :class:`Entry`.
+
+    Split out from :func:`simulate_arm` so a caller that needs the entry's
+    :attr:`~Entry.outcome` *and* its trades — :mod:`backtest.figures`, counting
+    what triggered before measuring what paid — computes the shared entry once and
+    walks it out per arm, rather than re-deriving it three times and once more for
+    the count.
+
+    ``None`` when the entry never filled: there is no position to walk out.
+    """
+    if not e.filled:
+        return None
     plan = exit_plan(contract, arm)
-
-    idx = bar_index(bars, detection.session)
-    if idx is None:
-        return None
-
-    # Everything that denominates the trade is measured at the detection's own
-    # session, on the bars that existed then.
-    at_decision = trailing_bars(bars, detection.session, ADR_WINDOW)
-    a = adr(at_decision)
-    if a is None or a <= 0:
-        return None
-    stop_width = detection.stopw_adr * a * detection.trigger
-    if stop_width <= 0:
-        return None
-
-    # The one absolute-price comparison the ADR geometry cannot make immune: a
-    # close persisted with the detection against the close on the bar it names.
-    bar_close = bars[idx].close
-    price_scale = detection.close / bar_close if bar_close else 0.0
-
-    # The break: the app's own definition, on the session after the detection.
-    if idx + 1 >= len(bars):
-        return None
-    break_bar = bars[idx + 1]
-    if break_bar.close <= detection.trigger:
-        return None
-
-    # The fill: the next session's open. A break with no session after it is a
-    # signal that never became a trade.
-    if idx + 2 >= len(bars):
-        return None
-    fill_bar = bars[idx + 2]
-
-    stop_price = detection.stop_price
-    legs = _walk_out(bars, idx + 2, stop_price=stop_price, plan=plan)
-
+    # The fill's own index, re-derived rather than carried on the entry: it is a
+    # position in *this* caller's bars, and a value that travels can be read
+    # against a different series than the one it was measured in.
+    start = bar_index(bars, e.fill.session)
     return SimulatedTrade(
         market=market,
-        symbol=detection.symbol,
+        symbol=e.symbol,
         arm=arm,
-        detection_session=detection.session,
-        trigger=Decision(session=detection.session, price=detection.trigger),
-        break_signal=Decision(session=break_bar.session, price=break_bar.close),
-        entry=Decision(session=fill_bar.session, price=fill_bar.open),
-        stop_price=Decision(session=detection.session, price=stop_price),
-        stop_width=stop_width,
-        legs=legs,
-        price_scale=price_scale,
-        price_scale_ok=PRICE_SCALE_MIN <= price_scale <= PRICE_SCALE_MAX,
+        detection_session=e.detection_session,
+        trigger=e.trigger,
+        break_signal=e.break_signal,
+        entry=e.fill,
+        stop_price=e.stop_price,
+        stop_width=e.stop_width,
+        legs=_walk_out(bars, start, stop_price=e.stop_price.price, plan=plan),
+        price_scale=e.price_scale,
+        price_scale_ok=e.price_scale_ok,
     )
 
 
@@ -612,6 +782,81 @@ def _walk_out(
     return tuple(legs)
 
 
+@dataclass(frozen=True)
+class DetectionOutcome:
+    """What became of one persisted detection: its entry, and a trade per arm.
+
+    The unit :mod:`backtest.figures` counts in, and the reason it can count at all.
+    A list of trades answers "what paid"; it cannot answer "how many of the setups
+    the detector named ever triggered", because a detection that never broke left
+    no trade to be counted. Both questions are the denominator's, so the walk emits
+    the detection *and* its outcome rather than only the trades that survived it.
+
+    ``trades`` holds one entry per arm that produced a position and is **empty**
+    when the entry never filled — the arms cannot disagree about that, because they
+    share the entry.
+    """
+
+    session: date
+    detection: Detection
+    entry: Entry
+    trades: dict[str, SimulatedTrade]
+
+
+def walk_detections(
+    store: Store,
+    denominator: DenominatorStore,
+    market: str,
+    contract: RunContract,
+    *,
+    arms: Sequence[str] = ARMS,
+    include_burn_in: bool = False,
+) -> list[DetectionOutcome]:
+    """Every persisted detection in the window, with its entry and its trades.
+
+    The one pass over the denominator, shared by :func:`simulate_market` and by
+    :mod:`backtest.figures`. Two callers walking the same fourteen years
+    separately would read every symbol's whole history twice and — worse — could
+    disagree about which detections were in the window at all, which is exactly
+    the kind of divergence a rate reported beside a total makes invisible.
+
+    Burn-in sessions are excluded by default for the reason they are flagged at
+    all: a warm-up session is persisted and never measured (story 76).
+
+    Bars are read once per symbol rather than once per detection — a fourteen-year
+    run names the same symbol on hundreds of sessions, and re-reading its whole
+    history each time is the difference between minutes and hours.
+    """
+    for arm in arms:
+        check_arm_mechanics(contract, arm)
+    ran = [arm for arm in ARMS if arm in arms]
+    bars_by_symbol: dict[str, list[Bar]] = {}
+    out: list[DetectionOutcome] = []
+    for row in denominator.sessions(market):
+        if row.burn_in and not include_burn_in:
+            continue
+        for scored in denominator.detections(market, row.session):
+            detection = scored.detection
+            symbol = detection.symbol
+            if symbol not in bars_by_symbol:
+                bars_by_symbol[symbol] = store.bars(market, symbol)
+            bars = bars_by_symbol[symbol]
+            e = entry(bars, detection)
+            trades = {}
+            for arm in ran:
+                trade = take_entry(
+                    bars, e, market=market, contract=contract, arm=arm
+                )
+                if trade is not None:
+                    trades[arm] = trade
+            out.append(
+                DetectionOutcome(
+                    session=row.session, detection=detection, entry=e, trades=trades
+                )
+            )
+    return out
+
+
 def simulate_market(
     store: Store,
     denominator: DenominatorStore,
@@ -633,32 +878,20 @@ def simulate_market(
     a warm-up session is persisted and never measured (story 76), so a trade taken
     off one would be a result resting on an unsettled chain.
 
-    Bars are read once per symbol rather than once per detection — a fourteen-year
-    run names the same symbol on hundreds of sessions, and re-reading its whole
-    history each time is the difference between minutes and hours.
+    The trades :func:`walk_detections` produced, with the detections that produced
+    nothing dropped. Those detections are not noise — the share that never
+    triggered is one of the denominator's headline figures — so a caller that needs
+    them takes the walk itself rather than inferring them from what is missing here.
     """
-    for arm in arms:
-        check_arm_mechanics(contract, arm)
-    bars_by_symbol: dict[str, list[Bar]] = {}
-    trades: list[SimulatedTrade] = []
-    for row in denominator.sessions(market):
-        if row.burn_in and not include_burn_in:
-            continue
-        for scored in denominator.detections(market, row.session):
-            symbol = scored.detection.symbol
-            if symbol not in bars_by_symbol:
-                bars_by_symbol[symbol] = store.bars(market, symbol)
-            for arm in arms:
-                trade = simulate_arm(
-                    bars_by_symbol[symbol],
-                    scored.detection,
-                    market=market,
-                    contract=contract,
-                    arm=arm,
-                )
-                if trade is not None:
-                    trades.append(trade)
-    return trades
+    return [
+        outcome.trades[arm]
+        for outcome in walk_detections(
+            store, denominator, market, contract,
+            arms=arms, include_burn_in=include_burn_in,
+        )
+        for arm in ARMS
+        if arm in outcome.trades
+    ]
 
 
 def price_scale_drops(trades: Sequence[SimulatedTrade]) -> int:

--- a/backend/backtest/simulate.py
+++ b/backend/backtest/simulate.py
@@ -882,6 +882,12 @@ def simulate_market(
     nothing dropped. Those detections are not noise — the share that never
     triggered is one of the denominator's headline figures — so a caller that needs
     them takes the walk itself rather than inferring them from what is missing here.
+
+    Within one detection the arms come out in :data:`ARMS` order rather than in the
+    order ``arms`` spelled them. Changed deliberately in #193 and recorded here
+    rather than left to be noticed: it makes the output diff-stable however a
+    caller wrote its argument, which is the property :func:`simulate_report`
+    already commits to for the same reason.
     """
     return [
         outcome.trades[arm]
@@ -892,6 +898,19 @@ def simulate_market(
         for arm in ARMS
         if arm in outcome.trades
     ]
+
+
+def closed_trades(trades: Sequence[SimulatedTrade]) -> list[SimulatedTrade]:
+    """The trades whose whole position came off, and which therefore have an R.
+
+    One line, and it lives here rather than at each call site because "closed" is a
+    fact about :class:`SimulatedTrade` and two readers of it must not drift. Both
+    :func:`arm_report` and :mod:`backtest.figures` split an arm's trades this way,
+    and a second spelling of the test — ``t.closed`` rather than
+    ``t.r_multiple is not None`` — would agree today and diverge the first time a
+    trade could close with no computable R.
+    """
+    return [t for t in trades if t.r_multiple is not None]
 
 
 def price_scale_drops(trades: Sequence[SimulatedTrade]) -> int:
@@ -920,7 +939,7 @@ def arm_report(
     """
     plan = exit_plan(contract, arm)
     mine = [t for t in trades if t.arm == arm]
-    closed = [t for t in mine if t.r_multiple is not None]
+    closed = closed_trades(mine)
     body: dict[str, Any] = {
         "arm": arm,
         "trail_ma": plan.trail_ma,

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -6616,10 +6616,11 @@ def test_precision_is_reported_per_arm_because_it_depends_on_the_exit(
     assert set(us.arms) == {ARM_A, ARM_B, ARM_C}
     # One entry, so the trigger share is one figure and not three.
     assert us.triggered == Share(1, 1)
-    # And a precision per arm, each with its own denominator: an arm still holding
-    # the position has answered nothing yet, whatever the arm beside it did.
-    assert all(a.precision is not None for a in us.arms.values())
+    # And a precision per arm, each measured against its own answered count: an arm
+    # still holding the position has answered nothing yet, whatever the arm beside
+    # it did. The entry is shared, so `filled` cannot differ; `answered` can.
     assert us.arms[ARM_B].filled == us.arms[ARM_C].filled == 1
+    assert [us.arms[a].answered for a in (ARM_A, ARM_B, ARM_C)] == [1, 1, 1]
 
 
 def test_the_favourable_rule_rides_on_the_result(store, denominator):
@@ -6850,3 +6851,158 @@ def test_the_figures_cli_reports_and_writes_the_denominator_figures(
     written = json.loads(out_json.read_text())
     assert written["contract"] == DEFAULT_CONTRACT.to_dict()
     assert written["markets"][0]["market"] == "US"
+
+
+# -- what the #193 review found unguarded -------------------------------------
+
+
+def test_a_year_the_store_missed_entirely_still_gets_a_row_and_a_flag(
+    store, denominator
+):
+    """The worst hole is the one a year-keyed report cannot see.
+
+    A year with no sessions at all contributes no rows to group by, so a report
+    built from the years *present* would give it no line, no flag and no weight in
+    the median — and the largest data hole the criterion exists to catch would be
+    the single case it could not. It survives only as a blank stretch in the
+    monthly grid, which is not a flag.
+    """
+    for year in (2019, 2020, 2022):
+        for month in (1, 4, 7, 10):
+            _seed_figure_name(
+                store, denominator, "US", f"N{year}{month}", date(year, month, 1),
+                _FIG_FLAT + _FIG_WIN,
+            )
+
+    us = _figures(store, denominator, "US")
+
+    assert [y.year for y in us.years] == [2019, 2020, 2021, 2022]
+    assert _year(us, 2021).sessions == 0
+    assert _year(us, 2021).sessions_collapsed is True
+    # And it makes no claim it cannot support: no sessions is no rate, never zero.
+    assert _year(us, 2021).detections_per_session is None
+    assert _year(us, 2021).detections_collapsed is False
+
+
+def test_a_hole_in_the_windows_first_year_is_flagged_like_any_other(
+    store, denominator
+):
+    """The edge exemption this first shipped with was itself a hole.
+
+    Exempting the window's opening and closing years from the sessions flag reads
+    as generosity — they are short by design — but a store that lost three quarters
+    of the opening year drops its sessions *and* its detections together, so the
+    per-session rate barely moves and the detections flag stays silent too. Judging
+    the density against the span the window actually covers removes the by-design
+    shortness without removing the flag.
+    """
+    # 2019 opens the window on 1 January and then holds one stretch and nothing
+    # else — the calendar says a year, the store holds two months of it.
+    _seed_figure_name(store, denominator, "US", "HOLE", date(2019, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    for year in (2020, 2021, 2022):
+        for month in (1, 4, 7, 10):
+            _seed_figure_name(
+                store, denominator, "US", f"N{year}{month}", date(year, month, 1),
+                _FIG_FLAT + _FIG_WIN,
+            )
+
+    us = _figures(store, denominator, "US")
+
+    assert _year(us, 2019).sessions_collapsed is True
+    # Not because its field thinned — the rate is ordinary, which is exactly why
+    # the detections flag cannot stand in for the sessions one.
+    assert _year(us, 2019).detections_collapsed is False
+
+
+def test_a_year_the_window_only_half_covers_is_not_a_hole(store, denominator):
+    """The other half of the same rule. A window that opens in November holds two
+    months of that year because it opened in November, and a flag that fired on it
+    would fire on every run — which teaches a reader to skip the one that means
+    something."""
+    _seed_figure_name(store, denominator, "US", "LATE", date(2019, 11, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    for year in (2020, 2021):
+        for month in (1, 4, 7, 10):
+            _seed_figure_name(
+                store, denominator, "US", f"N{year}{month}", date(year, month, 1),
+                _FIG_FLAT + _FIG_WIN,
+            )
+
+    us = _figures(store, denominator, "US")
+
+    assert _year(us, 2019).sessions < _year(us, 2020).sessions
+    assert _year(us, 2019).sessions_collapsed is False
+
+
+def test_a_break_the_window_ended_before_filling_is_counted_and_named(
+    store, denominator
+):
+    """It triggered, and no session opened to fill it.
+
+    That detection is in the trigger share — it *did* trade through its trigger —
+    and in no arm's precision denominator, because no position was ever taken. Left
+    unnamed it would sit in neither bucket and simply vanish from the arithmetic,
+    which is how a population leaves a report without anyone noticing it went.
+    """
+    # The bars end on the session that decides the break.
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + [110.0])
+
+    us = _figures(store, denominator, "US")
+
+    assert us.unfilled == 1
+    assert us.triggered == Share(1, 1)
+    assert us.arms[ARM_B].filled == 0
+    assert us.arms[ARM_B].precision == Share(0, 0)
+
+
+def test_every_detection_lands_in_exactly_one_bucket(store, denominator):
+    """The four buckets are the whole population, and they add up.
+
+    A bucket that does not reconcile is a population going somewhere unreported,
+    and a rate computed over the rest is a rate over a denominator nobody can
+    reconstruct.
+    """
+    _seed_figure_name(store, denominator, "US", "WINS", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "NONE", date(2020, 4, 1),
+                      _FIG_FLAT + _FIG_NO_BREAK)
+    _seed_figure_name(store, denominator, "US", "EDGE", date(2020, 8, 1),
+                      _FIG_FLAT + [110.0])
+
+    us = _figures(store, denominator, "US")
+
+    assert us.detections == 3
+    assert (us.no_break, us.unfilled, us.undecided) == (1, 1, 0)
+    assert us.arms[ARM_B].filled == 1
+    assert all(us.reconciles(arm) for arm in us.arms)
+
+
+def test_the_price_scale_count_rides_on_the_figures_it_qualifies(
+    store, denominator
+):
+    """The flag is reported beside every result built on it, and precision is built
+    on entries priced in absolute terms.
+
+    Yahoo's unlabelled rights-issue rescale is not visible in the R geometry, which
+    is in ADR units and immune — but it is visible in the one absolute comparison
+    the entry cannot avoid, and a precision figure quoted without the count is a
+    figure whose inputs nobody checked.
+    """
+    det = _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                            _FIG_FLAT + _FIG_WIN)
+    # The same detection, re-persisted with a close three times the bar's: a
+    # rescale, not a price that moved.
+    rescaled = dataclasses.replace(det, close=det.close * 3)
+    denominator._cursor().execute(
+        "UPDATE denominator_detections SET close = ? WHERE symbol = ?",
+        [rescaled.close, "AAA"],
+    )
+
+    us = _figures(store, denominator, "US")
+    report = figures_report(DEFAULT_CONTRACT, [us])
+
+    assert us.price_scale_dropped == len(us.arms)
+    assert report["markets"][0]["price_scale_dropped"] == len(us.arms)
+    assert "price-scale flag would drop" in format_figures(report)

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -4582,6 +4582,7 @@ from backtest.denominator import (
     FOLLOW_THROUGH_BASIS,
     DenominatorStore,
     RunStampMismatch,
+    SessionRow,
     declared_columns,
     denominator_path,
 )
@@ -6230,3 +6231,622 @@ def test_an_arm_that_ran_and_traded_nothing_reports_zeros_rather_than_vanishing(
     assert (quiet["trades"], quiet["closed"], quiet["total_r"]) == (0, 0, 0)
     # And an arm that never ran is absent, which is the distinction being kept.
     assert [r["arm"] for r in ran_one["arms"]] == [ARM_B]
+
+
+# -- the denominator figures: precision, at last (issue #193) ------------------
+#
+# Phase 5 of PRD #182, and the figures no prior study in this repo could produce.
+# The reference study has 828 trades a trader **took**, so every result in it is
+# conditioned on his selection and it can report no precision at all. #149 hit the
+# same wall from the other side and had to record 27,323 detections as volume
+# carrying no verdict. Those detections are exactly the population measured here.
+#
+# Three figures, and each carries the coverage it was measured against, because a
+# rate whose denominator is not printed is a rate nobody can check:
+#
+# - **detections per session**, per market and per year, plotted across the window
+# - **the share that trigger** — a close through the detection's own trigger
+# - **the share that reach a favourable outcome** — precision
+#
+# Two things the block guards that no assertion about a rate would catch. A
+# detection the bars cannot answer must never be counted as a miss, and a trade
+# still running at the end of the window must never be counted as a loss: both
+# would deflate precision silently and in the direction that makes the method look
+# worse, which is the direction nobody investigates. And a year whose count
+# collapses is a data hole that reads as a quiet market until someone looks, so it
+# is flagged on the row rather than left for a reader to spot in a column.
+
+from backtest.figures import (
+    DETECTION_COLLAPSE_FRACTION,
+    FAVOURABLE_RULE,
+    HOLE_MARK,
+    SESSION_COLLAPSE_FRACTION,
+    SMA50_OVERLAP_NOTE,
+    Share,
+    figures_for_market,
+    figures_report,
+    format_figures,
+    main as figures_main,
+)
+from backtest.simulate import (
+    ARM_A,
+    ARM_C,
+    ENTRY_FILLED,
+    ENTRY_NO_BREAK,
+    ENTRY_PENDING,
+    ENTRY_UNDECIDABLE,
+    ENTRY_UNFILLED,
+    entry,
+)
+
+
+def _fig_bars(start: date, closes: list[float]) -> list[Bar]:
+    """Bars for one authored name, one close per session, from ``start``."""
+    return _flat_then(_daily(start, len(closes)), closes)
+
+
+# A detection named on the 40th bar of a flat stretch, whose next session decides
+# the break. All three runs are the same length, so a year's session count is the
+# fixture's arithmetic and never an artefact of which outcome a name happened to
+# reach.
+#
+# ``_FIG_WIN`` breaks, runs to 290 and rolls over under its own 10MA at 200 — the
+# fill is at 111 and the exit at 195, so it is favourable by a distance no rounding
+# reaches. Authored that way deliberately: a fixture that merely *breaks out* is
+# not a winner, because the trail signals on the way back down and can easily fill
+# under the entry. ``_FIG_LOSS`` breaks and slides through the stop at 96.
+# ``_FIG_NO_BREAK`` never closes through the trigger at all.
+_FIG_FLAT = [100.0] * 40
+_FIG_WIN = [110.0, 111.0, 130.0, 150.0, 170.0, 190.0, 210.0, 230.0,
+            250.0, 270.0, 290.0, 200.0, 195.0, 190.0, 185.0, 180.0,
+            175.0, 170.0, 165.0, 160.0, 155.0, 150.0]
+_FIG_LOSS = [110.0, 111.0, 108.0, 102.0, 97.0, 90.0, 89.0, 88.0,
+             87.0, 86.0, 85.0, 84.0, 83.0, 82.0, 81.0, 80.0,
+             79.0, 78.0, 77.0, 76.0, 75.0, 74.0]
+_FIG_NO_BREAK = [101.0, 101.0, 100.0, 100.0, 99.0, 99.0, 98.0, 98.0,
+                 99.0, 99.0, 100.0, 100.0, 101.0, 101.0, 100.0, 100.0,
+                 99.0, 99.0, 100.0, 100.0, 101.0, 101.0]
+# What one authored name costs in sessions: the flat stretch plus its run.
+FIG_SESSIONS = len(_FIG_FLAT) + len(_FIG_WIN)
+
+
+def _fig_detection(bars: list[Bar], symbol: str) -> Detection:
+    """The detection the figures are measured over: trigger 102, stop 96.
+
+    Built the way ``_sim_detection`` is — ``stopw_adr`` derived from the ADR the
+    detector would have measured, never chosen beside it — so the fixture is a
+    detection some detector could actually have emitted.
+    """
+    a = adr(trailing_bars(bars, bars[39].session, ADR_WINDOW))
+    return dataclasses.replace(
+        _det(symbol, 5),
+        symbol=symbol,
+        session=bars[39].session,
+        trigger=SIM_TRIGGER,
+        stop=SIM_STOP_WIDTH,
+        stopw_adr=SIM_STOP_WIDTH / (a * SIM_TRIGGER),
+        adr=a,
+        close=bars[39].close,
+        cluster_high=SIM_TRIGGER,
+    )
+
+
+def _seed_figure_name(
+    store: Store,
+    denominator: DenominatorStore,
+    market: str,
+    symbol: str,
+    start: date,
+    closes: list[float],
+    *,
+    burn_in: bool = False,
+    detect: bool = True,
+) -> Detection:
+    """One authored name: its bars in the bar store, its detection in the denominator.
+
+    The denominator rows are written directly rather than replayed through the
+    chain, because these tests are about the *figures* read off the rows and a
+    fourteen-year fixture built through the detector would take the geometry — not
+    the arithmetic — as the thing under test. Every session between the first bar
+    and the last carries a header, so the per-year session counts below are the
+    fixture's own and not an artefact of which sessions happened to detect.
+
+    ``detect=False`` seeds the sessions and no detection, which is how a year gets
+    a full trading calendar and an empty field — the shape a collapsed count has
+    when it is a data hole rather than a short year.
+    """
+    bars = _fig_bars(start, closes)
+    store.append_bars(market, symbol, bars)
+    det = _fig_detection(bars, symbol)
+    for bar in bars:
+        denominator.append_session(
+            SessionRow(
+                market=market, session=bar.session, burn_in=burn_in,
+                members=1,
+                detections=1 if detect and bar.session == det.session else 0,
+                regime_state=None, breadth=None, broke_out=None, index_close=None,
+            )
+        )
+    if detect:
+        denominator.append_detections(market, det.session, [
+            ScoredDetection(
+                symbol=symbol, detection=det,
+                score=seven_dimension_score(det, prior_move=False),
+                star_rank=1, not_taken=False, rs_line=False, relative_move=None,
+            )
+        ])
+    return det
+
+
+def _figures(store, denominator, market="US", **kw):
+    return figures_for_market(store, denominator, market, DEFAULT_CONTRACT, **kw)
+
+
+def _year(figures, year: int):
+    (row,) = [y for y in figures.years if y.year == year]
+    return row
+
+
+# -- the entry, and why it never became a trade -------------------------------
+
+
+def test_an_entry_records_why_it_never_became_a_trade(store):
+    """The five ways an entry ends, and they are not interchangeable.
+
+    ``simulate_arm`` returns ``None`` for all of them, which is right for a
+    simulator and useless for a figure: "the next session did not break" is a
+    resolved miss and belongs in the trigger denominator, while "the bars end
+    before the session that would decide it" is the window's edge and does not.
+    Folding the two together deflates the trigger share by however many detections
+    the window happened to end on.
+    """
+    win = _fig_bars(date(2020, 1, 1), _FIG_FLAT + _FIG_WIN)
+    det = _fig_detection(win, "BASE")
+
+    assert entry(win, det).outcome == ENTRY_FILLED
+    # Bar 40 broke, and the market never opened again to fill it.
+    assert entry(win[:41], det).outcome == ENTRY_UNFILLED
+    # The bars end on the detection itself: nothing has decided the break yet.
+    assert entry(win[:40], det).outcome == ENTRY_PENDING
+    # The deciding session closed under the trigger. A resolved miss.
+    flat = _fig_bars(date(2020, 1, 1), _FIG_FLAT + _FIG_NO_BREAK)
+    assert entry(flat, _fig_detection(flat, "BASE")).outcome == ENTRY_NO_BREAK
+    # The detection's own session is not in the bars at all.
+    assert entry(win[45:], det).outcome == ENTRY_UNDECIDABLE
+
+
+def test_a_filled_entry_carries_the_prices_every_arm_shares(store):
+    """The entry *is* the shared part: trigger, break, fill, stop and stop width.
+
+    #190 pinned that the three arms agree on these; this pins that they agree
+    because there is one entry, not because three code paths happen to compute the
+    same numbers.
+    """
+    bars = _fig_bars(date(2020, 1, 1), _FIG_FLAT + _FIG_WIN)
+    det = _fig_detection(bars, "BASE")
+
+    e = entry(bars, det)
+    trade = simulate_arm(bars, det, market="US", contract=DEFAULT_CONTRACT, arm=ARM_B)
+
+    assert e.trigger == trade.trigger
+    assert e.break_signal == trade.break_signal
+    assert e.fill == trade.entry
+    assert e.stop_price == trade.stop_price
+    assert e.stop_width == trade.stop_width
+    assert e.price_scale == trade.price_scale
+
+
+# -- detections per session, per market and per year --------------------------
+
+
+def test_detections_per_session_is_reported_per_market_and_per_year(
+    store, denominator
+):
+    """Per market and per year, never pooled only. IDX magnitudes are not US
+    magnitudes and a window holding a crash and a mania is not described by a
+    single number that fits neither."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "BBB", date(2021, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "IDX", "CCC.JK", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    us = _figures(store, denominator, "US")
+    idx = _figures(store, denominator, "IDX")
+
+    assert [y.year for y in us.years] == [2020, 2021]
+    assert [y.year for y in idx.years] == [2020]
+    # Two names over 2020 and 2021, one detection each, on their own sessions.
+    assert _year(us, 2020).detections == 1
+    assert _year(us, 2021).detections == 1
+    assert _year(us, 2020).sessions == FIG_SESSIONS
+    assert _year(us, 2020).detections_per_session == pytest.approx(1 / FIG_SESSIONS)
+
+
+def test_burn_in_sessions_are_excluded_from_every_figure(store, denominator):
+    """A warm-up session is persisted and never measured. A figure that counted
+    them would rest on an unsettled chain — and would report a detection the run
+    itself declines to measure."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN, burn_in=True)
+    _seed_figure_name(store, denominator, "US", "BBB", date(2021, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    us = _figures(store, denominator, "US")
+
+    assert [y.year for y in us.years] == [2021]
+    assert us.detections == 1
+
+
+# -- the share that trigger ---------------------------------------------------
+
+
+def test_the_share_of_detections_that_trigger_is_reported(store, denominator):
+    """One name breaks through its trigger and one does not, so the share is a
+    half — the figure the reference study could never produce, because a setup he
+    declined was never recorded at all."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "BBB", date(2020, 6, 1),
+                      _FIG_FLAT + _FIG_NO_BREAK)
+
+    us = _figures(store, denominator, "US")
+
+    assert us.triggered == Share(2 - 1, 2)
+    assert us.triggered.rate == 0.5
+
+
+def test_a_detection_the_bars_cannot_answer_is_not_counted_as_a_miss(
+    store, denominator
+):
+    """Undecidable and pending detections leave the trigger denominator entirely.
+
+    A detection sitting on the last session of the window has not failed to
+    trigger; nothing has asked it yet. Counting it as a miss would deflate the
+    trigger share by however many detections the window happened to end on, in the
+    direction that makes the detector look worse — which is the direction nobody
+    investigates.
+    """
+    det = _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                            _FIG_FLAT + _FIG_WIN)
+    # A second detection on the store's very last session: undecided, not missed.
+    last = _fig_bars(date(2020, 1, 1), _FIG_FLAT + _FIG_WIN)[-1].session
+    pending = dataclasses.replace(det, symbol="AAA", session=last)
+    denominator.append_detections("US", last, [
+        ScoredDetection(
+            symbol="AAA", detection=pending,
+            score=seven_dimension_score(pending, prior_move=False),
+            star_rank=1, not_taken=False, rs_line=False, relative_move=None,
+        )
+    ])
+
+    us = _figures(store, denominator, "US")
+
+    assert us.detections == 2
+    assert us.triggered == Share(1, 1)
+    assert us.undecided == 1
+
+
+# -- precision ----------------------------------------------------------------
+
+
+def test_the_share_reaching_a_favourable_outcome_is_the_precision_figure(
+    store, denominator
+):
+    """Precision at last: of every setup the detector named and the bars answered,
+    the share that made money. Three names — one wins, one is stopped out, one
+    never breaks — so one detection in three reached a favourable outcome."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "BBB", date(2020, 6, 1),
+                      _FIG_FLAT + _FIG_LOSS)
+    _seed_figure_name(store, denominator, "US", "CCC", date(2021, 1, 1),
+                      _FIG_FLAT + _FIG_NO_BREAK)
+
+    us = _figures(store, denominator, "US")
+    arm_b = us.arms[ARM_B]
+
+    assert arm_b.favourable == 1
+    assert arm_b.precision == Share(1, 3)
+    # The win rate is a different question with a different denominator: of the
+    # trades that were *taken*, how many paid. Conflating the two would report a
+    # detector's precision as if it were a trader's hit rate.
+    assert arm_b.win_rate == Share(1, 2)
+
+
+def test_the_trigger_share_and_precision_are_reported_per_year_too(
+    store, denominator
+):
+    """Per market *and* per year, never pooled only. A window holding a crash and a
+    mania is not described by a single number that fits neither — and pooling is
+    how a year the method lost money in disappears into a decade it made money in.
+    """
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "BBB", date(2021, 1, 1),
+                      _FIG_FLAT + _FIG_LOSS)
+
+    us = _figures(store, denominator, "US")
+
+    assert _year(us, 2020).arms[ARM_B].precision == Share(1, 1)
+    assert _year(us, 2021).arms[ARM_B].precision == Share(0, 1)
+    assert _year(us, 2020).triggered == Share(1, 1)
+    # And the pooled figure is beside them, never instead of them.
+    assert us.arms[ARM_B].precision == Share(1, 2)
+    printed = format_figures(figures_report(DEFAULT_CONTRACT, [us]))
+    assert "precision B" in printed
+
+
+def test_a_trade_still_open_at_the_end_of_the_window_is_never_a_loss(
+    store, denominator
+):
+    """An open trade has no outcome, so it leaves precision's denominator.
+
+    Closing it at the last available close would invent an exit the rules never
+    gave — systematically, for every name still running when the window ends. It
+    is reported as unresolved instead, which is the honest shape: a question the
+    window was too short to answer.
+    """
+    # The run-up with no roll-over: the trail never signals and the bars run out.
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + [110.0, 111.0, 118.0, 124.0, 130.0])
+
+    us = _figures(store, denominator, "US")
+    arm_b = us.arms[ARM_B]
+
+    assert us.triggered == Share(1, 1)
+    assert arm_b.open_at_end == 1
+    assert arm_b.precision == Share(0, 0)
+    assert arm_b.precision.rate is None
+
+
+def test_precision_is_reported_per_arm_because_it_depends_on_the_exit(
+    store, denominator
+):
+    """The arms share one entry and one stop, so the trigger share is one figure
+    across all three — and precision is not. An exit is what turns a break into a
+    favourable outcome or an unfavourable one, so a single precision figure would
+    be a claim about an exit it never named."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    us = _figures(store, denominator, "US")
+
+    assert set(us.arms) == {ARM_A, ARM_B, ARM_C}
+    # One entry, so the trigger share is one figure and not three.
+    assert us.triggered == Share(1, 1)
+    # And a precision per arm, each with its own denominator: an arm still holding
+    # the position has answered nothing yet, whatever the arm beside it did.
+    assert all(a.precision is not None for a in us.arms.values())
+    assert us.arms[ARM_B].filled == us.arms[ARM_C].filled == 1
+
+
+def test_the_favourable_rule_rides_on_the_result(store, denominator):
+    """What counts as favourable is a threshold, and a threshold nobody can read
+    off the result is one a later run can quietly move."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    report = figures_report(DEFAULT_CONTRACT, [_figures(store, denominator, "US")])
+
+    assert report["favourable_rule"] == FAVOURABLE_RULE
+    assert FAVOURABLE_RULE in format_figures(report)
+
+
+def test_precision_is_a_before_cost_figure_and_the_report_says_so(
+    store, denominator
+):
+    """Costs are #191's, and a precision figure computed before them overstates.
+
+    A caveat a reader has to remember is one a reader forgets, so it rides on the
+    payload and is printed beside the number rather than living in a commit
+    message.
+    """
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    report = figures_report(DEFAULT_CONTRACT, [_figures(store, denominator, "US")])
+
+    assert report["costs_applied"] is False
+    assert "before costs" in format_figures(report)
+
+
+# -- coverage -----------------------------------------------------------------
+
+
+def test_every_figure_carries_the_coverage_count_it_was_measured_against(
+    store, denominator
+):
+    """A rate whose denominator is not printed is a rate nobody can check, and a
+    ``0/0`` reported as ``0.0`` is a claim the data never made."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_NO_BREAK)
+
+    us = _figures(store, denominator, "US")
+
+    assert us.triggered.of == 1
+    assert Share(0, 0).rate is None
+    assert Share(1, 4).rate == 0.25
+    # Every rate in the printed report arrives with its own coverage beside it.
+    printed = format_figures(figures_report(DEFAULT_CONTRACT, [us]))
+    assert "0 of 1" in printed
+
+
+# -- the SMA50 overlap --------------------------------------------------------
+
+
+def test_the_sma50_overlap_is_stated_wherever_counts_are_reported(
+    store, denominator
+):
+    """Detection counts fall against an unfiltered run because the contract's
+    SMA50 gate overlaps the detector's own trend logic. That is the gate working,
+    not the detector becoming more selective — and a reader who is not told
+    conflates the two."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    report = figures_report(DEFAULT_CONTRACT, [_figures(store, denominator, "US")])
+
+    assert report["sma50_overlap"] == SMA50_OVERLAP_NOTE
+    assert SMA50_OVERLAP_NOTE in format_figures(report)
+
+
+# -- the plot, and the years that collapse ------------------------------------
+
+
+def test_a_year_whose_detection_count_collapses_is_flagged(store, denominator):
+    """A count that collapses reads as a quiet market until someone looks, so the
+    row says so rather than leaving it for a reader to spot in a column."""
+    # Three years of a full calendar and a healthy field, then a fourth with the
+    # same calendar and an empty one. Nothing about the year is short — only the
+    # count is, which is what a data hole looks like from the report.
+    for year in (2019, 2020, 2021, 2022):
+        for month in (1, 4, 7, 10):
+            _seed_figure_name(
+                store, denominator, "US", f"N{year}{month}", date(year, month, 1),
+                _FIG_FLAT + _FIG_WIN, detect=year != 2022,
+            )
+
+    us = _figures(store, denominator, "US")
+
+    assert _year(us, 2021).detections_collapsed is False
+    assert _year(us, 2022).detections_collapsed is True
+    # The year is not short — only its field is, which is the confusion the two
+    # flags exist to keep apart.
+    assert _year(us, 2022).sessions == _year(us, 2021).sessions
+    assert _year(us, 2022).sessions_collapsed is False
+    assert any("detections" in f for f in _year(us, 2022).flags)
+
+
+def test_a_year_whose_session_count_collapses_is_flagged_as_a_data_hole(
+    store, denominator
+):
+    """Sessions missing from the middle of a window are a hole in the store, and
+    a rate computed over them is a rate over a year that never happened."""
+    for year in (2019, 2021, 2022):
+        for month in (1, 4, 7, 10):
+            _seed_figure_name(
+                store, denominator, "US", f"N{year}{month}", date(year, month, 1),
+                _FIG_FLAT + _FIG_WIN,
+            )
+    # 2020 is an interior year holding one short stretch and nothing else.
+    _seed_figure_name(store, denominator, "US", "HOLE", date(2020, 6, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    us = _figures(store, denominator, "US")
+
+    assert _year(us, 2020).sessions_collapsed is True
+    assert _year(us, 2021).sessions_collapsed is False
+    assert any("session" in f for f in _year(us, 2020).flags)
+
+
+def test_a_partial_year_at_the_edge_of_the_window_is_not_a_hole(store, denominator):
+    """The window opens and closes mid-year by design, so its first and last years
+    are short on purpose. Flagging them would cry wolf on every run and teach a
+    reader to skip the one flag that means something."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 11, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    for month in (1, 4, 7, 10):
+        _seed_figure_name(store, denominator, "US", f"M{month}", date(2021, month, 1),
+                          _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "ZZZ", date(2022, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    us = _figures(store, denominator, "US")
+
+    assert _year(us, 2020).sessions_collapsed is False
+    assert _year(us, 2022).sessions_collapsed is False
+
+
+def test_the_collapse_rules_ride_on_the_result_rather_than_on_a_reader(
+    store, denominator
+):
+    """A flag whose rule is not printed is a flag a reader has to trust."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    report = figures_report(DEFAULT_CONTRACT, [_figures(store, denominator, "US")])
+
+    assert report["collapse_rule"]["detections_fraction"] == DETECTION_COLLAPSE_FRACTION
+    assert report["collapse_rule"]["sessions_fraction"] == SESSION_COLLAPSE_FRACTION
+
+
+def test_detections_per_session_is_plotted_across_the_window(store, denominator):
+    """The plot is the deliverable, not the table beside it: a collapsing count is
+    a shape a reader sees at a glance and a number a reader has to compare."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "BBB", date(2021, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    printed = format_figures(
+        figures_report(DEFAULT_CONTRACT, [_figures(store, denominator, "US")])
+    )
+
+    assert "2020" in printed and "2021" in printed
+    # One bar per year, drawn from the year's own detections-per-session.
+    assert printed.count("█") > 0
+
+
+def test_a_month_the_store_never_covered_plots_as_a_hole_not_a_quiet_month(
+    store, denominator
+):
+    """A yearly mean hides a missing quarter — it drops by a quarter and looks like
+    a slow year. The monthly series is where a hole is actually visible, so a month
+    with no sessions at all draws differently from a month with sessions and no
+    detections."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    _seed_figure_name(store, denominator, "US", "BBB", date(2020, 10, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    printed = format_figures(
+        figures_report(DEFAULT_CONTRACT, [_figures(store, denominator, "US")])
+    )
+
+    assert HOLE_MARK in printed
+
+
+# -- the result, and the command ----------------------------------------------
+
+
+def test_the_figures_report_carries_the_contract_that_produced_it(
+    store, denominator
+):
+    """Every figure the package emits carries its contract, so two runs under
+    different contracts are distinguishable from their serialised output alone."""
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+
+    report = figures_report(DEFAULT_CONTRACT, [_figures(store, denominator, "US")])
+
+    assert report["contract"] == DEFAULT_CONTRACT.to_dict()
+    assert [m["market"] for m in report["markets"]] == ["US"]
+
+
+def test_the_figures_cli_reports_and_writes_the_denominator_figures(
+    tmp_path, capsys
+):
+    """One command reproduces the figures off a persisted denominator, and writes
+    the machine-readable result beside the printed one."""
+    path = tmp_path / "backtest_us.duckdb"
+    store = Store.open(path)
+    denominator = DenominatorStore.open(denominator_path(path))
+    denominator.stamp(DEFAULT_CONTRACT)
+    _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                      _FIG_FLAT + _FIG_WIN)
+    store.close()
+    denominator.close()
+    out_json = tmp_path / "figures.json"
+
+    code = figures_main([
+        "--store", str(path), "--market", "US", "--out-json", str(out_json)
+    ])
+
+    assert code == 0
+    printed = capsys.readouterr().out
+    assert SMA50_OVERLAP_NOTE in printed
+    written = json.loads(out_json.read_text())
+    assert written["contract"] == DEFAULT_CONTRACT.to_dict()
+    assert written["markets"][0]["market"] == "US"


### PR DESCRIPTION
Closes #193. Phase 5's first block of PRD #182.

`backtest.figures` produces the three figures the denominator was built for, per market and per year and never pooled only: **detections per session** (plotted across the window), **the share that trigger**, and **the share that reach a favourable outcome** — precision, which the reference study can report no value for at all, because every result in it is conditioned on trades the trader took.

```
python -m backtest.figures --store data/backtest.duckdb --market US --market IDX \
    --out-json references/backtest_figures.json
```

### Precision is not the win rate

They differ in the denominator, and the difference is the point. **Precision** is favourable outcomes over every *answered* detection — the ones that never triggered included — which makes it a figure about the **detector**. The **win rate** is favourable outcomes over the trades actually taken, a figure about the **exit**, and the one comparable to the reference set's shape. Both are computed and both are labelled, because reporting either as the other quotes a detector's precision as a trader's hit rate.

### The two silent deflations

Both push toward making the method look worse, which is the direction nobody investigates:

- **A detection the bars cannot answer is not a miss.** `simulate_arm` returned `None` for five different reasons and a figure cannot tell them apart, so the entry is now an `Entry` value carrying its outcome — filled, no-break, pending, unfilled or undecidable. Only decided detections are in the trigger denominator.
- **A trade still running is not a loss.** It leaves precision's denominator and is reported as `open_at_end`. Closing it at the last available close would invent an exit the rules never gave, systematically, for every name still running at the end.

Every detection lands in exactly one of four reported buckets and `Figures.reconciles` checks the arithmetic. Every rate is a `Share` carrying the coverage it was measured against; a `0/0` reports `None`, never `0.0`.

### Flagging a year that collapses

Two flags, because two things collapse: a hole in the **store** and a hole in the **field** with the calendar intact. Sessions are judged as a density per day of window covered, so the window's short-by-design first and last years need no exemption — and an exemption would have left a real hole at either end catchable by neither flag. A year the store missed entirely still gets a row. Both rules are mutation-tested.

### Also

The SMA50 overlap rides on the payload and prints in every market's section: these counts sit below an unfiltered run because the gate works, not because the detector got selective. `costs_applied: false` prints beside the numbers — costs are #191's, and precision before them overstates. `price_scale_dropped` rides on each market's figures per the house rule.

`walk_detections` is now the single pass over the denominator that both `simulate_market` and the figures share.

724 tests green. Two commits: the implementation, then the answer to a two-axis review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fgo7Zr6HExJQFkvaAt4yVq
