### PR TITLE
The pre-registered headline metric, with costs and clustered significance (#191)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -466,6 +466,45 @@ trigger persisted earlier against a bar read now. Flagged, never silently droppe
 count it would drop is reported beside every result**.
 _Avoid_: adjustment flag, bad data — the trade is not wrong, its scale is unverified.
 
+**Pre-registered metric**:
+The one headline the run promised in advance (PRD #182, `backtest.metric`): **arm B's
+after-cost expectancy in R, per market per year**. Arm B because it is the reference
+set's primary **simulated exit**, which keeps the headline comparable to figures already
+committed here. It is computed and recorded **before any swept variant exists**, and every
+report carries the count of variants standing behind it — every threshold tried is a test,
+and enough of them produce a winner from noise. A trade counts in the year of its **entry
+session**, the year the decision was taken, so a trade's year never moves with the exit
+rule under test.
+_Avoid_: the headline number, our main result — and never quote a swept variant under this
+name.
+
+**After-cost expectancy**:
+The mean R of the closed **simulated trades** in one cell, net of the contract's own
+per-market commission and slippage. Both are bps of the traded price **charged on each
+side** — the entry once for the whole position and every **exit leg** weighted by its
+share — divided by the trade's stop width, which keeps the cost in R and immune to a
+retroactive rescale. IDX carries real fees and spread against US's near-zero; a market the
+`costs.per_market` cell does not name is drift, never a free trade. Never reported without
+the **win rate and the R-distribution** behind it: 22.7% of his trades made money and his
+mean R was positive anyway, so a 20% win rate is not a broken method — a 20% win rate with
+a small right tail is. **Never pooled only**: per market, per year, and the
+**2020–21-excluded** figure beside the full-window one, because that tape rewarded momentum
+nearly everywhere and the window also holds a crash. An **open** trade has no R and is
+counted as open, never marked to the last close.
+_Avoid_: net expectancy, edge per trade; and never average US and IDX — findings §8
+measured that magnitudes do not transfer.
+
+**Clustered bootstrap**:
+The run's significance test (`backtest.metric.bootstrap_expectancy`): resample **symbols**
+with replacement, pooling every row inside a drawn symbol, and read the interval and the
+one-sided p off the resampled means. The cluster is the symbol because overlapping signals
+in one name are not independent observations — a stock throwing three signals in a
+fortnight contributes three correlated rows — so bootstrapping *rows* makes the effective
+sample larger than it is and flatters every p-value. Seeded, and the seed and resample
+count ride on every cell, because a significance figure that moved between two runs of the
+same data would be unreproducible with nothing in the output to show it.
+_Avoid_: bootstrapping the trades, resampling the rows — the row is not the unit.
+
 **Not-taken detection**:
 A member of the replayed field on a session where he entered something else. Not a
 declined setup — he may never have seen it — so it is a comparison group, never a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -475,8 +475,18 @@ report carries the count of variants standing behind it — every threshold trie
 and enough of them produce a winner from noise. A trade counts in the year of its **entry
 session**, the year the decision was taken, so a trade's year never moves with the exit
 rule under test.
-_Avoid_: the headline number, our main result — and never quote a swept variant under this
-name.
+_Avoid_: the headline number, our main result — and never quote a **swept variant** under
+this name.
+
+**Swept variant**:
+A result recomputed at a threshold other than the contract's, after the
+**pre-registered metric** has been computed and recorded. Always reported with the count
+of variants tried, because every threshold tried is a test and enough of them produce a
+winner from noise. The word narrows the **exit arm** entry's `_Avoid_: variant` rather
+than contradicting it: an arm is a *rule* the contract froze in Phase 0, a swept variant
+is a *threshold* moved afterwards, and calling an arm a variant is what that `_Avoid_`
+exists to stop.
+_Avoid_: variant on its own — unqualified it reads as an exit arm.
 
 **After-cost expectancy**:
 The mean R of the closed **simulated trades** in one cell, net of the contract's own

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -65,6 +65,24 @@ reason is now doubled: it is a command in its own right
 documented command warn on every invocation. The entry point is reached as
 ``backtest.simulate.simulate_market``.
 
+Issue #191 lands the first cell of Phase 5: :mod:`backtest.metric`, the one metric
+the run promised in advance — arm B's after-cost expectancy in R, per market per
+year. It reads no bar. The simulator already denominated each trade in R, so this
+module is arithmetic over those trades: the contract's per-market commission and
+slippage charged on both sides and divided by the trade's own stop width, the win
+rate and the R-distribution reported beside every expectancy, per year always and
+the 2020–21-excluded figure beside the full-window one, and significance
+bootstrapped by resampling **symbols** rather than rows. It computes and records the
+headline **before any swept variant exists**, and says so with the count of variants
+behind it.
+
+:mod:`backtest.metric`'s names are **not** re-exported here for the reasons that
+already keep :mod:`backtest.simulate` out: it is a command
+(``python -m backtest.metric``) and it imports both that module and
+:class:`~backtest.run.ContractDrift`, so re-exporting it would make either
+documented command warn on every invocation. The entry point is
+``backtest.metric.metric_report``.
+
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean
 something else one import away (:mod:`screener.universe`, :mod:`replay.reference`),

--- a/backend/backtest/metric.py
+++ b/backend/backtest/metric.py
@@ -1,0 +1,628 @@
+"""The pre-registered headline metric (issue #191, PRD #182 Phase 5).
+
+One metric, promised in advance: **arm B's after-cost expectancy in R, per market
+per year**. Arm B because it is the reference set's primary simulated exit, which
+is what keeps the headline comparable to figures already committed to this repo.
+
+The contract names it (``metric.primary``) and this module computes it. Nothing
+here reads a bar: :mod:`backtest.simulate` already turned each persisted detection
+into a trade denominated in R, and everything below is arithmetic over those
+trades. That separation is why the fixtures in the seam tests author trades
+directly — a metric that needed a chain to test would be a metric nobody could
+check by hand.
+
+Costs, and why they are per market
+----------------------------------
+Commission and slippage are contract cells, per market (``costs.per_market``), and
+they are **paid on both sides**: bps of the traded price on the entry and on every
+leg that comes off. IDX carries real fees and spread; US is near-zero. Modelling
+Jakarta with New York's assumptions would flatter the one market where costs can
+plausibly eat the edge, so a market the cell does not name is
+:class:`~backtest.run.ContractDrift` rather than a free trade.
+
+The cost is converted to R by the trade's own stop width, which keeps it in the
+unit the result is denominated in — and keeps it rescale-immune for the same
+reason :attr:`~backtest.simulate.SimulatedTrade.r_multiple` is: numerator and
+denominator are both prices from the same series.
+
+Why the win rate never travels alone
+------------------------------------
+A low win rate is judged against its right tail, not on its own. 22.7% of the
+reference trader's trades made money and his mean R was positive anyway (findings
+§3c). A method with a 20% win rate is not broken; a method with a 20% win rate and
+a *small* right tail is. So every expectancy in this module carries the win rate
+and the R-distribution behind it, and
+``test_the_same_win_rate_with_a_thin_tail_is_a_different_result`` pins that the two
+cases are distinguishable from the output alone.
+
+Never pooled only
+-----------------
+The measured window contains a crash and a mania, so a pooled fourteen-year number
+describes neither. Every market therefore reports **per year**, and the
+2020–21-excluded figure sits beside the full-window one because that tape rewarded
+momentum nearly everywhere. A year inside the span with no trades reports zeros
+rather than vanishing, for the same reason an arm that ran and traded nothing does:
+a missing row and a quiet year are indistinguishable after the fact.
+
+A trade is attributed to the year of its **entry session** — the year the decision
+was taken — so a trade entered in December and exited in February counts where it
+was decided. The alternative (attributing by exit) would move a trade's year with
+the exit rule under test, which is the one thing the arms are varying.
+
+US and IDX never pool, and it is enforced rather than remembered:
+:func:`expectancy_cell` refuses a cohort spanning two markets, because findings §8
+measured that magnitudes do not transfer and a mean across the two is a number
+about neither. It refuses a cohort spanning two arms for the same reason — the
+pre-registered metric is arm B's, and an arm A trade averaged into it would report
+a figure no arm produced under arm B's name.
+
+Significance is clustered by symbol, never by row
+-------------------------------------------------
+A stock throwing three signals in a fortnight contributes three correlated rows.
+Bootstrapping those rows treats them as three independent observations, and every
+p-value that comes out is flattered — the effective sample is smaller than the row
+count. So :func:`bootstrap_expectancy` resamples **clusters**, and
+:func:`clusters_by_symbol` makes the cluster a symbol. The seam test runs the same
+data both ways and asserts the interval widens and the p-value rises; that widening
+*is* the correction.
+
+The bootstrap is seeded (:data:`BOOTSTRAP_SEED`) and its seed and resample count
+ride on every cell, because a significance figure that moved between two runs of
+the same data would make every result unreproducible with nothing in the output to
+show it.
+
+What this module does not do
+----------------------------
+No sweep. Every threshold tried is a test, and enough of them produce a winner from
+noise, so the pre-registered metric is computed and recorded **before** any swept
+variant exists. The report says so with a variant count of zero, which is a claim a
+later phase must update rather than a blank it can quietly fill.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Any, Sequence
+
+from screener.store import Store
+
+from .contract import (
+    COSTS_KEY,
+    DEFAULT_CONTRACT,
+    METRIC_PRIMARY_KEY,
+    SCOPE_MARKETS_KEY,
+    RunContract,
+)
+from .denominator import DenominatorStore, denominator_path
+from .result import stamp_result
+from .run import ContractDrift
+from .simulate import ARM_B, SimulatedTrade, simulate_market
+
+# The arm the headline is computed on. Arm B is the reference set's primary
+# simulated exit, so the figure stays comparable to what this repo has already
+# committed; A and C are measured beside it and are not the headline.
+PRIMARY_ARM = ARM_B
+
+# The pre-registered metric's own name, as the contract spells it.
+# :func:`check_primary_metric` refuses a contract that has moved out from under it.
+PRIMARY_METRIC = "arm_b_after_cost_expectancy_r_per_market_per_year"
+
+# Costs are bps of the traded price, charged on **each side** — the entry and every
+# leg that comes off. Named rather than left implicit at the one call site, because
+# "is that a round-trip figure or a per-side one?" is the question a reader asks of
+# every cost model and the answer must not be inferred from arithmetic.
+COST_CHARGED = "both_sides"
+BPS = 10_000.0
+
+# The two windows every market reports, side by side. 2020–21 is excluded in the
+# second because that tape rewarded momentum nearly everywhere, and a result that
+# rests on it alone is a result about the tape.
+FULL_WINDOW = "full"
+EXCLUDED_YEARS_WINDOW = "excluding_2020_2021"
+EXCLUDED_YEARS = (2020, 2021)
+
+# The bootstrap. The cluster is the **symbol**: overlapping signals in one name are
+# correlated, so resampling rows would count a stock's three-signal fortnight as
+# three independent observations.
+BOOTSTRAP_CLUSTER = "symbol"
+BOOTSTRAP_RESAMPLES = 2_000
+BOOTSTRAP_SEED = 191
+BOOTSTRAP_CONFIDENCE = 0.95
+
+# The count of swept variants standing behind the headline. Zero, and structurally
+# so: this module computes the pre-registered metric and no sweep exists yet. A
+# later phase updates this rather than leaving a reader to assume it.
+SWEPT_VARIANTS = 0
+SWEEP_NOTE = (
+    "the pre-registered metric is computed and recorded before any swept variant "
+    "exists; a swept result is reported with the count of variants tried"
+)
+
+
+def check_primary_metric(contract: RunContract) -> None:
+    """Refuse a run whose contract's primary metric is not the one computed here.
+
+    Moving the cell without moving the code leaves a run whose contract and
+    behaviour disagree while both look right — and the headline is exactly the
+    figure pre-registration exists to keep fixed. The remedy is a new contract
+    recorded beside the old one, never a silent reinterpretation.
+    """
+    named = contract.value(METRIC_PRIMARY_KEY)
+    if named != PRIMARY_METRIC:
+        raise ContractDrift(
+            f"contract's primary metric is {named!r}, but this module computes "
+            f"{PRIMARY_METRIC!r}; a moved headline is a new run, not a rerun"
+        )
+
+
+def check_costs(contract: RunContract, market: str) -> None:
+    """Refuse a market the contract's costs cell does not price.
+
+    An unnamed market defaulting to zero would report the most flattering
+    expectancy in the whole run and would look like a clean result, which is the
+    one failure mode a cost model has that reading the output cannot catch.
+    """
+    costs = contract.value(COSTS_KEY)
+    if market not in costs:
+        raise ContractDrift(
+            f"the contract's {COSTS_KEY!r} cell prices {sorted(costs)} and not "
+            f"{market!r}; an unpriced market is drift, not a free trade"
+        )
+    for side in ("commission_bps", "slippage_bps"):
+        if side not in costs[market]:
+            raise ContractDrift(
+                f"the contract's costs for {market!r} carry no {side!r}"
+            )
+
+
+def per_side_cost_bps(contract: RunContract, market: str) -> float:
+    """Commission plus slippage for one side of a trade in ``market``, in bps.
+
+    The two are summed because they are charged the same way — bps of the price
+    actually traded — and separating them in the arithmetic would suggest a
+    distinction the model does not make. Both are still reported separately on
+    every cell, because only one of them is a fee somebody could negotiate.
+    """
+    check_costs(contract, market)
+    costs = contract.value(COSTS_KEY)[market]
+    return float(costs["commission_bps"]) + float(costs["slippage_bps"])
+
+
+def cost_r(trade: SimulatedTrade, contract: RunContract) -> float:
+    """The round trip's cost, in R, for one trade under the contract's costs.
+
+    Charged on the entry (the whole position, once) and on every leg that comes
+    off, weighted by the share of the position it was — so arm A's two legs pay
+    twice on halves rather than once on a whole, which is what actually happens.
+    A scale pays too: it is a planned partial, but it is still a fill.
+
+    Divided by the trade's own stop width, which puts the cost in the same unit as
+    the result and keeps it immune to a retroactive rescale of the bar series: both
+    terms are prices from that series, so a constant factor cancels.
+    """
+    rate = per_side_cost_bps(contract, trade.market) / BPS
+    if trade.stop_width <= 0:
+        return 0.0
+    priced = trade.entry.price + sum(
+        leg.weight * leg.exit.price for leg in trade.legs
+    )
+    return rate * priced / trade.stop_width
+
+
+def after_cost_r(trade: SimulatedTrade, contract: RunContract) -> float | None:
+    """A trade's R after costs, or ``None`` while any of the position is still on.
+
+    ``None`` rather than a number, and never a mark to the last close: closing a
+    running trade at whatever price the window ended on would invent an exit the
+    rules never gave, systematically, for every name still running.
+    """
+    if trade.r_multiple is None:
+        return None
+    return trade.r_multiple - cost_r(trade, contract)
+
+
+def clusters_by_symbol(
+    trades: Sequence[SimulatedTrade], contract: RunContract
+) -> list[tuple[float, ...]]:
+    """The closed trades' after-cost R, grouped into one cluster per symbol.
+
+    The unit of independence for the bootstrap. Overlapping signals in one name are
+    not independent observations — a stock throwing three signals in a fortnight
+    contributes three correlated rows — so the symbol is what gets resampled and the
+    rows inside it travel together.
+
+    Ordered by symbol so a resample under a fixed seed is reproducible: a bootstrap
+    whose clusters arrived in dictionary insertion order would move with the order
+    the trades happened to be read in.
+    """
+    grouped: dict[str, list[float]] = {}
+    for trade in trades:
+        r = after_cost_r(trade, contract)
+        if r is None:
+            continue
+        grouped.setdefault(trade.symbol, []).append(r)
+    return [tuple(grouped[symbol]) for symbol in sorted(grouped)]
+
+
+def _quantile(values: Sequence[float], q: float) -> float:
+    """The ``q``-quantile of already-sorted ``values``, linearly interpolated."""
+    if len(values) == 1:
+        return values[0]
+    pos = q * (len(values) - 1)
+    low = int(pos)
+    high = min(low + 1, len(values) - 1)
+    return values[low] + (values[high] - values[low]) * (pos - low)
+
+
+def bootstrap_expectancy(
+    clusters: Sequence[Sequence[float]],
+    *,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+    seed: int = BOOTSTRAP_SEED,
+    confidence: float = BOOTSTRAP_CONFIDENCE,
+    cluster: str = BOOTSTRAP_CLUSTER,
+) -> dict[str, Any]:
+    """A clustered bootstrap of the mean of ``clusters``' pooled values.
+
+    Each resample draws ``len(clusters)`` clusters **with replacement** and pools
+    everything inside them, so a cluster is either in or out as a whole. That is
+    the correction the whole exercise turns on: resampling rows instead would let
+    one name's twenty signals arrive twenty independent times, tighten the interval
+    and flatter the p-value.
+
+    ``p_value`` is one-sided — the share of resample means at or below zero — and
+    one-sided is the right shape because the decision rule it feeds is one-sided
+    too: the kill criterion asks whether expectancy is ≤ 0, not whether it differs
+    from 0. It is a percentile-bootstrap approximation and is named as such rather
+    than dressed up as a test statistic.
+
+    ``cluster`` names the unit for the reader, and taking it as an argument is what
+    lets the seam test run the same data clustered by row and show the difference.
+    """
+    n = len(clusters)
+    body: dict[str, Any] = {
+        "cluster": cluster,
+        "clusters": n,
+        "observations": sum(len(c) for c in clusters),
+        "resamples": resamples,
+        "seed": seed,
+        "confidence": confidence,
+    }
+    if n == 0:
+        return {**body, "ci_low": None, "ci_high": None, "p_value": None}
+
+    rng = random.Random(seed)
+    indices = range(n)
+    means: list[float] = []
+    for _ in range(resamples):
+        drawn = [clusters[rng.choice(indices)] for _ in indices]
+        total = sum(sum(c) for c in drawn)
+        count = sum(len(c) for c in drawn)
+        if count:
+            means.append(total / count)
+    if not means:
+        return {**body, "ci_low": None, "ci_high": None, "p_value": None}
+
+    means.sort()
+    tail = (1.0 - confidence) / 2.0
+    return {
+        **body,
+        "ci_low": _quantile(means, tail),
+        "ci_high": _quantile(means, 1.0 - tail),
+        "p_value": sum(1 for m in means if m <= 0.0) / len(means),
+    }
+
+
+def _distribution(rs: Sequence[float]) -> dict[str, Any]:
+    """The shape behind an expectancy: the quantiles and the two conditional means.
+
+    Reported whole rather than as a standard deviation, because the question a low
+    win rate raises is about the *right tail* specifically, and a spread statistic
+    answers it only if the distribution is symmetric — which this one is
+    emphatically not.
+    """
+    if not rs:
+        return {
+            "min": None, "p10": None, "q1": None, "median": None,
+            "q3": None, "p90": None, "max": None,
+            "mean_win": None, "mean_loss": None,
+        }
+    ordered = sorted(rs)
+    wins = [r for r in ordered if r > 0]
+    losses = [r for r in ordered if r <= 0]
+    return {
+        "min": ordered[0],
+        "p10": _quantile(ordered, 0.10),
+        "q1": _quantile(ordered, 0.25),
+        "median": _quantile(ordered, 0.50),
+        "q3": _quantile(ordered, 0.75),
+        "p90": _quantile(ordered, 0.90),
+        "max": ordered[-1],
+        "mean_win": sum(wins) / len(wins) if wins else None,
+        "mean_loss": sum(losses) / len(losses) if losses else None,
+    }
+
+
+def expectancy_cell(
+    contract: RunContract,
+    trades: Sequence[SimulatedTrade],
+    *,
+    market: str,
+    label: str,
+    arm: str = PRIMARY_ARM,
+) -> dict[str, Any]:
+    """One market's after-cost expectancy over one slice, with its shape and its CI.
+
+    ``label`` names the slice — a year, or one of the two windows — and is the only
+    thing that distinguishes two cells from each other, so it is carried rather than
+    inferred from the trades inside.
+
+    Every cohort is **one market and one arm**, and both are refused rather than
+    checked at the call site. A mean across two markets is the figure story 4
+    forbids and would be invisible in the output; a mean across two arms would
+    report a number no arm produced under arm B's name. Neither has a shape a reader
+    could catch afterwards, so neither is reachable.
+
+    A cell with no closed trades reports ``None`` for every figure that needs one
+    and zeros for the counts. That is a quiet slice, and it is deliberately not the
+    same output as a slice nobody computed.
+    """
+    check_costs(contract, market)
+    foreign = {t.market for t in trades} - {market}
+    if foreign:
+        raise ValueError(
+            f"an expectancy cell is one market's: {market!r} was asked for and "
+            f"{sorted(foreign)} arrived too; US and IDX never pool"
+        )
+    other_arms = {t.arm for t in trades} - {arm}
+    if other_arms:
+        raise ValueError(
+            f"the pre-registered metric is arm {arm}'s: {sorted(other_arms)} "
+            "arrived too, and no arm produced the average of them"
+        )
+
+    closed = [t for t in trades if t.r_multiple is not None]
+    rs = [after_cost_r(t, contract) for t in closed]
+    before = [t.r_multiple for t in closed]
+    wins = [r for r in rs if r > 0]
+    return {
+        "label": label,
+        "trades": len(trades),
+        "closed": len(closed),
+        "open_at_end": len(trades) - len(closed),
+        "symbols": len({t.symbol for t in trades}),
+        "price_scale_dropped": sum(1 for t in trades if not t.price_scale_ok),
+        "expectancy_r": (sum(rs) / len(rs)) if rs else None,
+        "expectancy_r_before_cost": (sum(before) / len(before)) if before else None,
+        "cost_r": (
+            sum(cost_r(t, contract) for t in closed) / len(closed) if closed else None
+        ),
+        "win_rate": (len(wins) / len(rs)) if rs else None,
+        "wins": len(wins),
+        "losses": len(rs) - len(wins),
+        "total_r": sum(rs),
+        "distribution": _distribution(rs),
+        "bootstrap": bootstrap_expectancy(clusters_by_symbol(trades, contract)),
+    }
+
+
+def _years(trades: Sequence[SimulatedTrade]) -> list[int]:
+    """Every year from the first entry to the last, gaps included.
+
+    The span rather than the years present: a year inside the window with no trade
+    is a measurement — possibly a data hole — and an absent row would read as a
+    quiet market until somebody looked.
+    """
+    if not trades:
+        return []
+    entries = [t.entry.session.year for t in trades]
+    return list(range(min(entries), max(entries) + 1))
+
+
+def market_report(
+    contract: RunContract,
+    trades: Sequence[SimulatedTrade],
+    *,
+    market: str,
+    arm: str = PRIMARY_ARM,
+) -> dict[str, Any]:
+    """One market's headline: the per-year cells, then the two windows beside them.
+
+    ``trades`` may span markets and arms; only this market's, on this arm, are
+    counted — so a caller hands over the whole run and the separation happens here
+    rather than at every call site.
+
+    The years come first because they are the metric: the two window figures are a
+    summary of them and a pooled fourteen-year number over a crash and a mania
+    describes neither. The 2020–21-excluded window sits beside the full one rather
+    than replacing it, because which of the two a reader should believe is exactly
+    the question the pair exists to pose.
+    """
+    check_costs(contract, market)
+    costs = contract.value(COSTS_KEY)[market]
+    mine = [t for t in trades if t.market == market and t.arm == arm]
+    kept = [t for t in mine if t.entry.session.year not in EXCLUDED_YEARS]
+    return {
+        "market": market,
+        "arm": arm,
+        "costs": {
+            "commission_bps": float(costs["commission_bps"]),
+            "slippage_bps": float(costs["slippage_bps"]),
+            "per_side_bps": per_side_cost_bps(contract, market),
+            "charged": COST_CHARGED,
+        },
+        "years": [
+            expectancy_cell(
+                contract,
+                [t for t in mine if t.entry.session.year == year],
+                market=market,
+                label=str(year),
+                arm=arm,
+            )
+            for year in _years(mine)
+        ],
+        "windows": [
+            expectancy_cell(contract, mine, market=market, label=FULL_WINDOW, arm=arm),
+            {
+                **expectancy_cell(
+                    contract, kept, market=market, label=EXCLUDED_YEARS_WINDOW, arm=arm
+                ),
+                "excluded_years": list(EXCLUDED_YEARS),
+            },
+        ],
+    }
+
+
+def metric_report(
+    contract: RunContract,
+    trades: Sequence[SimulatedTrade],
+    *,
+    markets: Sequence[str] | None = None,
+    arm: str = PRIMARY_ARM,
+) -> dict[str, Any]:
+    """The whole pre-registered metric as one stamped payload, market by market.
+
+    ``markets`` defaults to the contract's own ``scope.markets``, so a market that
+    produced no trade still reports its zeros rather than vanishing from the
+    headline — the same distinction the arms' report keeps between an arm that ran
+    quietly and one that never ran.
+
+    There is deliberately **no top-level expectancy**. findings §8 measured that
+    magnitudes do not transfer between the two markets, so a pooled figure would be
+    a number about neither, and the way to stop one being quoted is for it never to
+    have been computed.
+    """
+    check_primary_metric(contract)
+    named = tuple(markets) if markets is not None else tuple(
+        contract.value(SCOPE_MARKETS_KEY)
+    )
+    return stamp_result(
+        contract,
+        {
+            "metric": contract.value(METRIC_PRIMARY_KEY),
+            "arm": arm,
+            "pre_registered": True,
+            "sweep": {"variants_tried": SWEPT_VARIANTS, "note": SWEEP_NOTE},
+            "bootstrap": {
+                "cluster": BOOTSTRAP_CLUSTER,
+                "resamples": BOOTSTRAP_RESAMPLES,
+                "seed": BOOTSTRAP_SEED,
+                "confidence": BOOTSTRAP_CONFIDENCE,
+            },
+            "year_attributed_to": "entry_session",
+            "markets": [
+                market_report(contract, trades, market=market, arm=arm)
+                for market in named
+            ],
+        },
+    )
+
+
+def _cell_line(cell: dict[str, Any], *, width: int = 22) -> str:
+    """One cell as a line: the expectancy, then the shape and the interval behind it.
+
+    The win rate is printed immediately beside the expectancy and never on its own
+    line, because the two are read together or the low one gets read as a verdict.
+    """
+    if cell["closed"] == 0:
+        return f"  {cell['label']:<{width}} no closed trades (n={cell['trades']})"
+    dist = cell["distribution"]
+    boot = cell["bootstrap"]
+    ci = (
+        f"[{boot['ci_low']:+.2f}, {boot['ci_high']:+.2f}] p={boot['p_value']:.3f} "
+        f"on {boot['clusters']} {boot['cluster']}s"
+        if boot["ci_low"] is not None
+        else "no interval"
+    )
+    return (
+        f"  {cell['label']:<{width}} {cell['expectancy_r']:+.3f}R  "
+        f"win {cell['win_rate']:.1%}  n={cell['closed']}  "
+        f"med {dist['median']:+.2f} p90 {dist['p90']:+.2f} max {dist['max']:+.2f}  {ci}"
+    )
+
+
+def format_metric(report: dict[str, Any]) -> str:
+    """The headline as a page a terminal can print — per market, per year, never pooled.
+
+    The years are printed before the windows, in that order, because the printed
+    page is where "never pooled only" is either honoured or quietly broken: a reader
+    who skims to a bold summary figure must have passed the years to get there.
+    """
+    lines: list[str] = [
+        f"{report['metric']} — arm {report['arm']}",
+        f"  costs charged {COST_CHARGED}; bootstrap {report['bootstrap']['resamples']}× "
+        f"clustered by {report['bootstrap']['cluster']}, seed {report['bootstrap']['seed']}",
+        f"  swept variants behind this figure: {report['sweep']['variants_tried']}",
+    ]
+    for body in report["markets"]:
+        costs = body["costs"]
+        lines += [
+            "",
+            f"{body['market']} — {costs['commission_bps']:.0f}bps commission + "
+            f"{costs['slippage_bps']:.0f}bps slippage per side",
+            "  per year",
+        ]
+        lines += [_cell_line(cell) for cell in body["years"]] or [
+            "    no trades in this market"
+        ]
+        lines.append("  windows")
+        lines += [_cell_line(cell) for cell in body["windows"]]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Compute the pre-registered metric over a persisted denominator and record it.
+
+    The command that produces the headline::
+
+        python -m backtest.metric --store data/backtest.duckdb \\
+            --out-json references/backtest_primary_metric.json
+
+    Both markets by default, because the contract's scope names both and a headline
+    missing one is not the pre-registered metric. Arm B only: the other two arms are
+    measured by ``python -m backtest.simulate`` and are not the headline.
+
+    Reads the bar store and the denominator beside it, and writes neither.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the backtest bar store")
+    parser.add_argument(
+        "--market", action="append", default=None,
+        help="narrow to one market (repeatable); defaults to the contract's scope",
+    )
+    parser.add_argument(
+        "--out-json", default=None,
+        help="where to write the machine-readable, contract-stamped result",
+    )
+    args = parser.parse_args(argv)
+
+    contract = DEFAULT_CONTRACT
+    markets = tuple(args.market) if args.market else tuple(
+        contract.value(SCOPE_MARKETS_KEY)
+    )
+    store = Store.open(args.store)
+    denominator = DenominatorStore.open(denominator_path(args.store))
+    try:
+        trades: list[SimulatedTrade] = []
+        for market in markets:
+            trades += simulate_market(
+                store, denominator, market, contract, arms=(PRIMARY_ARM,)
+            )
+    finally:
+        denominator.close()
+        store.close()
+
+    report = metric_report(contract, trades, markets=markets)
+    if args.out_json:
+        Path(args.out_json).write_text(json.dumps(report, indent=1) + "\n")
+    print(format_metric(report))
+    if args.out_json:
+        print(f"\nwrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/backtest/metric.py
+++ b/backend/backtest/metric.py
@@ -71,6 +71,23 @@ ride on every cell, because a significance figure that moved between two runs of
 the same data would make every result unreproducible with nothing in the output to
 show it.
 
+A cell with fewer than :data:`BOOTSTRAP_MIN_CLUSTERS` symbols gets no interval at
+all, and says so. A resample can only draw the clusters it has, so one symbol
+resampled 2,000 times returns a zero-width interval at p = 0 — which prints as
+overwhelming significance and is one independent observation. Per-year cells are
+exactly where the cluster count goes thin, so this is a floor the metric needs
+where it is reported rather than an edge case.
+
+Never pooled only, at both edges
+--------------------------------
+The per-year span is anchored at the contract's ``window.measured_start``, not at
+the first trade: a market that traded nothing until 2016 in a run measuring from
+2012 has four silent years, and an empty crawl is precisely what hides in them.
+The far end stays observed, because the contract's ``measured_end`` is the token
+``latest_complete_session`` rather than a date — so a market silent in its final
+years is still under-reported at that end, and that limit is stated rather than
+papered over.
+
 What this module does not do
 ----------------------------
 No sweep. Every threshold tried is a test, and enough of them produce a winner from
@@ -94,12 +111,15 @@ from .contract import (
     DEFAULT_CONTRACT,
     METRIC_PRIMARY_KEY,
     SCOPE_MARKETS_KEY,
+    WINDOW_MEASURED_START_KEY,
     RunContract,
 )
 from .denominator import DenominatorStore, denominator_path
 from .result import stamp_result
 from .run import ContractDrift
-from .simulate import ARM_B, SimulatedTrade, simulate_market
+from .simulate import ARM_B, SimulatedTrade, price_scale_drops, simulate_market
+
+# -- what the contract says, and what this module adds to it ------------------
 
 # The arm the headline is computed on. Arm B is the reference set's primary
 # simulated exit, so the figure stays comparable to what this repo has already
@@ -117,6 +137,12 @@ PRIMARY_METRIC = "arm_b_after_cost_expectancy_r_per_market_per_year"
 COST_CHARGED = "both_sides"
 BPS = 10_000.0
 
+# The two sub-keys inside the contract's per-market costs cell. Named for the same
+# reason the cells themselves are: a bare ``costs["commission_bps"]`` at four sites
+# is four places a rename has to be found by grep.
+COMMISSION_BPS = "commission_bps"
+SLIPPAGE_BPS = "slippage_bps"
+
 # The two windows every market reports, side by side. 2020–21 is excluded in the
 # second because that tape rewarded momentum nearly everywhere, and a result that
 # rests on it alone is a result about the tape.
@@ -132,6 +158,19 @@ BOOTSTRAP_RESAMPLES = 2_000
 BOOTSTRAP_SEED = 191
 BOOTSTRAP_CONFIDENCE = 0.95
 
+# Below this many clusters no interval is reported at all. A resample can only ever
+# draw from the clusters it has, so one symbol resampled 2,000 times returns that
+# symbol's own mean 2,000 times: a zero-width interval and a p-value of exactly 0 or
+# 1. That prints as overwhelming significance and is the opposite — it is a cell
+# with one independent observation. Per-year cells are precisely where the cluster
+# count goes thin, so the floor matters most exactly where the metric is reported.
+#
+# Five is a judgement, not a derivation, and is recorded as one: below five symbols
+# a 95% percentile interval is pinned by fewer than five distinct values and
+# describes the sample's own range rather than the uncertainty around it. The
+# suppressed cells still report ``clusters``, so a thin cell reads as thin.
+BOOTSTRAP_MIN_CLUSTERS = 5
+
 # The count of swept variants standing behind the headline. Zero, and structurally
 # so: this module computes the pre-registered metric and no sweep exists yet. A
 # later phase updates this rather than leaving a reader to assume it.
@@ -140,6 +179,9 @@ SWEEP_NOTE = (
     "the pre-registered metric is computed and recorded before any swept variant "
     "exists; a swept result is reported with the count of variants tried"
 )
+
+
+# -- refusing a contract that has moved out from under the code ---------------
 
 
 def check_primary_metric(contract: RunContract) -> None:
@@ -171,7 +213,7 @@ def check_costs(contract: RunContract, market: str) -> None:
             f"the contract's {COSTS_KEY!r} cell prices {sorted(costs)} and not "
             f"{market!r}; an unpriced market is drift, not a free trade"
         )
-    for side in ("commission_bps", "slippage_bps"):
+    for side in (COMMISSION_BPS, SLIPPAGE_BPS):
         if side not in costs[market]:
             raise ContractDrift(
                 f"the contract's costs for {market!r} carry no {side!r}"
@@ -188,7 +230,10 @@ def per_side_cost_bps(contract: RunContract, market: str) -> float:
     """
     check_costs(contract, market)
     costs = contract.value(COSTS_KEY)[market]
-    return float(costs["commission_bps"]) + float(costs["slippage_bps"])
+    return float(costs[COMMISSION_BPS]) + float(costs[SLIPPAGE_BPS])
+
+
+# -- the arithmetic: costs, the distribution behind an expectancy, the bootstrap
 
 
 def cost_r(trade: SimulatedTrade, contract: RunContract) -> float:
@@ -264,6 +309,7 @@ def bootstrap_expectancy(
     seed: int = BOOTSTRAP_SEED,
     confidence: float = BOOTSTRAP_CONFIDENCE,
     cluster: str = BOOTSTRAP_CLUSTER,
+    min_clusters: int = BOOTSTRAP_MIN_CLUSTERS,
 ) -> dict[str, Any]:
     """A clustered bootstrap of the mean of ``clusters``' pooled values.
 
@@ -281,6 +327,12 @@ def bootstrap_expectancy(
 
     ``cluster`` names the unit for the reader, and taking it as an argument is what
     lets the seam test run the same data clustered by row and show the difference.
+
+    A cell with fewer than :data:`BOOTSTRAP_MIN_CLUSTERS` clusters gets **no
+    interval and no p-value**, and a ``suppressed`` line saying why. Reporting one
+    would be worse than reporting nothing: a single cluster resampled 2,000 times
+    returns its own mean 2,000 times, which prints as a zero-width interval at
+    p = 0 and reads as overwhelming significance from one independent observation.
     """
     n = len(clusters)
     body: dict[str, Any] = {
@@ -290,9 +342,20 @@ def bootstrap_expectancy(
         "resamples": resamples,
         "seed": seed,
         "confidence": confidence,
+        "min_clusters": min_clusters,
+        "suppressed": None,
     }
-    if n == 0:
-        return {**body, "ci_low": None, "ci_high": None, "p_value": None}
+    if n < min_clusters:
+        return {
+            **body,
+            "ci_low": None,
+            "ci_high": None,
+            "p_value": None,
+            "suppressed": (
+                f"{n} {cluster}s is fewer than {min_clusters}: too thin for an "
+                "interval, and a degenerate one would read as significance"
+            ),
+        }
 
     rng = random.Random(seed)
     indices = range(n)
@@ -316,6 +379,21 @@ def bootstrap_expectancy(
     }
 
 
+# The quantiles every distribution reports, and the fractions they read at. One
+# table rather than a list of keys and a parallel list of calls, so an empty
+# distribution and a populated one cannot drift into carrying different fields —
+# which would make a quiet cell and a computed one differently shaped.
+_QUANTILES = (
+    ("p10", 0.10),
+    ("q1", 0.25),
+    ("median", 0.50),
+    ("q3", 0.75),
+    ("p90", 0.90),
+)
+_DISTRIBUTION_KEYS = ("min", *(name for name, _ in _QUANTILES), "max",
+                      "mean_win", "mean_loss")
+
+
 def _distribution(rs: Sequence[float]) -> dict[str, Any]:
     """The shape behind an expectancy: the quantiles and the two conditional means.
 
@@ -325,25 +403,20 @@ def _distribution(rs: Sequence[float]) -> dict[str, Any]:
     emphatically not.
     """
     if not rs:
-        return {
-            "min": None, "p10": None, "q1": None, "median": None,
-            "q3": None, "p90": None, "max": None,
-            "mean_win": None, "mean_loss": None,
-        }
+        return {key: None for key in _DISTRIBUTION_KEYS}
     ordered = sorted(rs)
     wins = [r for r in ordered if r > 0]
     losses = [r for r in ordered if r <= 0]
     return {
         "min": ordered[0],
-        "p10": _quantile(ordered, 0.10),
-        "q1": _quantile(ordered, 0.25),
-        "median": _quantile(ordered, 0.50),
-        "q3": _quantile(ordered, 0.75),
-        "p90": _quantile(ordered, 0.90),
+        **{name: _quantile(ordered, q) for name, q in _QUANTILES},
         "max": ordered[-1],
         "mean_win": sum(wins) / len(wins) if wins else None,
         "mean_loss": sum(losses) / len(losses) if losses else None,
     }
+
+
+# -- the report: one cell, one market, the whole headline ---------------------
 
 
 def expectancy_cell(
@@ -352,7 +425,6 @@ def expectancy_cell(
     *,
     market: str,
     label: str,
-    arm: str = PRIMARY_ARM,
 ) -> dict[str, Any]:
     """One market's after-cost expectancy over one slice, with its shape and its CI.
 
@@ -377,11 +449,12 @@ def expectancy_cell(
             f"an expectancy cell is one market's: {market!r} was asked for and "
             f"{sorted(foreign)} arrived too; US and IDX never pool"
         )
-    other_arms = {t.arm for t in trades} - {arm}
+    other_arms = {t.arm for t in trades} - {PRIMARY_ARM}
     if other_arms:
         raise ValueError(
-            f"the pre-registered metric is arm {arm}'s: {sorted(other_arms)} "
-            "arrived too, and no arm produced the average of them"
+            f"the pre-registered metric is arm {PRIMARY_ARM}'s: "
+            f"{sorted(other_arms)} arrived too, and no arm produced the average "
+            "of them"
         )
 
     closed = [t for t in trades if t.r_multiple is not None]
@@ -392,9 +465,20 @@ def expectancy_cell(
         "label": label,
         "trades": len(trades),
         "closed": len(closed),
-        "open_at_end": len(trades) - len(closed),
+        # Off the trade's **own** property rather than off "has no R", because the
+        # two are not the same set: a trade whose stop width is non-positive has
+        # come fully off and still cannot be denominated. Counting it as open would
+        # report a finished trade as running, so it gets its own count and the two
+        # numbers add up to the total with nothing hidden between them.
+        "open_at_end": sum(1 for t in trades if t.open_at_end),
+        "undenominated": sum(
+            1 for t in trades if t.closed and t.r_multiple is None
+        ),
         "symbols": len({t.symbol for t in trades}),
-        "price_scale_dropped": sum(1 for t in trades if not t.price_scale_ok),
+        # The simulator's own count, not a second one: it is the function whose
+        # docstring argues why the flag is reported and never filtered, and two
+        # implementations of that would be two places for it to become a filter.
+        "price_scale_dropped": price_scale_drops(trades),
         "expectancy_r": (sum(rs) / len(rs)) if rs else None,
         "expectancy_r_before_cost": (sum(before) / len(before)) if before else None,
         "cost_r": (
@@ -409,17 +493,44 @@ def expectancy_cell(
     }
 
 
-def _years(trades: Sequence[SimulatedTrade]) -> list[int]:
-    """Every year from the first entry to the last, gaps included.
+def _reported_markets(
+    contract: RunContract, asked: Sequence[str] | None
+) -> tuple[str, ...]:
+    """The markets to report: those asked for, or the contract's own scope.
 
-    The span rather than the years present: a year inside the window with no trade
-    is a measurement — possibly a data hole — and an absent row would read as a
-    quiet market until somebody looked.
+    One fallback, in one place. Defaulting at the command *and* in the report would
+    be two places for "which markets is this run about" to diverge, and the
+    divergence would show up as a market silently missing from a headline that
+    promised both.
+    """
+    return tuple(asked) if asked else tuple(contract.value(SCOPE_MARKETS_KEY))
+
+
+def _years(contract: RunContract, trades: Sequence[SimulatedTrade]) -> list[int]:
+    """Every year of the measured window that this market could have traded in.
+
+    The span rather than the years present: a year with no trade is a measurement —
+    possibly a data hole — and an absent row reads as a quiet market until somebody
+    looks.
+
+    Anchored at the **contract's** ``window.measured_start`` rather than at the
+    first trade, because a market that traded nothing until 2016 in a run that
+    started measuring in 2012 has four silent years, and those are exactly the years
+    a crawl that came back empty would hide. Spanning the observed trades alone
+    protects interior gaps and quietly drops the ones at the edge, which is the
+    failure mode this function exists to prevent arriving through the function
+    itself.
+
+    The far end stays observed: the contract's ``measured_end`` is the token
+    ``latest_complete_session`` rather than a date, so no year is derivable from it.
+    A market silent for its final years is therefore still under-reported at that
+    end, and that is a known limit rather than a covered case.
     """
     if not trades:
         return []
     entries = [t.entry.session.year for t in trades]
-    return list(range(min(entries), max(entries) + 1))
+    start = int(str(contract.value(WINDOW_MEASURED_START_KEY))[:4])
+    return list(range(min(start, *entries), max(entries) + 1))
 
 
 def market_report(
@@ -427,13 +538,18 @@ def market_report(
     trades: Sequence[SimulatedTrade],
     *,
     market: str,
-    arm: str = PRIMARY_ARM,
 ) -> dict[str, Any]:
     """One market's headline: the per-year cells, then the two windows beside them.
 
-    ``trades`` may span markets and arms; only this market's, on this arm, are
-    counted — so a caller hands over the whole run and the separation happens here
-    rather than at every call site.
+    ``trades`` may span markets and arms; only this market's, on
+    :data:`PRIMARY_ARM`, are counted — so a caller hands over the whole run and the
+    separation happens here rather than at every call site.
+
+    The arm is **not** a parameter, and that is the point: the metric's name and the
+    trades under it have to be the same arm or the report is a mislabel. A caller
+    able to choose the arm could stamp arm A's result with arm B's pre-registered
+    name, which is the very confusion the two-arm refusal in :func:`expectancy_cell`
+    exists to prevent, arriving one level up.
 
     The years come first because they are the metric: the two window figures are a
     summary of them and a pooled fourteen-year number over a crash and a mania
@@ -443,11 +559,11 @@ def market_report(
     """
     check_costs(contract, market)
     costs = contract.value(COSTS_KEY)[market]
-    mine = [t for t in trades if t.market == market and t.arm == arm]
+    mine = [t for t in trades if t.market == market and t.arm == PRIMARY_ARM]
     kept = [t for t in mine if t.entry.session.year not in EXCLUDED_YEARS]
     return {
         "market": market,
-        "arm": arm,
+        "arm": PRIMARY_ARM,
         "costs": {
             "commission_bps": float(costs["commission_bps"]),
             "slippage_bps": float(costs["slippage_bps"]),
@@ -460,15 +576,14 @@ def market_report(
                 [t for t in mine if t.entry.session.year == year],
                 market=market,
                 label=str(year),
-                arm=arm,
             )
-            for year in _years(mine)
+            for year in _years(contract, mine)
         ],
         "windows": [
-            expectancy_cell(contract, mine, market=market, label=FULL_WINDOW, arm=arm),
+            expectancy_cell(contract, mine, market=market, label=FULL_WINDOW),
             {
                 **expectancy_cell(
-                    contract, kept, market=market, label=EXCLUDED_YEARS_WINDOW, arm=arm
+                    contract, kept, market=market, label=EXCLUDED_YEARS_WINDOW
                 ),
                 "excluded_years": list(EXCLUDED_YEARS),
             },
@@ -481,7 +596,6 @@ def metric_report(
     trades: Sequence[SimulatedTrade],
     *,
     markets: Sequence[str] | None = None,
-    arm: str = PRIMARY_ARM,
 ) -> dict[str, Any]:
     """The whole pre-registered metric as one stamped payload, market by market.
 
@@ -496,14 +610,12 @@ def metric_report(
     have been computed.
     """
     check_primary_metric(contract)
-    named = tuple(markets) if markets is not None else tuple(
-        contract.value(SCOPE_MARKETS_KEY)
-    )
+    named = _reported_markets(contract, markets)
     return stamp_result(
         contract,
         {
             "metric": contract.value(METRIC_PRIMARY_KEY),
-            "arm": arm,
+            "arm": PRIMARY_ARM,
             "pre_registered": True,
             "sweep": {"variants_tried": SWEPT_VARIANTS, "note": SWEEP_NOTE},
             "bootstrap": {
@@ -514,11 +626,14 @@ def metric_report(
             },
             "year_attributed_to": "entry_session",
             "markets": [
-                market_report(contract, trades, market=market, arm=arm)
+                market_report(contract, trades, market=market)
                 for market in named
             ],
         },
     )
+
+
+# -- printing it, and the command that produces it ----------------------------
 
 
 def _cell_line(cell: dict[str, Any], *, width: int = 22) -> str:
@@ -535,7 +650,10 @@ def _cell_line(cell: dict[str, Any], *, width: int = 22) -> str:
         f"[{boot['ci_low']:+.2f}, {boot['ci_high']:+.2f}] p={boot['p_value']:.3f} "
         f"on {boot['clusters']} {boot['cluster']}s"
         if boot["ci_low"] is not None
-        else "no interval"
+        # The thin cell says it is thin, in the place a reader looks for the
+        # interval — a blank there would read as "no result" rather than "too few
+        # symbols to say", and those are different findings.
+        else f"{boot['clusters']} {boot['cluster']}s — too thin for an interval"
     )
     return (
         f"  {cell['label']:<{width}} {cell['expectancy_r']:+.3f}R  "
@@ -600,9 +718,10 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     contract = DEFAULT_CONTRACT
-    markets = tuple(args.market) if args.market else tuple(
-        contract.value(SCOPE_MARKETS_KEY)
-    )
+    # ``None`` is passed straight through rather than defaulted here:
+    # :func:`metric_report` already falls back to the contract's own scope, and
+    # defaulting in two places is two places for the fallback to diverge.
+    markets = _reported_markets(contract, args.market)
     store = Store.open(args.store)
     denominator = DenominatorStore.open(denominator_path(args.store))
     try:

--- a/backend/backtest/simulate.py
+++ b/backend/backtest/simulate.py
@@ -100,10 +100,10 @@ so it is the one defect here that reading the output can never catch.
 
 What this module does not do
 ----------------------------
-Costs (#191) are not here: every figure this module reports is before commission
-and slippage, and the contract's ``costs`` cell is applied by the phase that
-computes the primary metric. So ``total_r`` here is not the headline and must not
-be read as one.
+Costs are not here: every figure this module reports is before commission and
+slippage. The contract's ``costs`` cell is applied by :mod:`backtest.metric`, which
+computes the pre-registered primary metric off arm B's trades (#191). So
+``total_r`` here is not the headline and must not be read as one.
 """
 
 from __future__ import annotations

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -6252,9 +6252,14 @@ def test_an_arm_that_ran_and_traded_nothing_reports_zeros_rather_than_vanishing(
 #     fortnight is not three independent observations, and bootstrapping the rows
 #     flatters every p-value.
 
-from backtest.contract import COSTS_KEY, METRIC_PRIMARY_KEY
+from backtest.contract import (
+    COSTS_KEY,
+    METRIC_PRIMARY_KEY,
+    WINDOW_MEASURED_START_KEY,
+)
 from backtest.metric import (
     BOOTSTRAP_CLUSTER,
+    BOOTSTRAP_MIN_CLUSTERS,
     BOOTSTRAP_RESAMPLES,
     BOOTSTRAP_SEED,
     EXCLUDED_YEARS,
@@ -6479,13 +6484,20 @@ def test_a_market_is_never_reported_pooled_only(store):
     A pooled fourteen-year number over a window holding a crash and a mania
     describes neither, so a reader must not be able to reach one without the years
     beside it.
+
+    The span runs from the **contract's** measured start, not from the first trade:
+    a market that traded nothing until 2016 in a run measuring from 2012 has four
+    silent years, and those are exactly the years an empty crawl would hide.
     """
     trades = [_mtrade("AAA", 2016, 1.0), _mtrade("BBB", 2020, -1.0)]
 
     body = market_report(DEFAULT_CONTRACT, trades, market="US")
 
     years = [y["label"] for y in body["years"]]
-    assert years == [str(y) for y in range(2016, 2021)]
+    start = int(DEFAULT_CONTRACT.value(WINDOW_MEASURED_START_KEY)[:4])
+    assert start == 2012
+    assert years == [str(y) for y in range(start, 2021)]
+    assert {y["label"]: y for y in body["years"]}["2013"]["trades"] == 0
     printed = format_metric(metric_report(DEFAULT_CONTRACT, trades))
     for label in years:
         assert label in printed
@@ -6668,4 +6680,74 @@ def test_the_metric_runs_off_the_simulator_end_to_end(store):
     assert window["expectancy_r"] == pytest.approx(
         trade.r_multiple - cost_r(trade, DEFAULT_CONTRACT)
     )
-    assert [y["label"] for y in body["years"]] == [str(trade.entry.session.year)]
+    # The years run from the contract's measured start to the trade's own year;
+    # every one before it is a silent year the run measured and found nothing in.
+    years = [y["label"] for y in body["years"]]
+    assert years[-1] == str(trade.entry.session.year)
+    assert years[0] == DEFAULT_CONTRACT.value(WINDOW_MEASURED_START_KEY)[:4]
+
+
+def test_a_cell_too_thin_to_bootstrap_reports_no_interval_rather_than_a_degenerate_one(store):
+    """One symbol resampled two thousand times returns its own mean two thousand
+    times — a zero-width interval at p = 0, which prints as overwhelming
+    significance and is the opposite: one independent observation.
+
+    Per-year cells are exactly where the cluster count goes thin, so the floor
+    matters most where the metric is reported. The thin cell still says how many
+    symbols it had, because "too few to say" and "no result" are different findings.
+    """
+    thin = [_mtrade("ONE", 2016, 3.0, month=1 + i) for i in range(4)]
+
+    cell = expectancy_cell(DEFAULT_CONTRACT, thin, market="US", label="2016")
+
+    boot = cell["bootstrap"]
+    assert boot["clusters"] == 1 < BOOTSTRAP_MIN_CLUSTERS
+    assert (boot["ci_low"], boot["ci_high"], boot["p_value"]) == (None, None, None)
+    assert "too thin" in boot["suppressed"]
+    # The expectancy itself is still reported — it is the interval that is refused.
+    assert cell["expectancy_r"] is not None
+    printed = format_metric(metric_report(DEFAULT_CONTRACT, thin))
+    assert "too thin for an interval" in printed
+
+    # And a cell at the floor gets its interval.
+    wide = [_mtrade(f"S{i}", 2016, 1.0) for i in range(BOOTSTRAP_MIN_CLUSTERS)]
+    at_floor = expectancy_cell(DEFAULT_CONTRACT, wide, market="US", label="2016")
+    assert at_floor["bootstrap"]["ci_low"] is not None
+    assert at_floor["bootstrap"]["suppressed"] is None
+
+
+def test_a_trade_that_closed_without_a_denominator_is_not_counted_as_open(store):
+    """A trade whose stop width is non-positive has come fully off and still has no
+    R. Folding it into the open count would report a finished trade as running, and
+    the two numbers would stop adding up to the total with nothing in between.
+    """
+    ok = _mtrade("AAA", 2016, 1.0)
+    broken = dataclasses.replace(_mtrade("BBB", 2016, 1.0), stop_width=0.0)
+    still_on = _mtrade("CCC", 2016, 1.0, open_at_end=True)
+
+    cell = expectancy_cell(
+        DEFAULT_CONTRACT, [ok, broken, still_on], market="US", label="2016"
+    )
+
+    assert broken.closed and broken.r_multiple is None
+    assert cell["trades"] == 3
+    assert cell["closed"] == 1
+    assert cell["open_at_end"] == 1
+    assert cell["undenominated"] == 1
+    # Every trade lands in exactly one of the three, so none can go missing.
+    assert cell["closed"] + cell["open_at_end"] + cell["undenominated"] == 3
+
+
+def test_the_headline_cannot_be_stamped_over_another_arms_trades(store):
+    """The metric's name and the trades under it are the same arm or the report is
+    a mislabel — which is exactly what the two-arm refusal exists to prevent, and
+    would be reintroduced by any caller able to choose the arm."""
+    arm_a = [_mtrade("AAA", 2016, 5.0, arm=ARM_A)]
+
+    report = metric_report(DEFAULT_CONTRACT, arm_a)
+
+    assert report["arm"] == ARM_B
+    # Arm A's trades are not this arm's, so the headline counts none of them rather
+    # than reporting arm A's result under arm B's name.
+    body = {m["market"]: m for m in report["markets"]}["US"]
+    assert {w["label"]: w for w in body["windows"]}[FULL_WINDOW]["trades"] == 0

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -6230,3 +6230,442 @@ def test_an_arm_that_ran_and_traded_nothing_reports_zeros_rather_than_vanishing(
     assert (quiet["trades"], quiet["closed"], quiet["total_r"]) == (0, 0, 0)
     # And an arm that never ran is absent, which is the distinction being kept.
     assert [r["arm"] for r in ran_one["arms"]] == [ARM_B]
+
+
+# -- the pre-registered headline metric (issue #191) ---------------------------
+#
+# Phase 5's first cell, and the only metric the run promised in advance: arm B's
+# after-cost expectancy in R, per market per year. Everything here is arithmetic
+# over trades the simulator already produced — no bar is read — which is why the
+# fixtures below author trades directly rather than running a chain to reach them.
+#
+# Three claims are load-bearing and each has a test that would fail loudly if the
+# code drifted from it:
+#
+#   * **Costs are the contract's own, per market.** IDX carries real fees and
+#     spread; US is near-zero. A market the cell does not name is drift, never a
+#     free trade.
+#   * **Never pooled only.** The window holds a crash and a mania, so a pooled
+#     fourteen-year figure describes neither. Per year always, and the
+#     2020–21-excluded figure beside the full-window one.
+#   * **Clustered by symbol, not by row.** A stock throwing three signals in a
+#     fortnight is not three independent observations, and bootstrapping the rows
+#     flatters every p-value.
+
+from backtest.contract import COSTS_KEY, METRIC_PRIMARY_KEY
+from backtest.metric import (
+    BOOTSTRAP_CLUSTER,
+    BOOTSTRAP_RESAMPLES,
+    BOOTSTRAP_SEED,
+    EXCLUDED_YEARS,
+    EXCLUDED_YEARS_WINDOW,
+    FULL_WINDOW,
+    PRIMARY_ARM,
+    after_cost_r,
+    bootstrap_expectancy,
+    check_costs,
+    check_primary_metric,
+    clusters_by_symbol,
+    cost_r,
+    expectancy_cell,
+    format_metric,
+    market_report,
+    metric_report,
+    per_side_cost_bps,
+)
+
+# The authored trade every metric test runs on: entry at 100 with a stop width of
+# 10, so a trade's *before-cost* R is exactly the number the fixture asks for and
+# every figure below is arithmetic a reader can check without a bar series.
+_M_ENTRY = 100.0
+_M_STOP_WIDTH = 10.0
+
+
+def _mtrade(
+    symbol: str,
+    year: int,
+    r: float,
+    *,
+    market: str = "US",
+    arm: str = ARM_B,
+    price_scale_ok: bool = True,
+    open_at_end: bool = False,
+    month: int = 3,
+) -> SimulatedTrade:
+    """One arm-B trade whose before-cost R is exactly ``r``.
+
+    Authored rather than simulated: the metric is arithmetic over trades, so a
+    fixture that ran the simulator to reach them would put a second phase's bugs
+    inside this one's tests. ``open_at_end`` leaves half the position on, which is
+    how a trade with no R is spelled — its legs do not add up to a whole one.
+    """
+    entry_session = date(year, month, 1)
+    exit_session = date(year, month, 20)
+    exit_price = _M_ENTRY + r * _M_STOP_WIDTH
+    weight = 0.5 if open_at_end else 1.0
+    leg = ExitLeg(
+        weight=weight,
+        signal=Decision(session=exit_session, price=exit_price),
+        exit=Decision(session=exit_session, price=exit_price),
+        reason=EXIT_TRAIL,
+    )
+    return SimulatedTrade(
+        market=market,
+        symbol=symbol,
+        arm=arm,
+        detection_session=date(year, month, 1),
+        trigger=Decision(session=date(year, month, 1), price=_M_ENTRY),
+        break_signal=Decision(session=date(year, month, 1), price=_M_ENTRY),
+        entry=Decision(session=entry_session, price=_M_ENTRY),
+        stop_price=Decision(
+            session=date(year, month, 1), price=_M_ENTRY - _M_STOP_WIDTH
+        ),
+        stop_width=_M_STOP_WIDTH,
+        legs=(leg,),
+        price_scale=1.0,
+        price_scale_ok=price_scale_ok,
+    )
+
+
+def test_the_primary_metric_is_the_contracts_own_and_is_arm_bs(store):
+    """The headline is the contract's cell, read rather than restated.
+
+    The metric that gets reported and the metric that was pre-registered are the
+    same string, or the run has quietly chosen its headline after the fact — which
+    is the one thing pre-registration exists to prevent.
+    """
+    assert PRIMARY_ARM == ARM_B
+    report = metric_report(DEFAULT_CONTRACT, [_mtrade("AAA", 2015, 1.0)])
+
+    assert report["metric"] == DEFAULT_CONTRACT.value(METRIC_PRIMARY_KEY)
+    assert report["arm"] == ARM_B
+    check_primary_metric(DEFAULT_CONTRACT)
+
+
+def test_a_contract_whose_primary_metric_moved_is_drift_not_a_new_headline(store):
+    """Changing the cell without changing the code leaves a run whose contract and
+    behaviour disagree while both look right — a new run recorded beside the old
+    one is the remedy, never a silent reinterpretation."""
+    moved = RunContract(
+        contract_version=DEFAULT_CONTRACT.contract_version,
+        label=DEFAULT_CONTRACT.label,
+        cells=tuple(
+            Cell(
+                key=c.key,
+                value="arm_a_after_cost_expectancy_r",
+                justification=c.justification,
+            )
+            if c.key == METRIC_PRIMARY_KEY else c
+            for c in DEFAULT_CONTRACT.cells
+        ),
+    )
+    with pytest.raises(ContractDrift):
+        check_primary_metric(moved)
+
+
+def test_costs_are_the_contracts_own_per_market_and_paid_on_both_sides(store):
+    """IDX's real fees and spread are not modelled with US's near-zero assumptions.
+
+    Commission and slippage are both per-side bps of the traded price, so a round
+    trip pays on the entry and on every leg that comes off. In R that is the cost
+    in price divided by the stop width, which keeps the figure in the unit the
+    result is denominated in.
+    """
+    us_costs = DEFAULT_CONTRACT.value(COSTS_KEY)["US"]
+    idx_costs = DEFAULT_CONTRACT.value(COSTS_KEY)["IDX"]
+    assert per_side_cost_bps(DEFAULT_CONTRACT, "US") == (
+        us_costs["commission_bps"] + us_costs["slippage_bps"]
+    )
+    assert per_side_cost_bps(DEFAULT_CONTRACT, "IDX") == (
+        idx_costs["commission_bps"] + idx_costs["slippage_bps"]
+    )
+
+    us = _mtrade("AAA", 2015, 1.0, market="US")
+    idx = _mtrade("BBB", 2015, 1.0, market="IDX")
+
+    # Entry at 100, exit at 110, stop width 10: (100 + 110) × rate / 10.
+    assert cost_r(us, DEFAULT_CONTRACT) == pytest.approx(
+        (100.0 + 110.0) * (5.0 / 10_000.0) / 10.0
+    )
+    assert cost_r(idx, DEFAULT_CONTRACT) == pytest.approx(
+        (100.0 + 110.0) * (40.0 / 10_000.0) / 10.0
+    )
+    # Jakarta pays materially more for the same trade, which is the whole reason
+    # the cell is per market.
+    assert cost_r(idx, DEFAULT_CONTRACT) > cost_r(us, DEFAULT_CONTRACT) * 5
+
+
+def test_a_market_the_costs_cell_does_not_name_is_drift_not_a_free_trade(store):
+    """An unnamed market priced at zero would report the most flattering
+    expectancy in the run and look like a clean result. So it is refused."""
+    with pytest.raises(ContractDrift):
+        check_costs(DEFAULT_CONTRACT, "LSE")
+    with pytest.raises(ContractDrift):
+        cost_r(_mtrade("AAA", 2015, 1.0, market="LSE"), DEFAULT_CONTRACT)
+
+
+def test_the_reported_expectancy_is_after_cost_and_lower_than_before_cost(store):
+    """The headline is the after-cost number, and it is the one in the cell."""
+    trades = [_mtrade("AAA", 2015, 1.0), _mtrade("BBB", 2015, -1.0)]
+
+    cell = expectancy_cell(DEFAULT_CONTRACT, trades, market="US", label="2015")
+
+    before = sum(t.r_multiple for t in trades) / len(trades)
+    after = sum(after_cost_r(t, DEFAULT_CONTRACT) for t in trades) / len(trades)
+    assert cell["expectancy_r_before_cost"] == pytest.approx(before)
+    assert cell["expectancy_r"] == pytest.approx(after)
+    assert cell["expectancy_r"] < cell["expectancy_r_before_cost"]
+    assert cell["cost_r"] == pytest.approx(before - after)
+
+
+def test_the_win_rate_and_the_r_distribution_ride_with_the_expectancy(store):
+    """A 20% win rate is not a broken method; a 20% win rate with a small right
+    tail is. So the expectancy never travels without the shape behind it.
+
+    Eight losers at −1R and two winners at +8R: one in five made money and the
+    mean R is positive anyway, which is the reference set's own shape (22.7% at a
+    positive mean) and the reason the win rate alone decides nothing.
+    """
+    trades = [_mtrade(f"L{i}", 2016, -1.0) for i in range(8)]
+    trades += [_mtrade(f"W{i}", 2016, 8.0) for i in range(2)]
+
+    cell = expectancy_cell(DEFAULT_CONTRACT, trades, market="US", label="2016")
+
+    assert cell["win_rate"] == pytest.approx(0.2)
+    assert cell["wins"] == 2 and cell["losses"] == 8
+    assert cell["expectancy_r"] > 0
+    dist = cell["distribution"]
+    assert dist["median"] < 0 < dist["max"]
+    assert dist["p90"] > 0
+    assert dist["mean_win"] > 0 > dist["mean_loss"]
+
+
+def test_the_same_win_rate_with_a_thin_tail_is_a_different_result(store):
+    """The distribution is what separates the two, and only one of them is a
+    method worth trading — which is why the win rate is never reported alone."""
+    fat = [_mtrade(f"L{i}", 2016, -1.0) for i in range(8)]
+    fat += [_mtrade(f"W{i}", 2016, 8.0) for i in range(2)]
+    thin = [_mtrade(f"L{i}", 2016, -1.0) for i in range(8)]
+    thin += [_mtrade(f"W{i}", 2016, 1.2) for i in range(2)]
+
+    fat_cell = expectancy_cell(DEFAULT_CONTRACT, fat, market="US", label="2016")
+    thin_cell = expectancy_cell(DEFAULT_CONTRACT, thin, market="US", label="2016")
+
+    assert fat_cell["win_rate"] == thin_cell["win_rate"]
+    assert fat_cell["expectancy_r"] > 0 > thin_cell["expectancy_r"]
+    assert fat_cell["distribution"]["max"] > thin_cell["distribution"]["max"]
+
+
+def test_the_2020_21_excluded_figure_is_reported_beside_the_full_window_one(store):
+    """That tape rewarded momentum nearly everywhere, so it cannot carry the
+    conclusion alone — and the way to stop it is to print both figures together."""
+    trades = [_mtrade("AAA", 2016, -0.5), _mtrade("BBB", 2020, 6.0)]
+
+    body = market_report(DEFAULT_CONTRACT, trades, market="US")
+
+    windows = {w["label"]: w for w in body["windows"]}
+    assert set(windows) == {FULL_WINDOW, EXCLUDED_YEARS_WINDOW}
+    assert EXCLUDED_YEARS == (2020, 2021)
+    assert windows[EXCLUDED_YEARS_WINDOW]["excluded_years"] == list(EXCLUDED_YEARS)
+    # The mania year carried the full-window figure, and dropping it flips the sign.
+    assert windows[FULL_WINDOW]["expectancy_r"] > 0
+    assert windows[EXCLUDED_YEARS_WINDOW]["expectancy_r"] < 0
+    assert windows[EXCLUDED_YEARS_WINDOW]["closed"] == 1
+
+
+def test_a_market_is_never_reported_pooled_only(store):
+    """Per year always, in the payload and on the printed page both.
+
+    A pooled fourteen-year number over a window holding a crash and a mania
+    describes neither, so a reader must not be able to reach one without the years
+    beside it.
+    """
+    trades = [_mtrade("AAA", 2016, 1.0), _mtrade("BBB", 2020, -1.0)]
+
+    body = market_report(DEFAULT_CONTRACT, trades, market="US")
+
+    years = [y["label"] for y in body["years"]]
+    assert years == [str(y) for y in range(2016, 2021)]
+    printed = format_metric(metric_report(DEFAULT_CONTRACT, trades))
+    for label in years:
+        assert label in printed
+
+
+def test_a_year_inside_the_span_with_no_trades_reports_zero_rather_than_vanishing(store):
+    """A quiet year is a measurement; a missing year is a gap in the report.
+
+    Absent rows collapse the two into the same output, and the years between the
+    first and last trade are exactly where a data hole would hide.
+    """
+    trades = [_mtrade("AAA", 2016, 1.0), _mtrade("BBB", 2019, 1.0)]
+
+    body = market_report(DEFAULT_CONTRACT, trades, market="US")
+
+    quiet = {y["label"]: y for y in body["years"]}["2017"]
+    assert (quiet["trades"], quiet["closed"]) == (0, 0)
+    assert quiet["expectancy_r"] is None
+    assert quiet["win_rate"] is None
+
+
+def test_us_and_idx_are_reported_separately_including_in_the_summary(store):
+    """findings §8 measured that magnitudes do not transfer, so an average across
+    the two markets is a number about neither."""
+    trades = [
+        _mtrade("AAA", 2016, 2.0, market="US"),
+        _mtrade("BBB", 2016, -1.0, market="IDX"),
+    ]
+
+    report = metric_report(DEFAULT_CONTRACT, trades)
+
+    markets = {m["market"]: m for m in report["markets"]}
+    assert set(markets) == {"US", "IDX"}
+    us = {w["label"]: w for w in markets["US"]["windows"]}[FULL_WINDOW]
+    idx = {w["label"]: w for w in markets["IDX"]["windows"]}[FULL_WINDOW]
+    assert us["expectancy_r"] > 0 > idx["expectancy_r"]
+    # And nothing anywhere in the payload pools them.
+    assert "expectancy_r" not in report
+    printed = format_metric(report)
+    assert "US" in printed and "IDX" in printed
+
+
+def test_a_cell_that_spans_two_markets_is_refused(store):
+    """The separation is enforced where the arithmetic happens, not remembered at
+    the call site — a mean across two markets is the exact figure story 4 forbids,
+    and it has no shape that would make it visible afterwards."""
+    trades = [
+        _mtrade("AAA", 2016, 1.0, market="US"),
+        _mtrade("BBB", 2016, 1.0, market="IDX"),
+    ]
+    with pytest.raises(ValueError):
+        expectancy_cell(DEFAULT_CONTRACT, trades, market="US", label="2016")
+
+
+def test_a_cell_that_spans_two_arms_is_refused(store):
+    """The pre-registered metric is arm B's. Averaging an arm A trade into it
+    would report a number no arm produced, under arm B's name."""
+    trades = [
+        _mtrade("AAA", 2016, 1.0),
+        _mtrade("BBB", 2016, 1.0, arm=ARM_A),
+    ]
+    with pytest.raises(ValueError):
+        expectancy_cell(DEFAULT_CONTRACT, trades, market="US", label="2016")
+
+
+def test_significance_is_bootstrapped_clustered_by_symbol_not_by_row(store):
+    """A stock throwing twenty signals is not twenty independent observations.
+
+    One hot name at +3R twenty times over, against twenty different names at −1R
+    each. Resampling *rows* treats the hot name's run as forty independent draws
+    and returns a tight interval and a tiny p-value; resampling *symbols* asks the
+    question that was actually asked — would another market have thrown up that
+    name at all — and the interval widens accordingly.
+    """
+    trades = [_mtrade("HOT", 2016, 3.0, month=1 + i % 12) for i in range(20)]
+    trades += [_mtrade(f"C{i}", 2016, -1.0) for i in range(20)]
+
+    by_symbol = bootstrap_expectancy(clusters_by_symbol(trades, DEFAULT_CONTRACT))
+    by_row = bootstrap_expectancy(
+        [(after_cost_r(t, DEFAULT_CONTRACT),) for t in trades], cluster="row"
+    )
+
+    assert by_symbol["cluster"] == BOOTSTRAP_CLUSTER == "symbol"
+    assert by_symbol["clusters"] == 21
+    assert by_row["clusters"] == 40
+    widened = (by_symbol["ci_high"] - by_symbol["ci_low"]) > (
+        by_row["ci_high"] - by_row["ci_low"]
+    )
+    assert widened
+    # And the flattering p-value is exactly what row-counting buys.
+    assert by_symbol["p_value"] > by_row["p_value"]
+
+
+def test_the_bootstrap_is_deterministic_under_its_seed(store):
+    """A significance figure that moved between two runs of the same data would
+    make every result unreproducible, and nothing in the output would show it."""
+    trades = [_mtrade(f"S{i}", 2016, 1.0 if i % 3 else -1.0) for i in range(30)]
+    clusters = clusters_by_symbol(trades, DEFAULT_CONTRACT)
+
+    first = bootstrap_expectancy(clusters)
+    second = bootstrap_expectancy(clusters)
+
+    assert first == second
+    assert first["resamples"] == BOOTSTRAP_RESAMPLES
+    assert first["seed"] == BOOTSTRAP_SEED
+    # And it rides on every cell rather than being computed on request.
+    cell = expectancy_cell(DEFAULT_CONTRACT, trades, market="US", label="2016")
+    assert cell["bootstrap"]["clusters"] == 30
+
+
+def test_an_open_trade_has_no_r_and_is_counted_rather_than_marked_to_market(store):
+    """Closing a running trade at the last close would invent an exit the rules
+    never gave — systematically, for every name still running at the end of the
+    window. So it is excluded from the expectancy and reported as open."""
+    trades = [_mtrade("AAA", 2016, 1.0), _mtrade("BBB", 2016, 5.0, open_at_end=True)]
+
+    cell = expectancy_cell(DEFAULT_CONTRACT, trades, market="US", label="2016")
+
+    assert (cell["trades"], cell["closed"], cell["open_at_end"]) == (2, 1, 1)
+    assert cell["expectancy_r"] == pytest.approx(
+        after_cost_r(trades[0], DEFAULT_CONTRACT)
+    )
+
+
+def test_the_price_scale_dropped_count_travels_with_every_cell(store):
+    """The flag's whole purpose is to make the comparisons that are *not*
+    rescale-immune visible, so its count rides beside every figure derived from
+    the trades it flags — never in a commit message."""
+    trades = [
+        _mtrade("AAA", 2016, 1.0),
+        _mtrade("BBB", 2016, 1.0, price_scale_ok=False),
+    ]
+
+    body = market_report(DEFAULT_CONTRACT, trades, market="US")
+
+    window = {w["label"]: w for w in body["windows"]}[FULL_WINDOW]
+    assert window["price_scale_dropped"] == 1
+    assert {y["label"]: y for y in body["years"]}["2016"]["price_scale_dropped"] == 1
+    # Flagged, never silently dropped: both trades are still in the expectancy.
+    assert window["closed"] == 2
+
+
+def test_the_metric_is_recorded_before_any_swept_variant_exists(store):
+    """Every threshold tried is a test, and enough of them produce a winner from
+    noise. So the headline is computed and recorded first, and the report says so
+    with the count of variants that stood behind it — zero, here, because none
+    exists yet."""
+    report = metric_report(DEFAULT_CONTRACT, [_mtrade("AAA", 2016, 1.0)])
+
+    assert report["pre_registered"] is True
+    assert report["sweep"]["variants_tried"] == 0
+    assert "before" in report["sweep"]["note"]
+
+
+def test_the_metric_report_is_stamped_with_the_contract(store):
+    """Like every other figure the package emits: two runs under different
+    contracts are distinguishable from their serialised output alone."""
+    report = metric_report(DEFAULT_CONTRACT, [_mtrade("AAA", 2016, 1.0)])
+
+    assert report[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
+    assert json.loads(json.dumps(report)) == report
+
+
+def test_the_metric_runs_off_the_simulator_end_to_end(store):
+    """The seam that matters: trades the simulator produced, priced and measured.
+
+    Every other test here authors its trades so the arithmetic is checkable; this
+    one proves the two phases actually join, and that the headline the run reports
+    is arm B's own trade after the contract's costs.
+    """
+    bars = _sim_bars()
+    det = _sim_detection(bars)
+    trade = simulate_arm_b(bars, det, market="US", contract=DEFAULT_CONTRACT)
+
+    report = metric_report(DEFAULT_CONTRACT, [trade])
+
+    body = {m["market"]: m for m in report["markets"]}["US"]
+    window = {w["label"]: w for w in body["windows"]}[FULL_WINDOW]
+    assert window["closed"] == 1
+    assert window["expectancy_r"] == pytest.approx(
+        trade.r_multiple - cost_r(trade, DEFAULT_CONTRACT)
+    )
+    assert [y["label"] for y in body["years"]] == [str(trade.entry.session.year)]


### PR DESCRIPTION
Closes #191.

Phase 5's pre-registered cell: **arm B's after-cost expectancy in R, per market per year** — the one metric the run promised in advance, computed and recorded before any swept variant exists.

`backtest.metric` reads no bars. The simulator already denominates every trade in R, so this module is arithmetic over those trades, which is why the seam tests author their trades directly and every figure is checkable by hand.

## The metric

**Costs** are the contract's own `costs.per_market` cell, charged on both sides: bps of the traded price on the entry once for the whole position, and on every exit leg weighted by its share — so arm A's two legs pay twice on halves rather than once on a whole. Divided by the trade's own stop width, which keeps the cost in R and immune to Yahoo's unlabelled retroactive rescale for the same reason `r_multiple` is. A market the cell does not price raises `ContractDrift`, never a free trade: an unpriced market defaulting to zero would report the most flattering expectancy in the run and would look like a clean result.

**The win rate never travels alone.** 22.7% of his trades made money and his mean R was positive anyway, so a 20% win rate is not a broken method — a 20% win rate with a small right tail is. Every cell carries the win rate and the R-distribution behind its expectancy, and two fixtures with the same win rate and different tails are required to read differently in the output.

**Never pooled only.** Per year always, and the 2020–21-excluded figure beside the full-window one, because that tape rewarded momentum nearly everywhere and the window also holds a crash. The year span is anchored at the contract's `window.measured_start` rather than at the first trade, so a market silent until 2016 in a run measuring from 2012 shows four silent years instead of hiding them.

**US and IDX never pool**, and it is enforced where the arithmetic happens rather than remembered at the call site — `expectancy_cell` refuses a cohort spanning two markets, and there is deliberately no top-level expectancy for a reader to quote.

**Significance resamples symbols, not rows.** A stock throwing three signals in a fortnight contributes three correlated rows, and counting them as three independent observations flatters every p-value. The seam test runs the same data both ways — one hot name at +3R twenty times against twenty names at −1R — and requires the symbol-clustered interval to widen and its p-value to rise. That widening is the correction.

## Acceptance criteria

- [x] Arm B's after-cost expectancy in R reported per market per year, never pooled only
- [x] Commission and slippage applied per market from the contract
- [x] The win rate and R-distribution behind the expectancy reported
- [x] The 2020–21-excluded figure reported beside the full-window figure
- [x] Significance bootstrapped clustered by symbol, not by row
- [x] The pre-registered metric present before any sweep is available
- [x] US and IDX reported separately throughout, including in the summary

## What the review caught

Two of the four defects would have produced believable output:

- **The headline could be stamped over another arm's trades.** `arm` was a free parameter while only the metric's *name* was guarded, so arm A's result could carry arm B's pre-registered name. The arm is no longer a parameter anywhere in the module.
- **A one-symbol cell printed a zero-width interval at p = 0.** A resample can only draw the clusters it has, so one symbol resampled 2,000 times returns its own mean 2,000 times — which reads as overwhelming significance from one independent observation. Below five symbols no interval is computed and the cell says why, in the place a reader looks for it. Per-year cells are exactly where cluster counts go thin.

Also fixed: a silent year at the start of the measured window vanished, and a closed trade with a non-positive stop width was counted as still open.

## No numbers yet

This lands the metric, not a result. The 2012-onward denominator has never been run — `data/` holds the bar store from #187 and nothing downstream — so `references/` gains no result file. The command is ready:

```
python -m backtest.metric --store data/backtest.duckdb --out-json references/backtest_primary_metric.json
```

Two related gaps, both out of scope here and worth their own issues: the kill criterion (PRD story 42) is computed nowhere, and after-cost figures for arms A and C (story 90) do not exist — #191 scopes to arm B.

## Testing

Full backend suite: **747 passed**, including #193's tests merged in. 23 new tests under `# -- the pre-registered headline metric (issue #191)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Xrn5r8BPbuSQ36qkR797G
