### PR TITLE
Does the rubric rank, out of sample? (#194)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -528,8 +528,36 @@ in one name are not independent observations — a stock throwing three signals 
 fortnight contributes three correlated rows — so bootstrapping *rows* makes the effective
 sample larger than it is and flatters every p-value. Seeded, and the seed and resample
 count ride on every cell, because a significance figure that moved between two runs of the
-same data would be unreproducible with nothing in the output to show it.
+same data would be unreproducible with nothing in the output to show it. A statistic that is
+not a mean — a **score band** gap, a rank correlation — is resampled the same way through
+`backtest.ranking.bootstrap_symbol_statistic`, on the metric's own seed and cluster floor, so
+two intervals in one report were never built differently.
 _Avoid_: bootstrapping the trades, resampling the rows — the row is not the unit.
+
+**Score band**:
+One bucket of the **out-of-sample ranking test**'s cut (`backtest.ranking.Band`): a
+contiguous run of star scores, and the decile positions it covers. A score value is
+**atomic** — it never splits across two bands — because the replayed score is seven
+dimensions of eight *integral* points, so a distribution most of which sits on one score has
+no tenth to cut at, and splitting one would report a difference between two buckets that is a
+difference in sort order and nothing else. The bands therefore **collapse to fewer than ten**
+and each says which deciles it swallowed. Cut **once on a market's whole measured window** and
+applied to every year, so a band names the same score in every row.
+_Avoid_: decile bucket on its own — there are rarely ten of them; score quintile.
+
+**Out-of-sample ranking test**:
+The measurement of whether a higher star score predicts a better result (PRD #182 story 93,
+`backtest.ranking`): outcomes bucketed by **score band**, per market and per year, with n on
+every bucket and the **clustered bootstrap** on both the top-minus-bottom gap and Spearman's
+rho. The verdict needs **both** intervals above zero — a gap can rest on one hot name at the
+top and a rho can be positive and negligible — and "no evidence it ranks" is never "the score
+does not rank". It is **not** findings §4a: that measured a rate of scores between his picks
+and the field, on the field v2's weights had been *fitted* to, at p = 0.055; this measures
+after-cost R by score band on trades nobody selected, so the outcome variable is independent
+of the weights. §4a's figures ride on the payload precisely so the two are never lined up as
+one.
+_Avoid_: the ranking result, the decile test; and never quote it against §4a's **+5.59pp**
+as though the two were comparable.
 
 **Not-taken detection**:
 A member of the replayed field on a session where he entered something else. Not a

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -535,15 +535,28 @@ two intervals in one report were never built differently.
 _Avoid_: bootstrapping the trades, resampling the rows — the row is not the unit.
 
 **Score band**:
-One bucket of the **out-of-sample ranking test**'s cut (`backtest.ranking.Band`): a
-contiguous run of star scores, and the decile positions it covers. A score value is
-**atomic** — it never splits across two bands — because the replayed score is seven
-dimensions of eight *integral* points, so a distribution most of which sits on one score has
-no tenth to cut at, and splitting one would report a difference between two buckets that is a
-difference in sort order and nothing else. The bands therefore **collapse to fewer than ten**
-and each says which deciles it swallowed. Cut **once on a market's whole measured window** and
-applied to every year, so a band names the same score in every row.
-_Avoid_: decile bucket on its own — there are rarely ten of them; score quintile.
+A contiguous run of star scores in the **out-of-sample ranking test**'s cut
+(`backtest.ranking.Band`), and the decile positions it covers. A score value is **atomic** —
+it never splits across two bands — because the replayed score is seven dimensions of eight
+*integral* points, so a distribution most of which sits on one score has no tenth to cut at,
+and splitting one would report a difference between two bands that is a difference in sort
+order and nothing else. The bands therefore **collapse to fewer than ten**, they **partition
+all ten decile positions** between them, and each says which ones fell inside it. Cut **once
+on a market's whole measured window** and over its **closed** trades only, then applied to
+every year — so a band names the same score in every row, and a trade still running never
+moved a boundary the measured population is read against.
+_Avoid_: score quintile; and do not call a band a **bucket** — the band is the score range,
+the bucket is that range *with the outcomes in it*.
+
+**Bucket**:
+One reported row of the **out-of-sample ranking test**: a **score band** together with the
+outcomes that landed in it — n taken, n closed, symbols, after-cost expectancy, win rate,
+R-distribution and clustered interval, in the same shape a **pre-registered metric** cell
+reports. A trade the cut holds no band for is counted in `outside_the_cut` rather than filed
+under the nearest edge, which would be a mislabel, or dropped, which would leave the buckets
+summing to less than the field. Only an **open** trade can be one, since the cut is taken over
+the closed ones.
+_Avoid_: decile bucket on its own — there are rarely ten of them.
 
 **Out-of-sample ranking test**:
 The measurement of whether a higher star score predicts a better result (PRD #182 story 93,

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -101,6 +101,25 @@ already keep :mod:`backtest.simulate` out: it is a command
 documented command warn on every invocation. The entry point is
 ``backtest.metric.metric_report``.
 
+Issue #194 lands Phase 5's ranking cell: :mod:`backtest.ranking`, the out-of-sample
+test §4a's claim has never had. Outcomes bucketed by star-score decile, per market
+and per year, with n on every bucket and significance bootstrapped clustered by
+symbol. §4a asked whether the rubric separates his *picks* from the field, on the
+field the v2 weights had been fitted to — a fit statistic, and marginal at
+p = 0.055 even so. Here the outcome variable is R after costs, which no weight was
+fitted to and no detection's score could see, so §4a's figures ride on the payload
+with the reason they are not comparable rather than being left for a reader to line
+up. The score is coarse — seven dimensions of eight integral points — so a score
+value is never split across two buckets: the buckets collapse to fewer than ten and
+each names the decile positions it covers, which is the honest reading of a
+distribution most of which can sit on one score.
+
+:mod:`backtest.ranking`'s names are **not** re-exported here, for the reasons that
+already keep :mod:`backtest.metric` out: it is a command
+(``python -m backtest.ranking``) and it imports both that module and
+:class:`~backtest.run.ContractDrift`. The entry point is
+``backtest.ranking.ranking_report``.
+
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean
 something else one import away (:mod:`screener.universe`, :mod:`replay.reference`),

--- a/backend/backtest/metric.py
+++ b/backend/backtest/metric.py
@@ -220,6 +220,36 @@ def check_costs(contract: RunContract, market: str) -> None:
             )
 
 
+def check_one_market_one_arm(
+    trades: Sequence[SimulatedTrade], *, market: str, what: str
+) -> None:
+    """Refuse a cohort spanning two markets or two arms, whatever is measuring it.
+
+    Both refusals exist because neither failure has a shape a reader could catch
+    afterwards. A mean across the two markets is the figure findings §8 forbids —
+    magnitudes do not transfer — and it would print as an ordinary number. A mean
+    across two arms would report a figure no arm produced, under the name of the
+    one the run pre-registered.
+
+    ``what`` names the caller in the message, because the same refusal now guards
+    two different measurements (:func:`expectancy_cell` and the ranking's cohort)
+    and "one market's" is unhelpful when a reader cannot tell which one refused.
+    """
+    foreign = {t.market for t in trades} - {market}
+    if foreign:
+        raise ValueError(
+            f"{what} is one market's: {market!r} was asked for and "
+            f"{sorted(foreign)} arrived too; US and IDX never pool"
+        )
+    other_arms = {t.arm for t in trades} - {PRIMARY_ARM}
+    if other_arms:
+        raise ValueError(
+            f"{what} is measured on arm {PRIMARY_ARM}, the pre-registered arm: "
+            f"{sorted(other_arms)} arrived too, and no arm produced the average "
+            "of them"
+        )
+
+
 def per_side_cost_bps(contract: RunContract, market: str) -> float:
     """Commission plus slippage for one side of a trade in ``market``, in bps.
 
@@ -448,19 +478,7 @@ def expectancy_cell(
     same output as a slice nobody computed.
     """
     check_costs(contract, market)
-    foreign = {t.market for t in trades} - {market}
-    if foreign:
-        raise ValueError(
-            f"an expectancy cell is one market's: {market!r} was asked for and "
-            f"{sorted(foreign)} arrived too; US and IDX never pool"
-        )
-    other_arms = {t.arm for t in trades} - {PRIMARY_ARM}
-    if other_arms:
-        raise ValueError(
-            f"the pre-registered metric is arm {PRIMARY_ARM}'s: "
-            f"{sorted(other_arms)} arrived too, and no arm produced the average "
-            "of them"
-        )
+    check_one_market_one_arm(trades, market=market, what="an expectancy cell")
 
     closed = [t for t in trades if t.r_multiple is not None]
     rs = [after_cost_r(t, contract) for t in closed]

--- a/backend/backtest/metric.py
+++ b/backend/backtest/metric.py
@@ -292,8 +292,13 @@ def clusters_by_symbol(
     return [tuple(grouped[symbol]) for symbol in sorted(grouped)]
 
 
-def _quantile(values: Sequence[float], q: float) -> float:
-    """The ``q``-quantile of already-sorted ``values``, linearly interpolated."""
+def quantile(values: Sequence[float], q: float) -> float:
+    """The ``q``-quantile of already-sorted ``values``, linearly interpolated.
+
+    Public because :mod:`backtest.ranking`'s bootstrap builds its interval the
+    same way: two percentile conventions in one report would make two intervals
+    incomparable while both printed as 95%.
+    """
     if len(values) == 1:
         return values[0]
     pos = q * (len(values) - 1)
@@ -373,8 +378,8 @@ def bootstrap_expectancy(
     tail = (1.0 - confidence) / 2.0
     return {
         **body,
-        "ci_low": _quantile(means, tail),
-        "ci_high": _quantile(means, 1.0 - tail),
+        "ci_low": quantile(means, tail),
+        "ci_high": quantile(means, 1.0 - tail),
         "p_value": sum(1 for m in means if m <= 0.0) / len(means),
     }
 
@@ -409,7 +414,7 @@ def _distribution(rs: Sequence[float]) -> dict[str, Any]:
     losses = [r for r in ordered if r <= 0]
     return {
         "min": ordered[0],
-        **{name: _quantile(ordered, q) for name, q in _QUANTILES},
+        **{name: quantile(ordered, q) for name, q in _QUANTILES},
         "max": ordered[-1],
         "mean_win": sum(wins) / len(wins) if wins else None,
         "mean_loss": sum(losses) / len(losses) if losses else None,
@@ -506,8 +511,15 @@ def _reported_markets(
     return tuple(asked) if asked else tuple(contract.value(SCOPE_MARKETS_KEY))
 
 
-def _years(contract: RunContract, trades: Sequence[SimulatedTrade]) -> list[int]:
+def measured_years(
+    contract: RunContract, trades: Sequence[SimulatedTrade]
+) -> list[int]:
     """Every year of the measured window that this market could have traded in.
+
+    Public rather than private because :mod:`backtest.ranking` reports per year
+    too, and two implementations of "which years does this market get a row for"
+    would be two places for a silent year to go missing from one report and not
+    the other.
 
     The span rather than the years present: a year with no trade is a measurement —
     possibly a data hole — and an absent row reads as a quiet market until somebody
@@ -577,7 +589,7 @@ def market_report(
                 market=market,
                 label=str(year),
             )
-            for year in _years(contract, mine)
+            for year in measured_years(contract, mine)
         ],
         "windows": [
             expectancy_cell(contract, mine, market=market, label=FULL_WINDOW),

--- a/backend/backtest/ranking.py
+++ b/backend/backtest/ranking.py
@@ -1,0 +1,1003 @@
+"""Does the rubric rank, out of sample? (issue #194, PRD #182 Phase 5).
+
+Outcomes bucketed by star-score decile, per market and per year, with n on every
+bucket and significance bootstrapped clustered by symbol. The question is the one
+findings §4a raised and could not answer: **does a higher score actually predict a
+better result?**
+
+Why this is not §4a again
+-------------------------
+§4a measured whether the star score separates the trader's *picks* from the field
+— his 104 in-field trades against 14,239 detections — and found his picks at
+≥3.5★ at 1.63× the field's rate — a gap of **+5.59pp**, at an exact-binomial
+**p = 0.055**.
+It refused to read that as "the rubric ranks", for a reason that is structural
+rather than a caveat: the v2 weights were derived from the selection contrast on
+*that* field, and A2 then asked whether they reproduced the separation they had
+been fitted to. A rubric fitted to a separation will reproduce it. That is a fit
+statistic, and it was marginal even so.
+
+Here the outcome variable is **R** — what the trade actually paid, mechanically,
+under the contract's own entry, stop and exit. No weight was fitted to it, no
+detection's score could see it, and the trades are ones the trader never took over
+a window his record does not cover. That independence is the whole point of the
+measurement, so §4a's figures ride on the payload (:data:`IN_SAMPLE_GAP`) with the
+reason they are not comparable rather than being left for a reader to line up. The
+two are also different *shapes*: §4a compares a rate of scores between two
+populations, this compares a mean outcome between score bands of one.
+
+Deciles of a coarse score, and why a tie never splits
+-----------------------------------------------------
+The replayed score is **seven dimensions of eight integral points** — the app's
+nine minus the struck ``Sector`` row (findings §1) — so its distribution takes at
+most nine values and true deciles do not exist. Cutting them anyway would put two
+trades scoring identically into different buckets and then report the difference
+between those buckets, which would be a difference in sort order and nothing else.
+
+So a score value is **atomic**: :func:`bands` walks the scores upward, closes a
+bucket when the cumulative share crosses a decile boundary, and never splits a
+value across two. The buckets therefore collapse to fewer than ten, and each one
+names the decile positions it covers — a band spanning deciles 1–8 says so, which
+is the honest reading of a distribution 80% of which sits on one score.
+
+The cut is made **once per market on the whole measured window** and every year is
+reported against it. Cutting per year would make "the top bucket" a different score
+band in every row, so a year-on-year comparison would be a comparison of two
+different questions.
+
+What is reported, and what the verdict rule is
+----------------------------------------------
+Three things, because one of them alone would mislead:
+
+* **Every bucket's after-cost expectancy**, with its n, its symbol count and its
+  clustered interval — a monotone ladder is visible here and nowhere else.
+* **The gap**, top band minus bottom band. The sharpest statement of the claim.
+* **The rank correlation** (Spearman's rho, ties averaged) over the whole cohort,
+  which the gap cannot give: a rubric whose extremes separate while its middle is
+  noise is a different finding from one that ranks throughout.
+
+:data:`VERDICT_RULE` reads the verdict off both, and requires both to agree.
+Neither alone is enough: a gap can be carried by one hot name at the top, and a rho
+can be positive and tiny. A cohort whose top or bottom band is too thin to
+bootstrap gets :data:`VERDICT_TOO_THIN` rather than a number, because the gap is
+computed *between* those two bands and an interval on a single-symbol band prints
+certainty it has not earned.
+
+Costs, arms and clustering are the metric's
+-------------------------------------------
+Nothing here re-implements arithmetic :mod:`backtest.metric` already owns. The
+after-cost R of a trade, the per-market costs, the cell shape behind every bucket
+(win rate, R-distribution, clustered interval) and the year span are all called
+from that module, so the ranking and the headline cannot disagree about what a
+trade paid. The arm is :data:`~backtest.metric.PRIMARY_ARM` for the same reason:
+the pre-registered metric is arm B's, and bucketing arm A's trades under the same
+banner would report a ranking of a result no headline names.
+
+The one piece of arithmetic that is new is the bootstrap over an arbitrary
+*statistic* (:func:`bootstrap_symbol_statistic`). The metric's bootstrap resamples
+clusters and takes their pooled **mean**, which cannot express a gap between two
+bands or a rank correlation — those need the whole resampled cohort, not a list of
+numbers. It resamples the same unit, by symbol, for the same reason: a stock
+throwing three signals in a fortnight contributes three correlated rows, and
+resampling rows would count them as three independent observations and flatter
+every p-value.
+
+What this measurement does not do
+---------------------------------
+It does not fire or clear the kill criterion — that is the pre-registered metric's
+(:mod:`backtest.metric`), and the contract's ``decision.kill`` cell draws the line.
+This is the measurement that says what a *fired* kill criterion leaves standing:
+whether the app's claim reduces to **ranking what a human selects** rather than
+selecting on its own. And it is one more view of a dataset that already had nine
+before any threshold was swept (:data:`MULTIPLE_TESTING_NOTE`), pre-specified by
+#194 rather than chosen after the fact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from replay.field import SEVEN_DIM_LABEL, SEVEN_DIM_MAX_POINTS, SevenDimScore
+from screener.score import DIMENSIONS
+from screener.store import Store
+
+from .contract import DEFAULT_CONTRACT, SCOPE_MARKETS_KEY, RunContract
+from .denominator import DenominatorStore, denominator_path
+from .metric import (
+    BOOTSTRAP_CLUSTER,
+    BOOTSTRAP_CONFIDENCE,
+    BOOTSTRAP_MIN_CLUSTERS,
+    BOOTSTRAP_RESAMPLES,
+    BOOTSTRAP_SEED,
+    PRIMARY_ARM,
+    after_cost_r,
+    check_costs,
+    expectancy_cell,
+    measured_years,
+    quantile,
+)
+from .result import stamp_result
+from .run import ContractDrift
+from .simulate import SimulatedTrade, simulate_market
+
+# -- the score these buckets are cut on ---------------------------------------
+
+# The replayed score, named on every output. Seven dimensions of eight points: the
+# app's nine minus the struck ``Sector`` row, which the store cannot recover
+# because the labels table carries no history (findings §1, PRD "Out of Scope").
+SCORE_LABEL = SEVEN_DIM_LABEL
+SCORE_DIMENSIONS = 7
+SCORE_MAX_POINTS = SEVEN_DIM_MAX_POINTS
+SCORE_MAX_STARS = SCORE_MAX_POINTS / 2
+
+# The app's own ceiling, derived from the live weight table rather than typed, so a
+# weight change moves it here too. Carried beside the replayed one because ≥3.5★
+# is 7 of 8 on this scale and 7 of 9 on the app's, and a band read off the wrong
+# ceiling mislabels every bucket in the report.
+APP_MAX_POINTS = sum(weight for _, weight in DIMENSIONS)
+
+SCORE_NOTE = (
+    f"the {SCORE_LABEL} — {SCORE_DIMENSIONS} dimensions of {SCORE_MAX_POINTS} "
+    f"points, ceiling {SCORE_MAX_STARS:.1f}★ — and not the app's "
+    f"{APP_MAX_POINTS}-point score: the replay strikes Sector, so a band here is "
+    "one dimension short of the one the product prints"
+)
+
+
+def check_seven_dimension_score(score: SevenDimScore) -> None:
+    """Refuse a score that is not the seven-dimension replayed one.
+
+    A nine-point row arriving here means the field was scored by something other
+    than :func:`replay.field.seven_dimension_score`, and reading it as a
+    seven-dimension one would silently re-base every band — 6 points is 3.0★ on
+    one scale and 3.0★ on the other while meaning a different sixth of the rubric.
+    A mislabelled band is invisible in the output, so it is refused at the door.
+    """
+    if score.max_points != SCORE_MAX_POINTS or score.label != SCORE_LABEL:
+        raise ContractDrift(
+            f"a bucket is cut on the {SCORE_LABEL} out of {SCORE_MAX_POINTS} "
+            f"points; {score.label!r} out of {score.max_points} arrived, and "
+            "reading one as the other re-bases every band"
+        )
+
+
+# -- §4a, carried so the two measurements are never conflated ------------------
+
+# The in-sample figure this measurement exists to replace, quoted from
+# `references/qullamaggie-replay-findings.md` §4a rather than recomputed. It rides
+# on the payload because the danger is not that a reader disbelieves §4a — it is
+# that a reader lines the two gaps up as though they answered the same question.
+IN_SAMPLE_GAP: dict[str, Any] = {
+    "source": "findings §4a — the paired A2 re-run (#136), under rubric v2",
+    "measure": "share of scores at >= 3.5 stars, his picks against the field",
+    "picks_rate": 0.1442,
+    "picks_n": 104,
+    "field_rate": 0.0883,
+    "field_n": 14239,
+    "gap_pp": 5.59,
+    "p_value": 0.055,
+    "test": "exact binomial",
+    "why_it_is_not_this_measurement": (
+        "in-sample by construction: v2's weights were fitted to the selection "
+        "contrast on that same field, so A2 asked whether they reproduced a "
+        "separation they had been built from — a fit statistic, and marginal at "
+        "p = 0.055 even so. It also measures a different thing: a rate of scores "
+        "between his picks and the field, where this measures the outcome R paid "
+        "by score band, on trades nobody selected"
+    ),
+}
+
+OUT_OF_SAMPLE_NOTE = (
+    "the outcome variable here is R after costs, which no weight was fitted to "
+    "and no detection's score could see; the field is taken mechanically over a "
+    "window his record does not cover"
+)
+
+# Story 100: three exit arms and three regime states are nine views of one dataset
+# before any threshold is swept, and this is another. Stated on the output rather
+# than in this docstring, because a multiple-testing budget a reader cannot see is
+# a budget nobody is keeping.
+MULTIPLE_TESTING_NOTE = (
+    "one more view of a dataset that already carried nine before any sweep; "
+    "pre-specified by #194 and computed once, not chosen after the fact"
+)
+
+# What a fired kill criterion leaves standing. The criterion itself is the
+# pre-registered metric's (``decision.kill``), and nothing here fires it.
+KILL_CRITERION_NOTE = (
+    "this measurement does not fire or clear the kill criterion — that is the "
+    "pre-registered metric's. It is what decides, if the criterion fires, whether "
+    "the app's claim reduces to ranking what a human selects rather than "
+    "selecting on its own"
+)
+
+
+# -- the cut ------------------------------------------------------------------
+
+DECILES = 10
+
+
+@dataclass(frozen=True)
+class Band:
+    """One bucket of the cut: a contiguous run of scores, and the deciles it covers.
+
+    ``deciles`` is what makes the tie rule readable rather than merely correct. A
+    band holding 80% of the cohort covers deciles 1–8 and says so, so a reader sees
+    a collapsed distribution instead of a report that quietly has three buckets
+    where it promised ten.
+
+    ``low_points`` and ``high_points`` are inclusive and equal whenever the band is
+    a single score, which is the common case at the edges.
+    """
+
+    index: int
+    deciles: tuple[int, ...]
+    low_points: int
+    high_points: int
+
+    @property
+    def low_stars(self) -> float:
+        return self.low_points / 2
+
+    @property
+    def high_stars(self) -> float:
+        return self.high_points / 2
+
+    @property
+    def label(self) -> str:
+        """The band as a reader reads it — in stars, which is what the app prints."""
+        if self.low_points == self.high_points:
+            return f"{self.low_stars:.1f}★"
+        return f"{self.low_stars:.1f}–{self.high_stars:.1f}★"
+
+    def holds(self, points: int) -> bool:
+        return self.low_points <= points <= self.high_points
+
+
+@dataclass(frozen=True)
+class ScoredTrade:
+    """One simulated trade beside the score of the detection that produced it.
+
+    The two are joined rather than stored together because the simulator has no
+    business carrying a score — it takes an entry and an exit and knows nothing
+    about the rubric — and the denominator's detection row is where the score
+    already lives. :func:`scored_trades` performs the join and refuses a trade
+    whose score is missing.
+    """
+
+    trade: SimulatedTrade
+    score: SevenDimScore
+
+    @property
+    def symbol(self) -> str:
+        return self.trade.symbol
+
+    @property
+    def market(self) -> str:
+        return self.trade.market
+
+    @property
+    def points(self) -> int:
+        return self.score.points
+
+    @property
+    def year(self) -> int:
+        """The year of the **entry** session — the year the decision was taken.
+
+        The same attribution :mod:`backtest.metric` uses, and for the same reason:
+        attributing by exit would move a trade's year with the exit rule, which is
+        the one thing the arms vary.
+        """
+        return self.trade.entry.session.year
+
+
+def bands(cohort: Sequence[ScoredTrade], *, deciles: int = DECILES) -> tuple[Band, ...]:
+    """The cut: score bands in ascending order, no score split across two of them.
+
+    Walks the distinct scores upward, accumulating until the cumulative share
+    crosses the next decile boundary, then closes a band covering every decile
+    position it reached. A score that carries more than a tenth of the cohort
+    therefore swallows several deciles at once and the result has fewer than
+    ``deciles`` bands — which is a fact about an eight-point score, not a defect in
+    the cut.
+
+    A function of the score distribution alone, so shuffling the cohort moves
+    nothing: a cut that read arrival order would produce different buckets on a
+    re-run of the same data with nothing in the output to show it.
+    """
+    if not cohort:
+        return ()
+    counts = Counter(s.points for s in cohort)
+    total = sum(counts.values())
+    out: list[Band] = []
+    cumulative = 0
+    low: int | None = None
+    next_decile = 1
+    for points in sorted(counts):
+        low = points if low is None else low
+        cumulative += counts[points]
+        reached = min(deciles, cumulative * deciles // total)
+        if reached >= next_decile:
+            out.append(
+                Band(
+                    index=len(out) + 1,
+                    deciles=tuple(range(next_decile, reached + 1)),
+                    low_points=low,
+                    high_points=points,
+                )
+            )
+            next_decile = reached + 1
+            low = None
+    return tuple(out)
+
+
+# -- the rows the statistics run on -------------------------------------------
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """One closed trade reduced to what a statistic needs: its symbol, score and R.
+
+    A flat row rather than a :class:`ScoredTrade`, because the bootstrap resamples
+    tens of thousands of times and every statistic below reads exactly these three
+    fields. Costs are already applied — there is one place a trade becomes a
+    number, :func:`~backtest.metric.after_cost_r`, and this is where it is called.
+    """
+
+    symbol: str
+    points: int
+    r: float
+
+
+def outcomes(
+    cohort: Sequence[ScoredTrade], contract: RunContract
+) -> list[Outcome]:
+    """The cohort's **closed** trades as rows, after costs, in cohort order.
+
+    A trade still running has no R, and marking one to the last close would invent
+    an exit the rules never gave — systematically, for every name still open — so
+    it contributes to a bucket's ``trades`` count and to nothing else.
+    """
+    rows: list[Outcome] = []
+    for scored in cohort:
+        r = after_cost_r(scored.trade, contract)
+        if r is None:
+            continue
+        rows.append(Outcome(symbol=scored.symbol, points=scored.points, r=r))
+    return rows
+
+
+def symbol_clusters(
+    cohort: Sequence[ScoredTrade], contract: RunContract
+) -> list[tuple[Outcome, ...]]:
+    """The closed outcomes grouped one cluster per symbol, symbol order.
+
+    The unit of independence. Ordered by symbol so a resample under a fixed seed is
+    reproducible — clusters arriving in insertion order would move the interval
+    with the order the trades happened to be read in.
+    """
+    grouped: dict[str, list[Outcome]] = {}
+    for row in outcomes(cohort, contract):
+        grouped.setdefault(row.symbol, []).append(row)
+    return [tuple(grouped[symbol]) for symbol in sorted(grouped)]
+
+
+# -- the two statistics -------------------------------------------------------
+
+
+def top_minus_bottom(
+    rows: Sequence[Outcome], cut: Sequence[Band]
+) -> float | None:
+    """The gap: the top band's mean R minus the bottom band's, or ``None``.
+
+    ``None`` when either edge band is empty — which a resample can easily produce
+    — because a gap against a band nobody drew is not zero, it is undefined, and
+    the difference matters to every interval built on it.
+    """
+    if len(cut) < 2:
+        return None
+    top = [row.r for row in rows if cut[-1].holds(row.points)]
+    bottom = [row.r for row in rows if cut[0].holds(row.points)]
+    if not top or not bottom:
+        return None
+    return sum(top) / len(top) - sum(bottom) / len(bottom)
+
+
+def _ranks(values: Sequence[float]) -> list[float]:
+    """Fractional ranks, ties taking the average of the positions they occupy.
+
+    Ties are the common case on an eight-point score, so this is the whole of why
+    the correlation is meaningful here: breaking them by arrival order would make
+    rho a function of the sort.
+    """
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    out = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        average = (i + j) / 2 + 1
+        for k in range(i, j + 1):
+            out[order[k]] = average
+        i = j + 1
+    return out
+
+
+def rank_correlation(rows: Sequence[Outcome]) -> float | None:
+    """Spearman's rho between score and outcome — the whole-cohort ranking claim.
+
+    Reported beside the gap because the two can disagree, and the disagreement is
+    informative: a rubric whose extremes separate while its middle is noise is a
+    different finding from one that ranks throughout, and the gap alone cannot
+    tell them apart.
+
+    ``None`` when either side has no variance — one score, or every trade paying
+    the same. There is no correlation to report there, and a zero would read as
+    "measured and found nothing" rather than "not measurable".
+    """
+    if len(rows) < 2:
+        return None
+    x = _ranks([float(row.points) for row in rows])
+    y = _ranks([row.r for row in rows])
+    n = len(rows)
+    mx, my = sum(x) / n, sum(y) / n
+    dx = [a - mx for a in x]
+    dy = [b - my for b in y]
+    sx = sum(a * a for a in dx) ** 0.5
+    sy = sum(b * b for b in dy) ** 0.5
+    if sx == 0.0 or sy == 0.0:
+        return None
+    return sum(a * b for a, b in zip(dx, dy)) / (sx * sy)
+
+
+# -- the bootstrap, over a statistic rather than over a mean -------------------
+
+
+def bootstrap_symbol_statistic(
+    clusters: Sequence[Sequence[Outcome]],
+    statistic: Callable[[Sequence[Outcome]], float | None],
+    *,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+    seed: int = BOOTSTRAP_SEED,
+    confidence: float = BOOTSTRAP_CONFIDENCE,
+    cluster: str = BOOTSTRAP_CLUSTER,
+    min_clusters: int = BOOTSTRAP_MIN_CLUSTERS,
+) -> dict[str, Any]:
+    """A clustered bootstrap of an arbitrary statistic over the pooled rows.
+
+    :func:`~backtest.metric.bootstrap_expectancy` resamples the same unit and takes
+    the pooled **mean**; a gap between two bands and a rank correlation are not
+    means of anything, so they need the resampled cohort itself. Hence a second
+    entry point rather than a second bootstrap: the seed, the resample count, the
+    confidence level, the cluster floor and the reported fields are all the
+    metric's, so two intervals in one report can never have been built differently.
+
+    Each resample draws ``len(clusters)`` clusters **with replacement** and pools
+    every row inside them, so a symbol is in or out as a whole. ``p_value`` is
+    one-sided — the share of resampled statistics at or below zero — which is the
+    shape of the claim: the question is whether a higher score pays *more*, not
+    whether it pays differently.
+
+    A resample the statistic cannot evaluate (an empty edge band, no variance) is
+    counted under ``undefined`` and left out of the interval rather than defaulted
+    to zero, because a resample that could not answer is not a resample that
+    answered no. If every resample is undefined the interval is refused outright.
+
+    Below ``min_clusters`` no interval is reported at all, for the reason the
+    metric records: one symbol resampled two thousand times returns its own mean
+    two thousand times, which prints as a zero-width interval at p = 0 and is one
+    independent observation.
+    """
+
+    n = len(clusters)
+    pooled = [row for cluster_rows in clusters for row in cluster_rows]
+    body: dict[str, Any] = {
+        "cluster": cluster,
+        "clusters": n,
+        "observations": len(pooled),
+        "resamples": resamples,
+        "seed": seed,
+        "confidence": confidence,
+        "min_clusters": min_clusters,
+        "undefined": 0,
+        "suppressed": None,
+    }
+    empty = {**body, "ci_low": None, "ci_high": None, "p_value": None}
+    if n < min_clusters:
+        return {
+            **empty,
+            "suppressed": (
+                f"{n} {cluster}s is fewer than {min_clusters}: too thin for an "
+                "interval, and a degenerate one would read as significance"
+            ),
+        }
+
+    rng = random.Random(seed)
+    indices = range(n)
+    drawn_values: list[float] = []
+    undefined = 0
+    for _ in range(resamples):
+        drawn = [row for i in indices for row in clusters[rng.choice(indices)]]
+        value = statistic(drawn)
+        if value is None:
+            undefined += 1
+            continue
+        drawn_values.append(value)
+    if not drawn_values:
+        return {
+            **empty,
+            "undefined": undefined,
+            "suppressed": (
+                f"every resample was undefined over {n} {cluster}s: no interval "
+                "exists to report"
+            ),
+        }
+
+    drawn_values.sort()
+    tail = (1.0 - confidence) / 2.0
+    return {
+        **body,
+        "undefined": undefined,
+        "ci_low": quantile(drawn_values, tail),
+        "ci_high": quantile(drawn_values, 1.0 - tail),
+        "p_value": sum(1 for v in drawn_values if v <= 0.0) / len(drawn_values),
+    }
+
+
+# -- the verdict --------------------------------------------------------------
+
+VERDICT_RANKS = "ranks"
+VERDICT_NO_EVIDENCE = "no evidence it ranks"
+VERDICT_TOO_THIN = "too thin to say"
+
+VERDICT_RULE = (
+    "'ranks' requires the top-minus-bottom gap and Spearman's rho to have "
+    "symbol-clustered intervals both entirely above zero; either one alone is "
+    "'no evidence it ranks', because a gap can rest on one hot name at the top "
+    "and a rho can be positive and negligible. A cohort whose top or bottom band "
+    "is below the cluster floor is 'too thin to say' — the gap is computed "
+    "between those two bands. 'no evidence it ranks' is never 'the score does not "
+    "rank': one sample cannot license that"
+)
+
+
+def verdict(
+    *,
+    gap: dict[str, Any],
+    rho: dict[str, Any],
+    edges: Sequence[dict[str, Any]],
+) -> str:
+    """The verdict :data:`VERDICT_RULE` spells out, read off both statistics.
+
+    ``edges`` are the two bands the gap is taken between; a suppressed interval on
+    either makes the gap unreadable however wide the cohort as a whole is.
+    """
+    thin = any(cell["bootstrap"]["suppressed"] is not None for cell in edges)
+    if thin or gap["value"] is None or rho["rho"] is None:
+        return VERDICT_TOO_THIN
+    if gap["bootstrap"]["ci_low"] is None or rho["bootstrap"]["ci_low"] is None:
+        return VERDICT_TOO_THIN
+    if gap["bootstrap"]["ci_low"] > 0 and rho["bootstrap"]["ci_low"] > 0:
+        return VERDICT_RANKS
+    return VERDICT_NO_EVIDENCE
+
+
+# -- joining a trade to the score that produced it ----------------------------
+
+ScoreIndex = Mapping[tuple[date, str], SevenDimScore]
+
+
+def score_index(
+    denominator: DenominatorStore, market: str, *, include_burn_in: bool = False
+) -> dict[tuple[date, str], SevenDimScore]:
+    """Every persisted detection's score for one market, keyed by session and symbol.
+
+    The key is the pair the denominator's own primary key uses, so the join below
+    is exact: a symbol is detected at most once on a session.
+
+    Burn-in sessions are excluded by default for the reason they are flagged at
+    all — a warm-up session is persisted and never measured (story 76) — and the
+    default matches :func:`~backtest.simulate.walk_detections`, so the index and
+    the trades cover the same sessions rather than nearly the same ones.
+    """
+    index: dict[tuple[date, str], SevenDimScore] = {}
+    for header in denominator.sessions(
+        market, burn_in=None if include_burn_in else False
+    ):
+        for scored in denominator.detections(market, header.session):
+            check_seven_dimension_score(scored.score)
+            index[(header.session, scored.symbol)] = scored.score
+    return index
+
+
+def scored_trades(
+    trades: Sequence[SimulatedTrade], scores: ScoreIndex
+) -> list[ScoredTrade]:
+    """Join each trade to its detection's score, refusing a trade that has none.
+
+    The join is **total** or it is a bug: every simulated trade came from a
+    persisted detection, and that detection carries a score. Dropping an unmatched
+    trade quietly would shrink the cohort the ranking is measured on with nothing
+    in the output to say which trades left — and the trades most likely to go
+    missing are not a random sample of them.
+    """
+    out: list[ScoredTrade] = []
+    for trade in trades:
+        key = (trade.detection_session, trade.symbol)
+        if key not in scores:
+            raise ValueError(
+                f"no persisted score for {trade.symbol} detected "
+                f"{trade.detection_session}: the join from trade to detection is "
+                "total, and a missing row is a broken denominator rather than a "
+                "trade to drop"
+            )
+        score = scores[key]
+        check_seven_dimension_score(score)
+        out.append(ScoredTrade(trade=trade, score=score))
+    return out
+
+
+# -- the report ---------------------------------------------------------------
+
+
+def check_cohort(cohort: Sequence[ScoredTrade], *, market: str) -> None:
+    """Refuse a cohort spanning two markets or two arms, before anything is cut.
+
+    Checked over the whole cohort rather than per bucket, because a foreign trade
+    that happened to land in a band nobody read would pass a per-bucket check and
+    still move the cut every other band was made against. findings §8 measured that
+    magnitudes do not transfer between the markets, and the pre-registered arm is
+    arm B's — a ranking averaged over two arms would rank a result no arm produced.
+    """
+    foreign = {s.market for s in cohort} - {market}
+    if foreign:
+        raise ValueError(
+            f"a ranking is one market's: {market!r} was asked for and "
+            f"{sorted(foreign)} arrived too; US and IDX never pool"
+        )
+    other_arms = {s.trade.arm for s in cohort} - {PRIMARY_ARM}
+    if other_arms:
+        raise ValueError(
+            f"the ranking is measured on arm {PRIMARY_ARM}, the pre-registered "
+            f"arm: {sorted(other_arms)} arrived too"
+        )
+
+
+def bucket_cell(
+    contract: RunContract,
+    band: Band,
+    cohort: Sequence[ScoredTrade],
+    *,
+    market: str,
+) -> dict[str, Any]:
+    """One band's cell: the metric's own expectancy cell, plus the band it is.
+
+    The body is :func:`~backtest.metric.expectancy_cell` unmodified, so a bucket
+    reports the same fields the headline does — the win rate, the R-distribution
+    and the symbol-clustered interval — and a reader comparing a bucket against the
+    headline is comparing two figures built the same way.
+    """
+    in_band = [s for s in cohort if band.holds(s.points)]
+    return {
+        "bucket": band.index,
+        "deciles": list(band.deciles),
+        "band": band.label,
+        "low_points": band.low_points,
+        "high_points": band.high_points,
+        "low_stars": band.low_stars,
+        "high_stars": band.high_stars,
+        "share_of_cohort": (len(in_band) / len(cohort)) if cohort else 0.0,
+        **expectancy_cell(
+            contract, [s.trade for s in in_band], market=market, label=band.label
+        ),
+    }
+
+
+def _gap_cell(
+    contract: RunContract, cohort: Sequence[ScoredTrade], cut: Sequence[Band]
+) -> dict[str, Any]:
+    """The top-minus-bottom gap with its clustered interval, and the bands it spans."""
+    rows = outcomes(cohort, contract)
+    clusters = symbol_clusters(cohort, contract)
+    return {
+        "top": cut[-1].label if cut else None,
+        "bottom": cut[0].label if cut else None,
+        "value": top_minus_bottom(rows, cut),
+        "bootstrap": bootstrap_symbol_statistic(
+            clusters, lambda drawn: top_minus_bottom(drawn, cut)
+        ),
+    }
+
+
+def _rho_cell(
+    contract: RunContract, cohort: Sequence[ScoredTrade]
+) -> dict[str, Any]:
+    """Spearman's rho over the whole cohort, with its clustered interval."""
+    rows = outcomes(cohort, contract)
+    return {
+        "statistic": "spearman_rho",
+        "ties": "averaged",
+        "rho": rank_correlation(rows),
+        "pairs": len(rows),
+        "bootstrap": bootstrap_symbol_statistic(
+            symbol_clusters(cohort, contract), rank_correlation
+        ),
+    }
+
+
+def _slice(
+    contract: RunContract,
+    cohort: Sequence[ScoredTrade],
+    cut: Sequence[Band],
+    *,
+    market: str,
+) -> dict[str, Any]:
+    """One slice — a window or a year — bucketed on ``cut``, with its verdict."""
+    buckets = [bucket_cell(contract, band, cohort, market=market) for band in cut]
+    gap = _gap_cell(contract, cohort, cut)
+    rho = _rho_cell(contract, cohort)
+    return {
+        "trades": len(cohort),
+        "symbols": len({s.symbol for s in cohort}),
+        "buckets": buckets,
+        "gap": gap,
+        "spearman": rho,
+        "verdict": verdict(
+            gap=gap, rho=rho, edges=[buckets[0], buckets[-1]] if buckets else []
+        ),
+    }
+
+
+def market_ranking(
+    contract: RunContract,
+    cohort: Sequence[ScoredTrade],
+    *,
+    market: str,
+) -> dict[str, Any]:
+    """One market's ranking: the window's buckets, then every year against them.
+
+    The cut is made **once**, on the whole measured window, and every year is
+    reported against it — so "the top bucket" names one score band throughout and a
+    year-on-year comparison is a comparison of one question. A year with no trade
+    in a band reports a zero rather than a missing row, for the reason the metric
+    reports a silent year: an absent row and a quiet year are indistinguishable
+    after the fact.
+    """
+    check_costs(contract, market)
+    check_cohort(cohort, market=market)
+    for scored in cohort:
+        check_seven_dimension_score(scored.score)
+
+    cut = bands(cohort)
+    by_year: dict[int, list[ScoredTrade]] = {}
+    for scored in cohort:
+        by_year.setdefault(scored.year, []).append(scored)
+
+    return {
+        "market": market,
+        "arm": PRIMARY_ARM,
+        "deciles": DECILES,
+        "bands": len(cut),
+        "tie_rule": (
+            "a score value is atomic: it never splits across two buckets, so the "
+            f"buckets collapse to fewer than {DECILES} on a "
+            f"{SCORE_MAX_POINTS}-point score and each names the deciles it covers"
+        ),
+        "cut_on": "the market's whole measured window, so a band means the same "
+                  "score in every year",
+        **_slice(contract, cohort, cut, market=market),
+        "years": [
+            {
+                "year": year,
+                **_slice(
+                    contract, by_year.get(year, []), cut, market=market
+                ),
+            }
+            for year in measured_years(contract, [s.trade for s in cohort])
+        ],
+    }
+
+
+def ranking_report(
+    contract: RunContract,
+    cohort: Sequence[ScoredTrade],
+    *,
+    markets: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """The whole ranking measurement as one stamped payload, market by market.
+
+    ``markets`` defaults to the contract's own scope, so a market that produced no
+    trade reports its zeros rather than vanishing. There is deliberately no pooled
+    figure: findings §8 measured that magnitudes do not transfer, and the way to
+    stop a pooled number being quoted is for it never to have been computed.
+    """
+    named = tuple(markets) if markets else tuple(contract.value(SCOPE_MARKETS_KEY))
+    return stamp_result(
+        contract,
+        {
+            "question": (
+                "does a higher star score predict a better result, out of sample?"
+            ),
+            "arm": PRIMARY_ARM,
+            "score": {
+                "label": SCORE_LABEL,
+                "dimensions": SCORE_DIMENSIONS,
+                "max_points": SCORE_MAX_POINTS,
+                "max_stars": SCORE_MAX_STARS,
+                "app_max_points": APP_MAX_POINTS,
+                "note": SCORE_NOTE,
+            },
+            "out_of_sample": OUT_OF_SAMPLE_NOTE,
+            "in_sample_reference": IN_SAMPLE_GAP,
+            "verdict_rule": VERDICT_RULE,
+            "multiple_testing": MULTIPLE_TESTING_NOTE,
+            "kill_criterion": KILL_CRITERION_NOTE,
+            "bootstrap": {
+                "cluster": BOOTSTRAP_CLUSTER,
+                "resamples": BOOTSTRAP_RESAMPLES,
+                "seed": BOOTSTRAP_SEED,
+                "confidence": BOOTSTRAP_CONFIDENCE,
+            },
+            "year_attributed_to": "entry_session",
+            "markets": [
+                market_ranking(
+                    contract,
+                    [s for s in cohort if s.market == market],
+                    market=market,
+                )
+                for market in named
+            ],
+        },
+    )
+
+
+# -- printing it, and the command that produces it ----------------------------
+
+
+def _interval(boot: dict[str, Any]) -> str:
+    """One interval as a phrase, or the reason there is none."""
+    if boot["ci_low"] is None:
+        return f"{boot['clusters']} {boot['cluster']}s — too thin for an interval"
+    return (
+        f"[{boot['ci_low']:+.2f}, {boot['ci_high']:+.2f}] p={boot['p_value']:.3f} "
+        f"on {boot['clusters']} {boot['cluster']}s"
+    )
+
+
+def _bucket_line(cell: dict[str, Any]) -> str:
+    """One bucket as a line: the band, its n, what it paid and how sure that is.
+
+    n sits immediately beside the expectancy and never on a line of its own,
+    because a band's expectancy without its count is unreadable — six trades and
+    six hundred print the same number.
+    """
+    deciles = cell["deciles"]
+    span = (
+        f"D{deciles[0]}" if len(deciles) == 1 else f"D{deciles[0]}–D{deciles[-1]}"
+    )
+    head = f"  {span:<8} {cell['band']:<12} n={cell['closed']:<5}"
+    if cell["closed"] == 0:
+        return f"{head} no closed trades ({cell['trades']} taken)"
+    return (
+        f"{head} {cell['expectancy_r']:+.3f}R  win {cell['win_rate']:.1%}  "
+        f"{cell['symbols']} symbols  {_interval(cell['bootstrap'])}"
+    )
+
+
+def _slice_lines(body: dict[str, Any], *, indent: str = "") -> list[str]:
+    """One slice's buckets, then the two statistics the verdict is read off."""
+    lines = [indent + line for line in map(_bucket_line, body["buckets"])]
+    gap, rho = body["gap"], body["spearman"]
+    value = "undefined" if gap["value"] is None else f"{gap['value']:+.3f}R"
+    rho_value = "undefined" if rho["rho"] is None else f"{rho['rho']:+.3f}"
+    lines += [
+        f"{indent}  gap {gap['bottom']} → {gap['top']}: {value}  "
+        f"{_interval(gap['bootstrap'])}",
+        f"{indent}  rho {rho_value} over {rho['pairs']} trades  "
+        f"{_interval(rho['bootstrap'])}",
+        f"{indent}  verdict: {body['verdict']}",
+    ]
+    return lines
+
+
+def format_ranking(report: dict[str, Any]) -> str:
+    """The measurement as a page a terminal can print.
+
+    §4a's figure is printed **before** the buckets rather than as a footnote, so a
+    reader meets the in-sample gap and the reason it is not this measurement before
+    reading a number that could be mistaken for it.
+    """
+    score, prior = report["score"], report["in_sample_reference"]
+    lines: list[str] = [
+        f"{report['question']} — arm {report['arm']}",
+        f"  scored on the {score['label']}: {score['dimensions']} dimensions, "
+        f"{score['max_points']} points, ceiling {score['max_stars']:.1f}★",
+        f"  — not the app's {score['app_max_points']}-point score, which carries "
+        "the struck Sector row",
+        "  out of sample: R after costs, which no weight was fitted to and no "
+        "detection's score could see",
+        f"  against §4a, which was in-sample: picks {prior['picks_rate']:.1%} vs "
+        f"field {prior['field_rate']:.1%} at ≥3.5★, gap +{prior['gap_pp']:.2f}pp,",
+        f"  p={prior['p_value']:.3f} ({prior['test']}) — a rubric measured against "
+        "the separation its own weights were fitted to",
+        f"  bootstrap {report['bootstrap']['resamples']}× clustered by "
+        f"{report['bootstrap']['cluster']}, seed {report['bootstrap']['seed']}",
+    ]
+    for body in report["markets"]:
+        lines += [
+            "",
+            f"{body['market']} — {body['bands']} bands over {body['trades']} "
+            f"trades in {body['symbols']} symbols",
+        ]
+        lines += _slice_lines(body)
+        lines.append("  per year")
+        for year in body["years"]:
+            # A year that traded nothing is one line rather than a band per
+            # bucket. It stays on the page — a silent year is a measurement, and
+            # possibly a data hole — but fourteen of them spelled out in full
+            # would bury the years that did trade.
+            if year["trades"] == 0:
+                lines.append(f"    {year['year']}  no trades")
+                continue
+            lines.append(f"    {year['year']}  ({year['trades']} trades)")
+            lines += _slice_lines(year, indent="    ")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Bucket the persisted denominator's outcomes by star-score decile and record it::
+
+        python -m backtest.ranking --store data/backtest.duckdb \\
+            --out-json references/backtest_score_ranking.json
+
+    Both markets by default, arm B only — the pre-registered arm. Reads the bar
+    store and the denominator beside it, and writes neither.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the backtest bar store")
+    parser.add_argument(
+        "--market", action="append", default=None,
+        help="narrow to one market (repeatable); defaults to the contract's scope",
+    )
+    parser.add_argument(
+        "--out-json", default=None,
+        help="where to write the machine-readable, contract-stamped result",
+    )
+    args = parser.parse_args(argv)
+
+    contract = DEFAULT_CONTRACT
+    markets = tuple(args.market) if args.market else tuple(
+        contract.value(SCOPE_MARKETS_KEY)
+    )
+    store = Store.open(args.store)
+    denominator = DenominatorStore.open(denominator_path(args.store))
+    try:
+        cohort: list[ScoredTrade] = []
+        for market in markets:
+            trades = simulate_market(
+                store, denominator, market, contract, arms=(PRIMARY_ARM,)
+            )
+            cohort += scored_trades(trades, score_index(denominator, market))
+    finally:
+        denominator.close()
+        store.close()
+
+    report = ranking_report(contract, cohort, markets=markets)
+    if args.out_json:
+        Path(args.out_json).write_text(json.dumps(report, indent=1) + "\n")
+    print(format_ranking(report))
+    if args.out_json:
+        print(f"\nwrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/backtest/ranking.py
+++ b/backend/backtest/ranking.py
@@ -119,6 +119,7 @@ from .metric import (
     PRIMARY_ARM,
     after_cost_r,
     check_costs,
+    check_one_market_one_arm,
     expectancy_cell,
     measured_years,
     quantile,
@@ -133,9 +134,24 @@ from .simulate import SimulatedTrade, simulate_market
 # app's nine minus the struck ``Sector`` row, which the store cannot recover
 # because the labels table carries no history (findings §1, PRD "Out of Scope").
 SCORE_LABEL = SEVEN_DIM_LABEL
-SCORE_DIMENSIONS = 7
+# Derived from the rubric's own table rather than typed, the way
+# :data:`replay.field.SEVEN_DIM_MAX_POINTS` is: a dimension added or retired
+# carries here instead of leaving a stale count printing in every payload.
+SCORE_DIMENSIONS = len(DIMENSIONS) - 1
 SCORE_MAX_POINTS = SEVEN_DIM_MAX_POINTS
-SCORE_MAX_STARS = SCORE_MAX_POINTS / 2
+
+
+def stars(points: int) -> float:
+    """Points as stars — the one site in this module that owns the ``÷ 2``.
+
+    :mod:`screener.score` keeps the division in a single place so the live rubric
+    cannot drift from the version table it is keyed in; a module that spelled it
+    at three sites would be three places for a re-based scale to be half-applied.
+    """
+    return points / 2
+
+
+SCORE_MAX_STARS = stars(SCORE_MAX_POINTS)
 
 # The app's own ceiling, derived from the live weight table rather than typed, so a
 # weight change moves it here too. Carried beside the replayed one because ≥3.5★
@@ -244,11 +260,11 @@ class Band:
 
     @property
     def low_stars(self) -> float:
-        return self.low_points / 2
+        return stars(self.low_points)
 
     @property
     def high_stars(self) -> float:
-        return self.high_points / 2
+        return stars(self.high_points)
 
     @property
     def label(self) -> str:
@@ -301,20 +317,33 @@ class ScoredTrade:
 def bands(cohort: Sequence[ScoredTrade], *, deciles: int = DECILES) -> tuple[Band, ...]:
     """The cut: score bands in ascending order, no score split across two of them.
 
+    Cut over the **closed** trades, because those are the outcomes being bucketed
+    and a trade still running contributes to no statistic in the report. Including
+    the open ones would let a population that pays nothing move every boundary the
+    measured population is then read against — and the open trades are not a random
+    sample of the field, since a name still running at the window's end is one the
+    trail never took out.
+
     Walks the distinct scores upward, accumulating until the cumulative share
-    crosses the next decile boundary, then closes a band covering every decile
-    position it reached. A score that carries more than a tenth of the cohort
+    crosses the next decile boundary, then closes a band carrying every decile
+    boundary that fell inside it. A score carrying more than a tenth of the cohort
     therefore swallows several deciles at once and the result has fewer than
-    ``deciles`` bands — which is a fact about an eight-point score, not a defect in
-    the cut.
+    ``deciles`` bands — a fact about an eight-point score, not a defect in the cut.
+
+    The bands **partition** the ten decile positions exactly: each boundary lands in
+    the band that contains it, and the last band always closes on the tenth. So a
+    band's decile span is where its share of the cohort sits, not a rounding of that
+    share — a band holding 49% carries the four boundaries below it and the fifth
+    belongs to its neighbour.
 
     A function of the score distribution alone, so shuffling the cohort moves
     nothing: a cut that read arrival order would produce different buckets on a
     re-run of the same data with nothing in the output to show it.
     """
-    if not cohort:
+    closed = [s for s in cohort if s.trade.r_multiple is not None]
+    if not closed:
         return ()
-    counts = Counter(s.points for s in cohort)
+    counts = Counter(s.points for s in closed)
     total = sum(counts.values())
     out: list[Band] = []
     cumulative = 0
@@ -460,6 +489,25 @@ def rank_correlation(rows: Sequence[Outcome]) -> float | None:
 
 # -- the bootstrap, over a statistic rather than over a mean -------------------
 
+# How much of a resample distribution may be undefined before the interval built
+# on the rest of it is refused.
+#
+# A resample is undefined exactly when it drew no symbol from the top band or none
+# from the bottom — the draws that carry the most uncertainty about a gap resting
+# on a thin edge. Dropping them and reading the interval off what is left
+# *conditions on the statistic having been computable*, which renormalises the
+# distribution towards the cases where it was, and those are the confident ones.
+# The correction goes the wrong way: it tightens the interval exactly where the
+# data is weakest.
+#
+# There is no honest value to substitute for an undefined draw — zero is a
+# measurement nobody made — so the remedy is to refuse the interval rather than to
+# repair it. A tenth is a judgement and is recorded as one: below it the
+# renormalisation moves a percentile bound by less than the resampling noise around
+# it, and above it the interval is describing a sub-population of the resamples.
+# The count always rides on the output, so a cell just under the line reads as one.
+MAX_UNDEFINED_SHARE = 0.10
+
 
 def bootstrap_symbol_statistic(
     clusters: Sequence[Sequence[Outcome]],
@@ -470,6 +518,7 @@ def bootstrap_symbol_statistic(
     confidence: float = BOOTSTRAP_CONFIDENCE,
     cluster: str = BOOTSTRAP_CLUSTER,
     min_clusters: int = BOOTSTRAP_MIN_CLUSTERS,
+    max_undefined_share: float = MAX_UNDEFINED_SHARE,
 ) -> dict[str, Any]:
     """A clustered bootstrap of an arbitrary statistic over the pooled rows.
 
@@ -487,9 +536,12 @@ def bootstrap_symbol_statistic(
     whether it pays differently.
 
     A resample the statistic cannot evaluate (an empty edge band, no variance) is
-    counted under ``undefined`` and left out of the interval rather than defaulted
-    to zero, because a resample that could not answer is not a resample that
-    answered no. If every resample is undefined the interval is refused outright.
+    counted under ``undefined`` rather than defaulted to zero, because a resample
+    that could not answer is not a resample that answered no. Past
+    :data:`MAX_UNDEFINED_SHARE` of the draws the interval is **refused**: reading it
+    off the draws that did compute would condition on the statistic having been
+    computable, which is a condition satisfied disproportionately by the confident
+    draws. See that constant for the argument.
 
     Below ``min_clusters`` no interval is reported at all, for the reason the
     metric records: one symbol resampled two thousand times returns its own mean
@@ -508,6 +560,7 @@ def bootstrap_symbol_statistic(
         "confidence": confidence,
         "min_clusters": min_clusters,
         "undefined": 0,
+        "max_undefined_share": max_undefined_share,
         "suppressed": None,
     }
     empty = {**body, "ci_low": None, "ci_high": None, "p_value": None}
@@ -531,13 +584,16 @@ def bootstrap_symbol_statistic(
             undefined += 1
             continue
         drawn_values.append(value)
-    if not drawn_values:
+    share_undefined = undefined / resamples if resamples else 1.0
+    if not drawn_values or share_undefined > max_undefined_share:
         return {
             **empty,
             "undefined": undefined,
             "suppressed": (
-                f"every resample was undefined over {n} {cluster}s: no interval "
-                "exists to report"
+                f"{share_undefined:.1%} of resamples could not be evaluated over "
+                f"{n} {cluster}s, past the {max_undefined_share:.0%} the interval "
+                "is allowed: reading it off the rest would condition on the draws "
+                "where the statistic was computable, which are the confident ones"
             ),
         }
 
@@ -563,9 +619,14 @@ VERDICT_RULE = (
     "symbol-clustered intervals both entirely above zero; either one alone is "
     "'no evidence it ranks', because a gap can rest on one hot name at the top "
     "and a rho can be positive and negligible. A cohort whose top or bottom band "
-    "is below the cluster floor is 'too thin to say' — the gap is computed "
-    "between those two bands. 'no evidence it ranks' is never 'the score does not "
-    "rank': one sample cannot license that"
+    "is below the cluster floor, or whose interval was refused for undefined "
+    "resamples, is 'too thin to say' — the gap is computed between those two "
+    "bands. The verdict reads the 95% interval's lower bound, which is a "
+    "one-sided 2.5% test and is deliberately stricter than the one-sided p "
+    "printed beside it: a cell can therefore show p just under 0.05 and still "
+    "read 'no evidence it ranks', and the interval is the one that governs. 'no "
+    "evidence it ranks' is never 'the score does not rank': one sample cannot "
+    "license that"
 )
 
 
@@ -651,24 +712,14 @@ def scored_trades(
 def check_cohort(cohort: Sequence[ScoredTrade], *, market: str) -> None:
     """Refuse a cohort spanning two markets or two arms, before anything is cut.
 
-    Checked over the whole cohort rather than per bucket, because a foreign trade
-    that happened to land in a band nobody read would pass a per-bucket check and
-    still move the cut every other band was made against. findings §8 measured that
-    magnitudes do not transfer between the markets, and the pre-registered arm is
-    arm B's — a ranking averaged over two arms would rank a result no arm produced.
+    The metric's own refusal (:func:`~backtest.metric.check_one_market_one_arm`),
+    called on the whole cohort rather than left to fire per bucket: a foreign trade
+    landing in a band nobody read would pass a per-bucket check and still have moved
+    the cut every other band was made against.
     """
-    foreign = {s.market for s in cohort} - {market}
-    if foreign:
-        raise ValueError(
-            f"a ranking is one market's: {market!r} was asked for and "
-            f"{sorted(foreign)} arrived too; US and IDX never pool"
-        )
-    other_arms = {s.trade.arm for s in cohort} - {PRIMARY_ARM}
-    if other_arms:
-        raise ValueError(
-            f"the ranking is measured on arm {PRIMARY_ARM}, the pre-registered "
-            f"arm: {sorted(other_arms)} arrived too"
-        )
+    check_one_market_one_arm(
+        [s.trade for s in cohort], market=market, what="a ranking"
+    )
 
 
 def bucket_cell(
@@ -686,6 +737,12 @@ def bucket_cell(
     headline is comparing two figures built the same way.
     """
     in_band = [s for s in cohort if band.holds(s.points)]
+    # Off the closed trades on both sides, because that is the population the cut
+    # was made over and the one every figure in the cell is computed from. A share
+    # whose numerator counted outcomes and whose denominator counted entries would
+    # not sum to 1 across the bands, and the gap would read as a rounding error.
+    closed_in_band = sum(1 for s in in_band if s.trade.r_multiple is not None)
+    closed_total = sum(1 for s in cohort if s.trade.r_multiple is not None)
     return {
         "bucket": band.index,
         "deciles": list(band.deciles),
@@ -694,7 +751,7 @@ def bucket_cell(
         "high_points": band.high_points,
         "low_stars": band.low_stars,
         "high_stars": band.high_stars,
-        "share_of_cohort": (len(in_band) / len(cohort)) if cohort else 0.0,
+        "share_of_closed": (closed_in_band / closed_total) if closed_total else 0.0,
         **expectancy_cell(
             contract, [s.trade for s in in_band], market=market, label=band.label
         ),
@@ -733,7 +790,7 @@ def _rho_cell(
     }
 
 
-def _slice(
+def _slice_cell(
     contract: RunContract,
     cohort: Sequence[ScoredTrade],
     cut: Sequence[Band],
@@ -747,6 +804,14 @@ def _slice(
     return {
         "trades": len(cohort),
         "symbols": len({s.symbol for s in cohort}),
+        # A trade whose score no band holds, and the count that makes the buckets
+        # add up. Only an **open** trade can be one: the cut is taken over the
+        # closed trades, so every closed score is inside some band by construction.
+        # It is reported rather than filed under the nearest edge, because a band
+        # labelled 1.0★ holding a 3.5★ trade would be a mislabel, and rather than
+        # dropped, because then the buckets would sum to less than the field with
+        # nothing saying where the difference went.
+        "outside_the_cut": len(cohort) - sum(b["trades"] for b in buckets),
         "buckets": buckets,
         "gap": gap,
         "spearman": rho,
@@ -793,17 +858,36 @@ def market_ranking(
         ),
         "cut_on": "the market's whole measured window, so a band means the same "
                   "score in every year",
-        **_slice(contract, cohort, cut, market=market),
+        **_slice_cell(contract, cohort, cut, market=market),
         "years": [
             {
                 "year": year,
-                **_slice(
+                **_slice_cell(
                     contract, by_year.get(year, []), cut, market=market
                 ),
             }
             for year in measured_years(contract, [s.trade for s in cohort])
         ],
     }
+
+
+def _intervals_reported(markets_body: Sequence[dict[str, Any]]) -> int:
+    """How many significance intervals this report actually states.
+
+    Every bucket, gap and rho in every slice — the window rows and each year's —
+    because each is a statement made at nominal alpha and the multiple-testing
+    budget is the count of them, not the count of the ones a reader happens to
+    quote. Suppressed intervals are not counted: a cell that refused to say
+    anything made no claim to correct for.
+    """
+    def in_slice(body: dict[str, Any]) -> int:
+        cells = [*body["buckets"], body["gap"], body["spearman"]]
+        return sum(1 for c in cells if c["bootstrap"]["ci_low"] is not None)
+
+    return sum(
+        in_slice(market) + sum(in_slice(year) for year in market["years"])
+        for market in markets_body
+    )
 
 
 def ranking_report(
@@ -820,6 +904,12 @@ def ranking_report(
     stop a pooled number being quoted is for it never to have been computed.
     """
     named = tuple(markets) if markets else tuple(contract.value(SCOPE_MARKETS_KEY))
+    markets_body = [
+        market_ranking(
+            contract, [s for s in cohort if s.market == market], market=market
+        )
+        for market in named
+    ]
     return stamp_result(
         contract,
         {
@@ -838,7 +928,23 @@ def ranking_report(
             "out_of_sample": OUT_OF_SAMPLE_NOTE,
             "in_sample_reference": IN_SAMPLE_GAP,
             "verdict_rule": VERDICT_RULE,
-            "multiple_testing": MULTIPLE_TESTING_NOTE,
+            "multiple_testing": {
+                "note": MULTIPLE_TESTING_NOTE,
+                # Counted rather than described. Every year of every market gets
+                # its own gap, rho and verdict, so a report over fourteen years and
+                # two markets makes scores of significance statements at nominal
+                # alpha and some of them come up positive by construction. A budget
+                # a reader has to infer from the length of the page is a budget
+                # nobody is keeping, so the number rides on the payload beside the
+                # note that says why it matters.
+                "intervals_reported": _intervals_reported(markets_body),
+                "alpha_is_nominal": True,
+                "reading": (
+                    "the window rows are the measurement; a per-year row is a "
+                    "diagnostic and one positive year among many is what this "
+                    "count exists to make visible"
+                ),
+            },
             "kill_criterion": KILL_CRITERION_NOTE,
             "bootstrap": {
                 "cluster": BOOTSTRAP_CLUSTER,
@@ -847,14 +953,7 @@ def ranking_report(
                 "confidence": BOOTSTRAP_CONFIDENCE,
             },
             "year_attributed_to": "entry_session",
-            "markets": [
-                market_ranking(
-                    contract,
-                    [s for s in cohort if s.market == market],
-                    market=market,
-                )
-                for market in named
-            ],
+            "markets": markets_body,
         },
     )
 

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -7525,3 +7525,443 @@ def test_the_price_scale_count_rides_on_the_figures_it_qualifies(
     assert us.price_scale_dropped == len(us.arms)
     assert report["markets"][0]["price_scale_dropped"] == len(us.arms)
     assert "price-scale flag would drop" in format_figures(report)
+
+
+# -- does the rubric rank, out of sample? (issue #194) -------------------------
+#
+# Phase 5's ranking cell, and the out-of-sample test §4a's claim has never had.
+# §4a asked whether the star score separates the trader's *picks* from the field,
+# on the same field the v2 weights had been fitted to — a fit statistic dressed as
+# a test, and marginal anyway at p = 0.055. Here the outcome variable is R, which
+# no weight was fitted to and which no detection's score could see. That is the
+# whole point of the measurement, and it is why the two figures are carried side
+# by side in the output rather than left for a reader to conflate.
+#
+# Three claims are load-bearing:
+#
+#   * **A tie never splits.** The replayed score is seven dimensions of eight
+#     integral points, so its distribution is coarse and true deciles do not
+#     exist. Every trade on the same score lands in the same bucket, the buckets
+#     collapse to fewer than ten, and the decile positions each one covers are
+#     named — a cut that split a tie would report two buckets differing by nothing
+#     but which rows the sort happened to put first.
+#   * **The score is the seven-dimension replayed one.** Never the app's nine
+#     points: ≥3.5★ is 7 of 8 here and 7 of 9 there, and a ceiling read off the
+#     wrong scale mislabels every band.
+#   * **Clustered by symbol, as everywhere else.** A name detected three times in
+#     a fortnight is one observation's worth of independence, not three.
+
+from backtest.ranking import (
+    APP_MAX_POINTS,
+    IN_SAMPLE_GAP,
+    SCORE_DIMENSIONS,
+    SCORE_LABEL,
+    SCORE_MAX_POINTS,
+    VERDICT_NO_EVIDENCE,
+    VERDICT_RANKS,
+    VERDICT_TOO_THIN,
+    Band,
+    ScoredTrade,
+    bands,
+    bootstrap_symbol_statistic,
+    check_seven_dimension_score,
+    format_ranking,
+    market_ranking,
+    outcomes,
+    rank_correlation,
+    ranking_report,
+    score_index,
+    scored_trades,
+    symbol_clusters,
+    top_minus_bottom,
+)
+
+
+def _score(points: int) -> SevenDimScore:
+    """A seven-dimension score worth exactly ``points``, out of eight.
+
+    The breakdown is not read by anything under test — the buckets are cut on the
+    total — so it is left empty rather than authored dimension by dimension, which
+    would make every fixture below an assertion about the rubric instead of about
+    the bucketing.
+    """
+    return SevenDimScore(
+        stars=points / 2,
+        points=points,
+        max_points=SEVEN_DIM_MAX_POINTS,
+        breakdown=[],
+        label=SEVEN_DIM_LABEL,
+    )
+
+
+def _rtrade(
+    symbol: str,
+    points: int,
+    r: float,
+    *,
+    year: int = 2016,
+    market: str = "US",
+    month: int = 3,
+    arm: str = ARM_B,
+) -> ScoredTrade:
+    """One arm-B trade at a known score and a known before-cost R.
+
+    Authored on :func:`_mtrade`, the metric section's own fixture, because the
+    ranking is arithmetic over the same trades priced the same way — a second
+    trade fixture here would be a second cost model nobody compared.
+    """
+    return ScoredTrade(
+        trade=_mtrade(symbol, year, r, market=market, arm=arm, month=month),
+        score=_score(points),
+    )
+
+
+def _ladder(points_to_r: dict[int, float], *, per_score: int = 6) -> list[ScoredTrade]:
+    """A cohort with ``per_score`` distinct symbols on each score, each paying its
+    score's R. Enough symbols per band to clear the bootstrap's cluster floor."""
+    return [
+        _rtrade(f"S{points}_{i}", points, r)
+        for points, r in points_to_r.items()
+        for i in range(per_score)
+    ]
+
+
+def test_outcomes_are_bucketed_by_star_score_decile_with_n_on_every_bucket(store):
+    """The measurement itself: buckets in ascending score order, each carrying the
+    count behind it.
+
+    n rides on every bucket because a bucket's expectancy is unreadable without it
+    — one trade at +4R and six hundred at +0.1R print the same headline — and the
+    counts sum to the cohort, so no trade is silently dropped between the cut and
+    the report.
+    """
+    cohort = _ladder({2: -0.5, 4: 0.2, 6: 1.5})
+
+    body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
+
+    buckets = body["buckets"]
+    assert [b["low_points"] for b in buckets] == [2, 4, 6]
+    assert [b["closed"] for b in buckets] == [6, 6, 6]
+    assert sum(b["trades"] for b in buckets) == len(cohort)
+    assert [b["symbols"] for b in buckets] == [6, 6, 6]
+    # Ascending in score, and the expectancy follows it here by construction.
+    values = [b["expectancy_r"] for b in buckets]
+    assert values == sorted(values)
+
+
+def test_a_tie_never_splits_across_two_buckets(store):
+    """The replayed score is eight integral points, so true deciles do not exist.
+
+    A cut that split a tie would put two trades scoring identically in different
+    buckets and report a difference between them, which would be a difference in
+    sort order and nothing else. So a score value is atomic: the buckets collapse
+    to fewer than ten and each one names the decile positions it covers.
+    """
+    # 80% of the cohort on one score: no decile boundary can pass through it.
+    cohort = [_rtrade(f"L{i}", 3, 0.1) for i in range(80)]
+    cohort += [_rtrade(f"H{i}", 6, 2.0) for i in range(20)]
+
+    cut = bands(cohort)
+
+    assert all(isinstance(b, Band) for b in cut)
+    assert len(cut) < 10
+    assert [(b.low_points, b.high_points) for b in cut] == [(3, 3), (6, 6)]
+    # The band that swallowed eight deciles says so, rather than reporting as one.
+    assert cut[0].deciles == tuple(range(1, 9))
+    assert cut[1].deciles == (9, 10)
+
+
+def test_the_bucket_a_trade_lands_in_never_depends_on_the_order_it_arrived(store):
+    """Determinism, stated as the property the tie rule buys.
+
+    The cut is a function of the score distribution, so shuffling the cohort moves
+    nothing. A cut that read the incoming order would produce a different set of
+    buckets on a re-run of the same data, with nothing in the output to show it.
+    """
+    cohort = _ladder({1: -1.0, 3: 0.0, 5: 1.0, 7: 2.0})
+    shuffled = list(reversed(cohort))
+
+    assert bands(cohort) == bands(shuffled)
+    assert market_ranking(DEFAULT_CONTRACT, cohort, market="US") == market_ranking(
+        DEFAULT_CONTRACT, shuffled, market="US"
+    )
+
+
+def test_a_score_that_ranks_shows_a_positive_gap_and_a_positive_rho(store):
+    """The claim under test, in the shape that would confirm it.
+
+    The top band beats the bottom, the rank correlation between score and outcome
+    is positive, and both intervals sit above zero — which is the only combination
+    the verdict rule reads as "ranks".
+    """
+    cohort = _ladder({1: -1.0, 3: -0.2, 5: 0.6, 7: 1.8}, per_score=8)
+
+    body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
+
+    assert body["gap"]["value"] > 0
+    assert body["gap"]["bootstrap"]["ci_low"] > 0
+    assert body["spearman"]["rho"] > 0
+    assert body["spearman"]["bootstrap"]["ci_low"] > 0
+    assert body["verdict"] == VERDICT_RANKS
+
+
+def test_a_score_that_does_not_rank_reports_no_evidence_rather_than_a_null_result(store):
+    """A rubric whose bands pay the same is the outcome §4a's claim risks.
+
+    The gap straddles zero, so the verdict says there is no evidence the score
+    ranks — not that it is proven flat, which is a stronger claim than a bootstrap
+    over one sample can license.
+
+    Every band draws the *same* spread of outcomes, so the score carries no
+    information about R and the true gap is zero. The spread inside a band is what
+    makes the interval an interval: a band whose every trade paid the same would
+    resample to a single number and print a certainty it has not earned.
+    """
+    spread = (-1.0, -1.0, -0.6, 0.3, 0.8, 2.2, -0.7, 1.1)
+    cohort = [
+        _rtrade(f"S{points}_{i}", points, r)
+        for points in (1, 3, 5, 7)
+        for i, r in enumerate(spread)
+    ]
+
+    body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
+
+    assert body["gap"]["bootstrap"]["ci_low"] < 0 < body["gap"]["bootstrap"]["ci_high"]
+    assert body["verdict"] == VERDICT_NO_EVIDENCE
+    assert "no evidence" in format_ranking(
+        ranking_report(DEFAULT_CONTRACT, cohort, markets=("US",))
+    )
+
+
+def test_significance_is_clustered_by_symbol_not_by_row(store):
+    """One name detected twenty times is not twenty independent observations.
+
+    The same data bootstrapped by row and by symbol must not produce the same
+    interval: the clustered one is wider and its p-value higher, and that widening
+    *is* the correction. Run on the gap rather than on a mean, because the gap is
+    the statistic the verdict is read off.
+    """
+    # One hot name at the top band, twenty times over, beside four cold names in
+    # the same band; twenty distinct names at the bottom. By row the top band is
+    # its hot name's twenty rows and the gap is decisive. By symbol the whole
+    # result turns on whether that one name was drawn, and a third of the time it
+    # is not — which is what the interval has to show.
+    cohort = [_rtrade("HOT", 7, 3.0, month=1 + (i % 12)) for i in range(20)]
+    cohort += [_rtrade(f"T{i}", 7, -1.5) for i in range(4)]
+    cohort += [_rtrade(f"C{i}", 1, -1.0) for i in range(20)]
+    cut = bands(cohort)
+    clustered = symbol_clusters(cohort, DEFAULT_CONTRACT)
+
+    by_symbol = bootstrap_symbol_statistic(
+        clustered, lambda rows: top_minus_bottom(rows, cut)
+    )
+    by_row = bootstrap_symbol_statistic(
+        [(row,) for cluster in clustered for row in cluster],
+        lambda rows: top_minus_bottom(rows, cut),
+    )
+
+    assert by_symbol["clusters"] == 25
+    assert by_row["clusters"] == 44
+    assert (by_symbol["ci_high"] - by_symbol["ci_low"]) > (
+        by_row["ci_high"] - by_row["ci_low"]
+    )
+    assert by_symbol["p_value"] > by_row["p_value"]
+    assert by_symbol["cluster"] == BOOTSTRAP_CLUSTER
+
+
+def test_a_bucket_too_thin_to_bootstrap_says_so_and_still_reports_its_n(store):
+    """Per-year buckets are exactly where the symbol count goes thin.
+
+    A single symbol resampled two thousand times returns its own mean two thousand
+    times — a zero-width interval that prints as certainty from one observation.
+    So the interval is refused and the count is not: "too few symbols to say" and
+    "no result" are different findings.
+    """
+    cohort = [_rtrade("ONE", 6, 2.0, month=1 + i) for i in range(3)]
+    cohort += _ladder({2: -1.0}, per_score=6)
+
+    body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
+
+    top = body["buckets"][-1]
+    assert top["closed"] == 3
+    assert top["symbols"] == 1
+    assert top["bootstrap"]["ci_low"] is None
+    assert "too thin" in top["bootstrap"]["suppressed"]
+    assert body["verdict"] == VERDICT_TOO_THIN
+    assert "too thin" in format_ranking(
+        ranking_report(DEFAULT_CONTRACT, cohort, markets=("US",))
+    )
+
+
+def test_every_year_of_the_measured_window_gets_a_row_on_the_same_bands(store):
+    """Per market *and* per year, and the bands are cut once on the market's whole
+    window.
+
+    Cutting per year would make "the top bucket" a different score band in every
+    row, so a year-on-year comparison would compare two different questions. The
+    years run from the contract's measured start, so a market that traded nothing
+    until later has its silent years on the page rather than missing from it.
+    """
+    cohort = _ladder({2: -0.5, 6: 1.5}, per_score=6)
+    cohort += [_rtrade(f"N{i}", 6, 1.0, year=2017) for i in range(6)]
+
+    body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
+
+    years = {y["year"]: y for y in body["years"]}
+    assert min(years) == int(DEFAULT_CONTRACT.value(WINDOW_MEASURED_START_KEY)[:4])
+    assert max(years) == 2017
+    window_bands = [b["band"] for b in body["buckets"]]
+    for year in years.values():
+        assert [b["band"] for b in year["buckets"]] == window_bands
+    # 2017 traded only the top band; the bottom band's row is a zero, not a gap.
+    assert [b["closed"] for b in years[2017]["buckets"]] == [0, 6]
+
+    # On the page a silent year is one line rather than a band per bucket: it
+    # stays visible — it is a measurement, and possibly a data hole — without
+    # burying the years that traded under fourteen empty ladders.
+    printed = format_ranking(
+        ranking_report(DEFAULT_CONTRACT, cohort, markets=("US",))
+    ).splitlines()
+    assert "    2013  no trades" in printed
+    assert sum(1 for line in printed if line.startswith("    2013")) == 1
+
+
+def test_us_and_idx_never_pool(store):
+    """findings §8 measured that magnitudes do not transfer, so a mean across the
+    two markets is a number about neither — and a bucket built from both would
+    hide it inside a band label that looked ordinary."""
+    with pytest.raises(ValueError):
+        market_ranking(
+            DEFAULT_CONTRACT,
+            [_rtrade("AAA", 6, 1.0), _rtrade("BBB.JK", 6, 1.0, market="IDX")],
+            market="US",
+        )
+
+
+def test_the_ranking_is_arm_bs_and_refuses_another_arm(store):
+    """Arm B is the pre-registered arm, and an arm A trade averaged into it would
+    report a figure no arm produced under arm B's name."""
+    with pytest.raises(ValueError):
+        market_ranking(
+            DEFAULT_CONTRACT,
+            [_rtrade("AAA", 6, 1.0), _rtrade("BBB", 6, 1.0, arm=ARM_A)],
+            market="US",
+        )
+
+
+def test_the_score_is_the_seven_dimension_one_and_the_apps_ceiling_is_named(store):
+    """≥3.5★ is 7 of 8 here and 7 of 9 in the app. A band read off the wrong
+    ceiling mislabels every bucket, so both scales ride on the output and the
+    replayed one is labelled wherever it is printed."""
+    report = ranking_report(
+        DEFAULT_CONTRACT, _ladder({2: -0.5, 6: 1.5}), markets=("US",)
+    )
+
+    score = report["score"]
+    assert score["label"] == SCORE_LABEL == SEVEN_DIM_LABEL
+    assert score["dimensions"] == SCORE_DIMENSIONS == 7
+    assert score["max_points"] == SCORE_MAX_POINTS == SEVEN_DIM_MAX_POINTS
+    assert score["app_max_points"] == APP_MAX_POINTS == SCORE_MAX_POINTS + 1
+    assert score["max_stars"] == 4.0
+    printed = format_ranking(report)
+    assert SEVEN_DIM_LABEL in printed
+    assert "not the app's" in printed
+
+
+def test_a_score_on_the_apps_nine_point_ceiling_is_drift_not_a_ninth_point(store):
+    """The replayed score drops `Sector` and totals out of eight. A nine-point row
+    arriving here means the field was scored by something else, and reading it as
+    a seven-dimension one would re-base every band silently."""
+    nine = SevenDimScore(
+        stars=4.5, points=9, max_points=9, breakdown=[], label="star score"
+    )
+
+    check_seven_dimension_score(_score(6))
+    with pytest.raises(ContractDrift):
+        check_seven_dimension_score(nine)
+
+
+def test_the_result_is_stated_against_4as_in_sample_gap(store):
+    """The two are not the same measurement and must not be read as one.
+
+    §4a's +5.59pp is a separation the v2 weights were *fitted* to, on the field
+    they were fitted on, at p = 0.055. This one's outcome variable is R, which no
+    weight ever saw. So §4a's figures ride on the payload with the reason they are
+    not comparable, rather than being left for a reader to line up.
+    """
+    report = ranking_report(
+        DEFAULT_CONTRACT, _ladder({2: -0.5, 6: 1.5}), markets=("US",)
+    )
+
+    prior = report["in_sample_reference"]
+    assert prior["gap_pp"] == IN_SAMPLE_GAP["gap_pp"] == 5.59
+    assert prior["p_value"] == 0.055
+    assert "§4a" in prior["source"]
+    assert "fitted" in prior["why_it_is_not_this_measurement"]
+    printed = format_ranking(report)
+    assert "§4a" in printed
+    assert "in-sample" in printed
+
+
+def test_a_trade_with_no_score_row_is_a_failure_rather_than_a_silent_drop(store):
+    """The join between a trade and the detection that produced it is total.
+
+    A trade whose detection row is missing is a broken denominator, and dropping
+    it quietly would shrink the cohort the ranking is measured on with nothing in
+    the output to show which trades left.
+    """
+    trade = _mtrade("AAA", 2016, 1.0)
+    scores = {(trade.detection_session, "AAA"): _score(6)}
+
+    assert [s.score.points for s in scored_trades([trade], scores)] == [6]
+    with pytest.raises(ValueError):
+        scored_trades([trade], {})
+
+
+def test_rho_reads_the_score_against_the_outcome_and_ties_are_averaged(store):
+    """The rank correlation is the statistic that answers "does a higher score
+    predict a better result" over the whole cohort rather than at its two edges.
+
+    Ties are the common case on an eight-point score, so they take the average
+    rank: a tie broken by arrival order would make rho depend on the sort.
+    """
+    rising = _ladder({1: -1.0, 3: 0.0, 5: 1.0, 7: 2.0}, per_score=3)
+    falling = _ladder({1: 2.0, 3: 1.0, 5: 0.0, 7: -1.0}, per_score=3)
+    rho = lambda cohort: rank_correlation(outcomes(cohort, DEFAULT_CONTRACT))
+
+    assert rho(rising) == pytest.approx(1.0)
+    assert rho(falling) == pytest.approx(-1.0)
+    # One score only: no variance in the ranks, so no correlation exists to report.
+    assert rho(_ladder({4: 1.0})) is None
+
+
+def test_the_ranking_report_is_stamped_and_serialises(store):
+    """Like every figure the package emits: the contract rides on it, and two runs
+    under different contracts differ in their output alone."""
+    report = ranking_report(
+        DEFAULT_CONTRACT, _ladder({2: -0.5, 6: 1.5}), markets=("US", "IDX")
+    )
+
+    assert report[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
+    assert [m["market"] for m in report["markets"]] == ["US", "IDX"]
+    assert json.loads(json.dumps(report)) == report
+
+
+def test_the_ranking_runs_off_the_denominator_end_to_end(store, denominator):
+    """The seam that matters: persisted detections, their scores, and the trades
+    the simulator took off them, joined by the session they were decided on."""
+    det = _seed_figure_name(store, denominator, "US", "AAA", date(2020, 1, 1),
+                            _FIG_FLAT + _FIG_WIN)
+    trades = simulate_market(
+        store, denominator, "US", DEFAULT_CONTRACT, arms=(ARM_B,)
+    )
+    scores = score_index(denominator, "US")
+
+    cohort = scored_trades(trades, scores)
+
+    assert [s.trade.symbol for s in cohort] == ["AAA"]
+    assert cohort[0].score.points == seven_dimension_score(
+        det, prior_move=False
+    ).points
+    body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
+    assert sum(b["trades"] for b in body["buckets"]) == 1

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -7554,6 +7554,7 @@ def test_the_price_scale_count_rides_on_the_figures_it_qualifies(
 from backtest.ranking import (
     APP_MAX_POINTS,
     IN_SAMPLE_GAP,
+    MAX_UNDEFINED_SHARE,
     SCORE_DIMENSIONS,
     SCORE_LABEL,
     SCORE_MAX_POINTS,
@@ -7603,6 +7604,7 @@ def _rtrade(
     market: str = "US",
     month: int = 3,
     arm: str = ARM_B,
+    open_at_end: bool = False,
 ) -> ScoredTrade:
     """One arm-B trade at a known score and a known before-cost R.
 
@@ -7611,7 +7613,10 @@ def _rtrade(
     trade fixture here would be a second cost model nobody compared.
     """
     return ScoredTrade(
-        trade=_mtrade(symbol, year, r, market=market, arm=arm, month=month),
+        trade=_mtrade(
+            symbol, year, r, market=market, arm=arm, month=month,
+            open_at_end=open_at_end,
+        ),
         score=_score(points),
     )
 
@@ -7933,6 +7938,114 @@ def test_rho_reads_the_score_against_the_outcome_and_ties_are_averaged(store):
     assert rho(falling) == pytest.approx(-1.0)
     # One score only: no variance in the ranks, so no correlation exists to report.
     assert rho(_ladder({4: 1.0})) is None
+
+
+def test_the_cut_is_taken_over_outcomes_and_an_open_trade_moves_no_boundary(store):
+    """A trade still running has no R and contributes to no statistic in the report.
+
+    Letting it move a boundary would cut the measured population against a
+    distribution that includes one that pays nothing — and the open trades are not
+    a random sample of the field, since a name still running at the window's end is
+    one the trail never took out.
+    """
+    closed = [_rtrade(f"C{i}", 2, 0.5) for i in range(9)]
+    still_running = ScoredTrade(
+        trade=_mtrade("OPEN", 2016, 3.0, open_at_end=True), score=_score(7)
+    )
+
+    assert [(b.low_points, b.high_points) for b in bands(closed)] == [(2, 2)]
+    assert bands(closed + [still_running]) == bands(closed)
+
+    body = market_ranking(DEFAULT_CONTRACT, closed + [still_running], market="US")
+    only = body["buckets"][0]
+    assert only["trades"] == 9
+    assert only["closed"] == 9
+    assert only["share_of_closed"] == 1.0
+    # Its score is above every band the closed trades produced, so no bucket holds
+    # it. It is counted rather than dropped or filed under the nearest edge: the
+    # buckets have to add up to the field, and a 1.0★ band holding a 3.5★ trade
+    # would be a mislabel.
+    assert body["outside_the_cut"] == 1
+    assert sum(b["trades"] for b in body["buckets"]) + body["outside_the_cut"] == 10
+
+
+def test_an_interval_built_mostly_on_resamples_that_could_not_answer_is_refused(store):
+    """A resample is undefined exactly when it drew no symbol from an edge band.
+
+    Those are the draws carrying the most uncertainty about a gap resting on a thin
+    edge, so reading the interval off the rest conditions on the statistic having
+    been computable — which is a condition the confident draws satisfy. The remedy
+    is to refuse the interval, not to repair it: there is no honest value to
+    substitute, and zero is a measurement nobody made.
+    """
+    # One symbol alone in the top band: better than a third of resamples of 7
+    # symbols draw none of it, and the gap is undefined in every one of those.
+    cohort = [_rtrade("ONE", 6, 2.0, month=1 + i) for i in range(3)]
+    cohort += _ladder({2: -1.0}, per_score=6)
+    cut = bands(cohort)
+
+    boot = bootstrap_symbol_statistic(
+        symbol_clusters(cohort, DEFAULT_CONTRACT),
+        lambda rows: top_minus_bottom(rows, cut),
+    )
+
+    assert boot["clusters"] >= BOOTSTRAP_MIN_CLUSTERS
+    assert boot["undefined"] / boot["resamples"] > MAX_UNDEFINED_SHARE
+    assert (boot["ci_low"], boot["ci_high"], boot["p_value"]) == (None, None, None)
+    assert "could not be evaluated" in boot["suppressed"]
+
+    # And a cohort whose bands are always drawable gets its interval.
+    wide = _ladder({2: -1.0, 6: 2.0}, per_score=8)
+    wide_cut = bands(wide)
+    healthy = bootstrap_symbol_statistic(
+        symbol_clusters(wide, DEFAULT_CONTRACT),
+        lambda rows: top_minus_bottom(rows, wide_cut),
+    )
+    assert healthy["undefined"] == 0
+    assert healthy["ci_low"] is not None
+
+
+def test_the_bands_partition_the_ten_decile_positions_exactly(store):
+    """Each band carries the decile boundaries that fall inside it, and between them
+    the bands account for all ten.
+
+    A band holding 49% carries the four boundaries below it and the fifth belongs to
+    its neighbour — so a band's decile span says where its share sits rather than
+    rounding that share, and no decile position goes unreported.
+    """
+    for cohort in (
+        _ladder({1: -1.0, 3: 0.0, 5: 1.0, 7: 2.0}),
+        [_rtrade(f"L{i}", 3, 0.1) for i in range(49)]
+        + [_rtrade(f"H{i}", 6, 2.0) for i in range(51)],
+        _ladder({4: 1.0}),
+    ):
+        covered = [d for band in bands(cohort) for d in band.deciles]
+        assert covered == list(range(1, 11))
+
+
+def test_the_count_of_intervals_the_report_states_rides_on_it(store):
+    """Every year of every market gets its own gap, rho and verdict, so a report
+    over fourteen years makes scores of significance statements at nominal alpha and
+    some come up positive by construction. A budget a reader has to infer from the
+    length of the page is a budget nobody is keeping."""
+    report = ranking_report(
+        DEFAULT_CONTRACT, _ladder({2: -0.5, 6: 1.5}, per_score=8), markets=("US",)
+    )
+
+    budget = report["multiple_testing"]
+    assert budget["intervals_reported"] > 1
+    assert budget["alpha_is_nominal"] is True
+    assert "sweep" in budget["note"]
+    # A suppressed cell states nothing, so it is not in the count of claims made.
+    stated = sum(
+        1
+        for market in report["markets"]
+        for slice_body in [market, *market["years"]]
+        for cell in [*slice_body["buckets"], slice_body["gap"],
+                     slice_body["spearman"]]
+        if cell["bootstrap"]["ci_low"] is not None
+    )
+    assert budget["intervals_reported"] == stated
 
 
 def test_the_ranking_report_is_stamped_and_serialises(store):


### PR DESCRIPTION
Phase 5's ranking cell: outcomes bucketed by star-score decile, per market and per year, with n on every bucket and significance bootstrapped clustered by symbol. Closes #194.

This is the out-of-sample test §4a's claim has never had. §4a asked whether the rubric separates his picks from the field — on the field v2's weights had been fitted to, which makes it a fit statistic rather than a test, and marginal at p = 0.055 even so. Here the outcome variable is R after costs: no weight was fitted to it, no detection's score could see it, and the trades are ones nobody selected. §4a's figures ride on the payload and print above the buckets with the reason the two are not comparable, so a reader meets the in-sample gap before meeting a number that could be mistaken for it.

**A tie never splits.** The replayed score is seven dimensions of eight integral points, so true deciles do not exist. A score value is atomic: the bands collapse to fewer than ten, partition all ten decile positions between them, and each names the ones that fell inside it. The cut is taken once per market over its **closed** trades — the outcomes being bucketed — and every year is reported against it, so a band names the same score in every row.

**Two statistics, and the verdict needs both.** The top-minus-bottom gap can rest entirely on one hot name; Spearman's rho can be positive and negligible. `ranks` requires both symbol-clustered intervals above zero, a thin or refused edge is `too thin to say`, and `no evidence it ranks` is never `the score does not rank`.

**Undefined resamples do not buy confidence.** A resample is undefined exactly when it drew no symbol from an edge band — the draws carrying the most uncertainty — so reading the interval off the rest conditions on the confident draws. Past `MAX_UNDEFINED_SHARE` the interval is refused rather than repaired.

Costs, the cell shape, the seed, the cluster and the year span are all `backtest.metric`'s, so the ranking and the headline cannot disagree about what a trade paid.

No figures are committed: no denominator has been built over the full window yet, so the run and its write-up remain Phase 3 and Phase 7.

768 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhczH6USPuA7efhu2qizK3