### PR TITLE
Anchor before believing (#197)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -623,7 +623,8 @@ only for a named reason — the published value was measured on the store that r
 references as candidates (#162), so a fresh build shifts percentile denominators by ~0.5%
 and a difference of a few trades is that fix landing. What the tolerance may **never**
 absorb is a flip in the sign of findings §4b's gap, which is the bug the whole table exists
-to find.
+to find — and neither may a **written divergence**: every other anchor may be reproduced *or*
+explained in writing, and that one may only be reproduced.
 _Avoid_: "trades detected", which named one and valued the other; and never check a
 rebuilt pipeline against whichever of the two is nearer.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -595,6 +595,38 @@ one.
 _Avoid_: the ranking result, the decile test; and never quote it against §4a's **+5.59pp**
 as though the two were comparable.
 
+**Anchor**:
+A figure already committed to this repo that a rebuilt pipeline must reproduce before any
+new figure from it is read (PRD #182 Phase 6, `backtest.anchors`). Six of them, checked
+through the study's existing **drift** mechanism, which raises rather than logs. Two kinds,
+and only one is stable. A **geometry anchor** — median trailing 3-bar range 1.31 ADR,
+5-bar 1.86 ADR, 20-day ADR at entry eve 6.08% — is measured from his bars and holds
+whatever the detector does, so it anchors the *store and the indicators* and is checked
+**first**; a failure there stops the check, because nothing downstream is worth
+investigating yet. A **gate-dependent anchor** — coverage, **detection recall**,
+**`in_field`** — moves with coverage and with the gates, so it carries the detector version
+it was measured at and every **superseded pin** beside its live value. An anchor quoted
+from a superseded pin fails for a reason that has nothing to do with the pipeline it is
+testing. Anchoring is against **arms B and C** only: arm A has no counterpart in the
+reference set, so it is measured and never anchored.
+_Avoid_: benchmark, target — an anchor is reproduced or its divergence is written up, and
+neither is something to aim at.
+
+**Detection recall** vs **`in_field`**:
+Two different anchors, conflated once already (#165) and now different *quantities* in
+code. **Detection recall** asks whether the detector would have fired on his name at all —
+**gate-invariant**, because the funnel evaluates every stage unconditionally, and pinned
+exactly at 549 of 656. **`in_field`** asks whether the name reached that night's field, so
+it moves with every gate and coverage change: 397 of 656 at detector **v3**, and a **first
+measurement** with no second one agreeing with it. Only `in_field` carries a tolerance, and
+only for a named reason — the published value was measured on the store that ranks five
+references as candidates (#162), so a fresh build shifts percentile denominators by ~0.5%
+and a difference of a few trades is that fix landing. What the tolerance may **never**
+absorb is a flip in the sign of findings §4b's gap, which is the bug the whole table exists
+to find.
+_Avoid_: "trades detected", which named one and valued the other; and never check a
+rebuilt pipeline against whichever of the two is nearer.
+
 **Not-taken detection**:
 A member of the replayed field on a session where he entered something else. Not a
 declined setup — he may never have seen it — so it is a comparison group, never a

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -152,6 +152,34 @@ already keep :mod:`backtest.metric` out: it is a command
 :class:`~backtest.run.ContractDrift`. The entry point is
 ``backtest.ranking.ranking_report``.
 
+Issue #197 lands Phase 6: :mod:`backtest.anchors`, the six committed figures this
+run reproduces before any new figure from it is read. Three are geometry measured
+from his bars — they hold whatever the detector does, so they anchor the store and
+the indicators and are checked first and reported apart; a failure there stops the
+check, because nothing downstream is worth investigating yet. Three move with
+coverage and with the gates, so each carries the detector version it was measured
+at and every superseded pin beside its live value. Detection recall and ``in_field``
+are kept as different quantities and can never be checked against each other — the
+conflation #165 fixed, made unrepresentable — and the ``in_field`` row's #162
+tolerance covers a few trades' worth of denominator shift but never a flip in the
+sign of §4b's gap. Anchoring is against arms B and C, derived from
+:data:`~backtest.simulate.ARM_SPECS` rather than restated: arm A has no counterpart
+in the reference set, so it is measured and never anchored.
+
+Nothing in it re-measures what already has a home. The anchors arrive as the
+existing measurement types — the funnel's :class:`~replay.funnel.StageRecall`, the
+grid's :class:`~replay.discrimination_grid.CellMeasurement`, the reference
+module's :class:`~replay.reference.ReferenceReport` — and a mismatch raises
+:class:`~replay.reference.DriftError`, the mechanism the study has failed loudly on
+since #114. The geometry is the one exception, and only because its committed
+figures came from a throwaway prototype rather than from a module anything can call.
+
+:mod:`backtest.anchors`'s names are **not** re-exported here, for the reasons that
+already keep :mod:`backtest.metric` out: it is a command
+(``python -m backtest.anchors``) and it imports :mod:`backtest.simulate`, which
+imports :class:`~backtest.run.ContractDrift`. The entry point is
+``backtest.anchors.check_anchors``.
+
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean
 something else one import away (:mod:`screener.universe`, :mod:`replay.reference`),

--- a/backend/backtest/anchors.py
+++ b/backend/backtest/anchors.py
@@ -1,0 +1,1183 @@
+"""Anchor before believing: the six committed figures a new run must reproduce
+(issue #197, PRD #182 Phase 6).
+
+The run overlaps ground the reference study already measured. Before any new
+figure from it is read, it reproduces the figures already committed to this repo
+or writes down why it cannot — because a mismatch is a bug in the new store or
+the new chain, and every downstream number inherits it.
+
+Nothing here is a second measurement. The anchors arrive as the *existing*
+measurement types — :class:`replay.funnel.StageRecall`,
+:class:`replay.discrimination_grid.CellMeasurement`,
+:class:`replay.reference.ReferenceReport` — through the adapters below, and a
+mismatch is raised as :class:`replay.reference.DriftError`, the drift mechanism
+the study has failed loudly on since #114. The one quantity measured here is the
+geometry (:func:`measure_geometry`), and only because its committed figures came
+from a throwaway prototype (findings §3b) rather than from a module anything can
+call.
+
+Two kinds of anchor, and only one is stable
+-------------------------------------------
+The three **geometry** anchors are measured from his bars: median trailing 3-bar
+range 1.31 ADR, median trailing 5-bar range 1.86 ADR, median 20-day ADR at entry
+eve 6.08%. They hold whatever the detector does, so they anchor the *store and the
+indicators*. :func:`check_anchors` checks them **first**, reports them apart, and
+on a failure stops without reading the other three: if the store's geometry is
+wrong, nothing downstream is worth investigating yet.
+
+The three **gate-dependent** anchors — coverage, detection recall, ``in_field`` —
+depend on coverage and on the gates themselves and have moved repeatedly (#139,
+#149, #154, #164, #165). Each is stamped with the detector version it was measured
+at, and every superseded pin is recorded beside its live value
+(:attr:`Anchor.superseded`), because an anchor quoted from a stale pin fails for a
+reason that has nothing to do with the pipeline it is testing.
+
+The two field rows are different anchors, and were once conflated
+-----------------------------------------------------------------
+Until #165 one row carried detection recall's label and ``in_field``'s value. They
+are not the same quantity: recall asks whether the detector would have fired on his
+name at all and is **gate-invariant**; ``in_field`` asks whether the name reached
+that night's field and moves with every gate and coverage change. So each anchor
+declares the :attr:`Anchor.quantity` it measures, every measurement carries the
+quantity it *is*, and :func:`check_anchors` refuses a measurement whose quantity is
+not the anchor's. Wiring the funnel's recall into the ``in_field`` anchor is
+therefore an error at the seam rather than an anchor failing that should have
+passed — the failure this table exists to prevent, arriving through the table.
+
+The ``in_field`` tolerance, and the one thing it may not absorb
+---------------------------------------------------------------
+``in_field`` was measured on ``replay.duckdb``, which ranks five references as
+though they were candidates (#162). The store was deliberately left that way; the
+fix binds fresh builds only. **This run is a fresh build, so it will not reproduce
+the committed value exactly, and should not.** The direction is known and the size
+is bounded — percentile denominators shift by ~0.5%, moving decile membership at
+the margin and nothing else — so :data:`CONTAMINATION_TRADES` treats a difference
+of a few trades as the fix landing.
+
+What the tolerance may **not** absorb is a difference large enough to flip the sign
+of §4b's gap. That is the bug this table is looking for, so the gap rides on the
+same anchor as a **sign-checked** component (:attr:`Anchor.sign_checked`): its
+magnitude is free to move, its sign is not, and a flip fails the anchor whatever
+the trade count did.
+
+Arms B and C only
+-----------------
+:data:`ANCHOR_ARMS` is derived from :data:`~backtest.simulate.ARM_SPECS`, not
+restated: an arm is anchorable exactly when it is comparable to the reference set's
+simulated exits. Arm A has no counterpart there, so a measurement tagged with it is
+refused — arm A is measured, never anchored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date
+from math import inf, isnan
+from pathlib import Path
+from statistics import median
+from typing import Any, Iterable, Mapping, Sequence
+
+from replay.discrimination_grid import (
+    FIELD_WHOLE,
+    PUBLISHED_RUBRIC,
+    CellMeasurement,
+)
+from replay.funnel import STAGE_DETECTION, StageRecall
+from replay.reference import (
+    DEFAULT_REFERENCE_JSON,
+    REFERENCE_FIGURES,
+    DriftError,
+    ExecutedTrade,
+    ReferenceReport,
+    build_report,
+    evaluation_session,
+    load_trades,
+)
+from screener.bars import Bar
+from screener.detection import DETECTOR_VERSION, K_MIN
+from screener.indicators import ADR_WINDOW, adr as _adr
+from screener.store import Store
+
+from .contract import DEFAULT_CONTRACT, RunContract
+from .result import stamp_result
+from .simulate import ARM_SPECS
+
+# The market the reference set was traded in. Every anchor here is measured over
+# his 828 US entries; the run reports IDX separately and anchors nothing against
+# it, because there is no IDX counterpart in the reference set to anchor to.
+ANCHOR_MARKET = "US"
+
+# The arms an anchor may be taken against: exactly the arms comparable to the
+# reference set's two simulated exits. Derived from the arm table rather than
+# restated as ``("B", "C")``, so a fourth arm is anchorable or not according to
+# the one fact that decides it.
+ANCHOR_ARMS: tuple[str, ...] = tuple(
+    arm for arm, spec in sorted(ARM_SPECS.items()) if spec.comparable_to_reference
+)
+
+# The two kinds of anchor. Geometry is measured from his bars and holds whatever
+# the detector does; a gate-dependent anchor moves with coverage and with the
+# gates, which is why the two are checked and reported apart.
+GEOMETRY = "geometry"
+GATE_DEPENDENT = "gate-dependent"
+
+# What an anchor measures. The two field anchors carry different quantities and
+# that is the whole point: a measurement of one can never be checked against the
+# other (#165's conflation, made unrepresentable).
+QUANTITY_GEOMETRY = "bar-geometry"
+QUANTITY_COVERAGE = "reference-coverage"
+QUANTITY_DETECTION_RECALL = "detection-recall (gate-invariant)"
+QUANTITY_IN_FIELD = "field-membership (gate-dependent)"
+
+# The `in_field` band the #162 reference contamination is allowed to move the count
+# by. The published values were measured on a store that ranks five references in a
+# ranked population of ~1,000, so percentile denominators shift by ~0.5%. Applied to
+# the 656 replayable trades that is 3.3 trades at one decile boundary; doubled to
+# bound movement at both edges and rounded up, which is the "difference of a few
+# trades" the plan calls the fix landing. Deliberately not wider: past this, the
+# difference is not a denominator shift.
+CONTAMINATION_TRADES = 7
+
+# The geometry bands. The committed medians were measured over 649 replayable
+# entries by an independently written prototype against a differently-built store,
+# so a handful of trades entering or leaving the sample moves a median in the second
+# decimal. These bands are that wobble and the quoted precision — roughly 1.5% of
+# each figure — and nothing like the movement a wrong adjustment basis or a
+# mis-slid evaluation session would produce.
+RANGE_TOL_ADR = 0.02
+ADR_TOL = 0.001  # 0.10 percentage points, on a fraction
+
+# The sign-checked component's own tolerance: the gap's *magnitude* is free.
+_FREE = inf
+
+
+@dataclass(frozen=True)
+class Pin:
+    """A superseded value, recorded beside the live one.
+
+    Kept on the anchor rather than in a comment, because the failure mode this
+    guards is a reader quoting a stale figure at a new run: the pin fails the
+    anchor for a reason that has nothing to do with the pipeline being tested.
+    ``why`` says what moved it, so a mismatch against a pin is recognisable as a
+    mismatch against a pin.
+    """
+
+    value: str
+    why: str
+
+
+@dataclass(frozen=True)
+class Anchor:
+    """One committed figure, and everything needed to check it honestly.
+
+    ``committed`` and ``tolerance`` are keyed by component, so a row quoting two
+    numbers ("92 / 172 of 312 / 828") is one anchor rather than two half-anchors
+    that could pass separately. ``measured_at`` is the detector version stamp —
+    empty for the geometry rows, which no detector touches, and multi-valued for
+    detection recall, which is gate-invariant and holds at v2 and v3 alike.
+    ``sign_checked`` names components whose *sign* must reproduce regardless of
+    tolerance.
+    """
+
+    key: str
+    label: str
+    kind: str
+    quantity: str
+    committed: Mapping[str, float]
+    tolerance: Mapping[str, float]
+    unit: str
+    source: str
+    measured_at: tuple[int, ...]
+    first_measurement: bool = False
+    tolerance_reason: str | None = None
+    sign_checked: tuple[str, ...] = ()
+    superseded: tuple[Pin, ...] = ()
+    note: str = ""
+
+    @property
+    def detector_stamp(self) -> str:
+        """The version stamp as it prints — never blank, because a figure whose
+        version is absent gets compared against a run built at another one."""
+        if not self.measured_at:
+            return "detector-independent (bar geometry)"
+        versions = ", ".join(f"v{v}" for v in self.measured_at)
+        return f"detector {versions}"
+
+    def holds_at(self, detector_version: int) -> bool:
+        """Whether this anchor has a committed value at ``detector_version``.
+
+        Version-independent anchors hold everywhere. A gate-dependent one holds
+        only where it was measured: quoting v2's ``in_field`` at a run built on v3
+        is the error the row's per-version stamp exists to prevent.
+        """
+        return not self.measured_at or detector_version in self.measured_at
+
+
+# -- the six anchors, geometry first ------------------------------------------
+
+# Findings §3b/§3c. Measured from his bars at the evaluation session, so they say
+# whether the store holds the right bars and the indicators read them the same way
+# — independently of every gate. Checked first for that reason.
+GEOMETRY_ANCHORS: tuple[Anchor, ...] = (
+    Anchor(
+        key="median_range_3bar_adr",
+        label="Median trailing 3-bar range at his entries",
+        kind=GEOMETRY,
+        quantity=QUANTITY_GEOMETRY,
+        committed={"median": 1.31},
+        tolerance={"median": RANGE_TOL_ADR},
+        unit="ADR",
+        source="findings §3b",
+        measured_at=(),
+        note=(
+            "the ungated ruler the far-outlier guard tests and the rubric grades; "
+            "monotone in k, so it is also the tightest window the cluster scan sees"
+        ),
+    ),
+    Anchor(
+        key="median_range_5bar_adr",
+        label="Median trailing 5-bar range at his entries",
+        kind=GEOMETRY,
+        quantity=QUANTITY_GEOMETRY,
+        committed={"median": 1.86},
+        tolerance={"median": RANGE_TOL_ADR},
+        unit="ADR",
+        source="findings §3b, §3c",
+        measured_at=(),
+        note=(
+            "the travel measure §3c reads the late contraction off — flat at ~2.4 "
+            "ADR from three months out, falling only in the last ~10 sessions"
+        ),
+    ),
+    Anchor(
+        key="median_adr_at_entry_eve",
+        label="Median 20-day ADR at entry eve",
+        kind=GEOMETRY,
+        quantity=QUANTITY_GEOMETRY,
+        committed={"median": 0.0608},
+        tolerance={"median": ADR_TOL},
+        unit="fraction of price",
+        source="findings §3c",
+        measured_at=(),
+        note=(
+            "flat into his entries: what contracts is travel, not the daily range, "
+            "so a store bug that smooths bars shows here before anywhere else"
+        ),
+    ),
+)
+
+# The three that move with coverage and with the gates. Each carries its version
+# stamp and its superseded pins.
+GATE_DEPENDENT_ANCHORS: tuple[Anchor, ...] = (
+    Anchor(
+        key="coverage_blind_spot",
+        label="Blind-spot tickers / trades, 2019–2022",
+        kind=GATE_DEPENDENT,
+        quantity=QUANTITY_COVERAGE,
+        # Read off the reference module's own pins rather than restated, so this
+        # table and :func:`replay.reference.assert_matches_reference` cannot come
+        # to disagree about what was committed.
+        committed={
+            "blind_spot_tickers": REFERENCE_FIGURES["blind_spot_tickers"],
+            "blind_spot_trades": REFERENCE_FIGURES["blind_spot_trades"],
+            "distinct_tickers": REFERENCE_FIGURES["distinct_tickers"],
+            "total_rows": REFERENCE_FIGURES["total_rows"],
+        },
+        tolerance={
+            "blind_spot_tickers": 0,
+            "blind_spot_trades": 0,
+            "distinct_tickers": 0,
+            "total_rows": 0,
+        },
+        unit="count",
+        source="findings §2",
+        measured_at=(),
+        note=(
+            "measured in the replay window against bars covering each trade's "
+            "evaluation session — the condition under which anything can be said "
+            "about a trade at all"
+        ),
+        superseded=(
+            Pin("81 tickers / 141 trades / 11.7%",
+                "measured over all history rather than in the replay window (#114)"),
+            Pin("91 tickers / 170 trades of 658 replayable",
+                "measured under the has-any-bars test #139 replaced, which replayed "
+                "one company's trade against another company's bars"),
+        ),
+    ),
+    Anchor(
+        key="detection_recall",
+        label="Detection recall (A1), gate-invariant",
+        kind=GATE_DEPENDENT,
+        quantity=QUANTITY_DETECTION_RECALL,
+        committed={"passed": 549, "of": 656},
+        tolerance={"passed": 0, "of": 0},
+        unit="trades",
+        source="findings §3, §3b",
+        # Gate-invariant: the funnel evaluates every stage unconditionally, so
+        # #149's gate width does not move it. It is stamped at both versions whose
+        # geometry it was measured under, and holds at either.
+        measured_at=(2, 3),
+        note=(
+            "whether the detector would have fired on his name at all — never "
+            "whether the name reached that night's field"
+        ),
+        superseded=(
+            Pin("380 of 658",
+                "measured under v1's hard 1.5×ADR cluster cut, before #154's "
+                "far-outlier guard, and on the pre-#139 replayable population"),
+        ),
+    ),
+    Anchor(
+        key="in_field",
+        label="Trades in the replayed field (A2 in_field)",
+        kind=GATE_DEPENDENT,
+        quantity=QUANTITY_IN_FIELD,
+        # The gap rides on the same anchor as the count, because the count's
+        # tolerance is only defensible while the gap's sign holds.
+        committed={"in_field": 397, "of": 656, "gap_pp": 1.95},
+        tolerance={
+            "in_field": CONTAMINATION_TRADES,
+            "of": 0,
+            "gap_pp": _FREE,
+        },
+        unit="trades",
+        source="findings §4b",
+        measured_at=(3,),
+        first_measurement=True,
+        tolerance_reason=(
+            "#162: both committed in_field values were measured on a store that "
+            "ranks five references as candidates. A fresh build shifts percentile "
+            f"denominators by ~0.5%, so a difference up to {CONTAMINATION_TRADES} "
+            "trades is the fix landing, not a bug. The gap's sign is not covered "
+            "by this tolerance"
+        ),
+        sign_checked=("gap_pp",),
+        note=(
+            "a first measurement with no second one agreeing with it, so a "
+            "mismatch is investigated in both directions rather than charged "
+            "straight to the new pipeline"
+        ),
+        superseded=(
+            Pin("349 of 656 at detector v2",
+                "the live gate has moved v2 → v3; the v2 → v3 widening admits 48 "
+                "more of his trades without any of them changing"),
+            Pin("159 of 656 at detector v2",
+                "measured on the field the two-year rank retention had truncated "
+                "(#164)"),
+            Pin("104 of 656 at detector v1",
+                "measured on the truncated field under v1's hard cluster cut"),
+            Pin("104 of 658 at detector v1",
+                "measured before #139 re-pinned the replayable population"),
+        ),
+    ),
+)
+
+ANCHORS: tuple[Anchor, ...] = GEOMETRY_ANCHORS + GATE_DEPENDENT_ANCHORS
+
+ANCHORS_BY_KEY: Mapping[str, Anchor] = {a.key: a for a in ANCHORS}
+
+
+# -- measurements: the existing types, adapted --------------------------------
+
+
+@dataclass(frozen=True)
+class Measurement:
+    """One anchor's measured value, tagged with what it *is*.
+
+    ``quantity`` is the guard that keeps the two field anchors apart: it is set by
+    the adapter that built the measurement, from the type it read, so a caller
+    cannot offer the funnel's recall as the field-membership measurement. ``arm``
+    is the exit arm the measurement was taken on where one applies; ``None`` for a
+    quantity no exit touches (geometry, coverage, recall).
+    """
+
+    anchor: str
+    quantity: str
+    values: Mapping[str, float]
+    arm: str | None = None
+    detector_version: int | None = None
+
+
+@dataclass(frozen=True)
+class GeometryMeasurement:
+    """The three geometry medians, measured over his entries at the eval session.
+
+    ``n`` is how many trades carried all three; ``without_bars``,
+    ``short_history`` and ``no_prior_session`` say where the rest went, because a
+    median over a silently halved sample is the failure this anchor is meant to
+    catch and it prints as a plausible number.
+    """
+
+    n: int
+    median_range_3bar_adr: float | None
+    median_range_5bar_adr: float | None
+    median_adr_at_entry_eve: float | None
+    without_bars: int
+    short_history: int
+    no_prior_session: int
+
+
+def trailing_range_adr(bars: Sequence[Bar], as_of: int, k: int) -> float | None:
+    """The trailing ``k``-bar range at index ``as_of``, in ADR units.
+
+    ``(max high − min low) / (ADR × close)`` over the ``k`` bars ending at
+    ``as_of``, ungated — the quantity findings §3b tabulates for every k in 3..7.
+    The detector owns this ruler at ``k = K_MIN`` and only there
+    (:func:`screener.detection.range_3bar_adr`), which is why this generalisation
+    lives here rather than in the app: nothing the app does needs k = 5. It is
+    checked against the detector's own function at k = 3 by
+    ``test_the_five_bar_ruler_agrees_with_the_detectors_own_at_three_bars``, so
+    the two cannot drift into disagreeing about the same number.
+
+    ``None`` when the window runs off the front of the series or ADR is
+    unavailable or non-positive.
+    """
+    if as_of < 0 or as_of >= len(bars) or k < 1:
+        return None
+    lo = as_of - k + 1
+    if lo < 0:
+        return None
+    a = _adr(list(bars[: as_of + 1]))
+    if a is None or a <= 0:
+        return None
+    adr_abs = a * bars[as_of].close
+    if adr_abs <= 0:
+        return None
+    window = bars[lo : as_of + 1]
+    return (max(b.high for b in window) - min(b.low for b in window)) / adr_abs
+
+
+def _index_at(bars: Sequence[Bar], as_of: date) -> int | None:
+    """Index of the last bar on or before ``as_of``, or ``None`` if there is none."""
+    idx = None
+    for i, bar in enumerate(bars):
+        if bar.session > as_of:
+            break
+        idx = i
+    return idx
+
+
+def measure_geometry(
+    store: Store,
+    trades: Iterable[ExecutedTrade],
+    *,
+    market: str = ANCHOR_MARKET,
+) -> GeometryMeasurement:
+    """Measure the three geometry anchors off ``store`` at his evaluation sessions.
+
+    Point-in-time throughout: every value is read at the last session strictly
+    before the entry (:func:`replay.reference.evaluation_session`), from bars at or
+    before it, with the app's own ADR. Nothing is gated at measurement time — the
+    ranges are the raw trailing spans, which is what makes them anchor the store
+    rather than the detector.
+
+    A trade contributes to all three medians or to none of them, so the three
+    figures are taken over one sample and a divergence between them cannot be a
+    difference in who was included.
+    """
+    calendar = store.sessions(market)
+    ranges3: list[float] = []
+    ranges5: list[float] = []
+    adrs: list[float] = []
+    without_bars = short_history = no_prior_session = 0
+
+    for trade in trades:
+        bars = store.bars(market, trade.ticker)
+        if not bars:
+            without_bars += 1
+            continue
+        eve = evaluation_session(calendar, trade.entry_date)
+        if eve is None:
+            no_prior_session += 1
+            continue
+        idx = _index_at(bars, eve)
+        if idx is None or idx + 1 < ADR_WINDOW:
+            short_history += 1
+            continue
+        a = _adr(list(bars[: idx + 1]))
+        r3 = trailing_range_adr(bars, idx, K_MIN)
+        r5 = trailing_range_adr(bars, idx, 5)
+        if a is None or a <= 0 or r3 is None or r5 is None:
+            short_history += 1
+            continue
+        adrs.append(a)
+        ranges3.append(r3)
+        ranges5.append(r5)
+
+    return GeometryMeasurement(
+        n=len(adrs),
+        median_range_3bar_adr=median(ranges3) if ranges3 else None,
+        median_range_5bar_adr=median(ranges5) if ranges5 else None,
+        median_adr_at_entry_eve=median(adrs) if adrs else None,
+        without_bars=without_bars,
+        short_history=short_history,
+        no_prior_session=no_prior_session,
+    )
+
+
+def geometry_measurements(
+    measured: GeometryMeasurement,
+) -> list[Measurement]:
+    """The three geometry medians as anchor measurements.
+
+    A median that could not be computed is offered as ``nan`` rather than skipped:
+    an anchor with no measurement must fail, not vanish from the report.
+    """
+    values = {
+        "median_range_3bar_adr": measured.median_range_3bar_adr,
+        "median_range_5bar_adr": measured.median_range_5bar_adr,
+        "median_adr_at_entry_eve": measured.median_adr_at_entry_eve,
+    }
+    return [
+        Measurement(
+            anchor=key,
+            quantity=QUANTITY_GEOMETRY,
+            values={"median": float("nan") if value is None else value},
+        )
+        for key, value in values.items()
+    ]
+
+
+def coverage_measurement(report: ReferenceReport) -> Measurement:
+    """The blind-spot coverage anchor, read off the reference report.
+
+    The same report :func:`replay.reference.assert_matches_reference` checks, and
+    against the same committed numbers — this anchor reports it in Phase 6's order
+    beside the others rather than measuring it a second way.
+    """
+    return Measurement(
+        anchor="coverage_blind_spot",
+        quantity=QUANTITY_COVERAGE,
+        values={
+            "blind_spot_tickers": report.blind_spot_tickers,
+            "blind_spot_trades": report.blind_spot_trades,
+            "distinct_tickers": report.distinct_tickers,
+            "total_rows": report.total_rows,
+        },
+    )
+
+
+def recall_measurement(stage: StageRecall, *, arm: str | None = None) -> Measurement:
+    """Detection recall, read off the funnel's **detection** stage.
+
+    Takes a :class:`~replay.funnel.StageRecall` and nothing else, which is what
+    makes the conflation #165 fixed unrepresentable here: the field-membership
+    anchor cannot be fed from this type, and this anchor cannot be fed from a grid
+    cell. A recall offered from another stage is refused — the liquidity stage's
+    recall is a real number and is not this anchor.
+    """
+    if stage.stage != STAGE_DETECTION:
+        raise DriftError(
+            f"detection recall must be read off the funnel's detection stage; "
+            f"got the {stage.stage!r} stage"
+        )
+    return Measurement(
+        anchor="detection_recall",
+        quantity=QUANTITY_DETECTION_RECALL,
+        values={"passed": stage.passed, "of": stage.total},
+        arm=arm,
+    )
+
+
+def in_field_measurement(
+    cell: CellMeasurement, *, replayable: int, arm: str | None = None
+) -> Measurement:
+    """The ``in_field`` anchor and §4b's gap, read off one grid cell.
+
+    The cell must be the **whole** field: the truncated field is the population
+    #164 found the two-year rank retention had emptied on 316 of 821 sessions, and
+    every figure taken over it is superseded. The gap is the cell's own
+    :meth:`~replay.discrimination_grid.CellMeasurement.edge` under the rubric §4b
+    published it with, so the sign this anchor guards is the sign §4b states.
+    """
+    if cell.field_source is not FIELD_WHOLE:
+        raise DriftError(
+            f"in_field is anchored on the whole field; got the "
+            f"{cell.field_source.name!r} field, whose figures are superseded"
+        )
+    gap = cell.edge(PUBLISHED_RUBRIC)
+    return Measurement(
+        anchor="in_field",
+        quantity=QUANTITY_IN_FIELD,
+        values={
+            "in_field": cell.in_field,
+            "of": replayable,
+            "gap_pp": float("nan") if gap is None else gap,
+        },
+        arm=arm,
+        detector_version=cell.detector.version,
+    )
+
+
+# -- the check ----------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ComponentCheck:
+    """One component of one anchor: what was committed, what came back, and why
+    the difference did or did not pass."""
+
+    name: str
+    committed: float
+    measured: float
+    tolerance: float
+    matched: bool
+    sign_flipped: bool
+
+    @property
+    def divergence(self) -> float:
+        return self.measured - self.committed
+
+
+@dataclass(frozen=True)
+class AnchorCheck:
+    """One anchor's verdict, with its components and any written divergence."""
+
+    anchor: Anchor
+    measurement: Measurement | None
+    components: tuple[ComponentCheck, ...]
+    explanation: str | None = None
+
+    @property
+    def matched(self) -> bool:
+        return bool(self.components) and all(c.matched for c in self.components)
+
+    @property
+    def explained(self) -> bool:
+        """A divergence with a cause written down. Recorded as a divergence, never
+        reported as a match — the plan's "or explain the divergence in writing"."""
+        return not self.matched and bool(self.explanation)
+
+    @property
+    def passes(self) -> bool:
+        return self.matched or self.explained
+
+    @property
+    def verdict(self) -> str:
+        if self.matched:
+            return "match"
+        if self.explained:
+            return "diverged (explained)"
+        return "FAILED"
+
+
+@dataclass(frozen=True)
+class AnchorReport:
+    """The Phase 6 result: geometry apart from gate-dependent, in that order.
+
+    ``geometry_only`` is set when the gate-dependent anchors were not read at all
+    — a geometry failure stopped the check, or their measurements never arrived.
+    The report says so rather than printing an empty section that reads as three
+    passes, and :attr:`passes` is false whatever the geometry did: a partially
+    anchored run is not an anchored run.
+    """
+
+    detector_version: int
+    arms: tuple[str, ...]
+    geometry: tuple[AnchorCheck, ...]
+    gate_dependent: tuple[AnchorCheck, ...]
+    geometry_only: bool = False
+    sample: GeometryMeasurement | None = None
+
+    @property
+    def checks(self) -> tuple[AnchorCheck, ...]:
+        return self.geometry + self.gate_dependent
+
+    @property
+    def passes(self) -> bool:
+        return not self.geometry_only and all(c.passes for c in self.checks)
+
+
+def _matches(value: float, committed: float, tolerance: float) -> bool:
+    if isnan(value):
+        return False
+    if tolerance == _FREE:
+        return True
+    return abs(value - committed) <= tolerance
+
+
+def _sign(value: float) -> int:
+    return (value > 0) - (value < 0)
+
+
+def _check_one(
+    anchor: Anchor,
+    measurement: Measurement | None,
+    *,
+    detector_version: int,
+    explanation: str | None,
+) -> AnchorCheck:
+    if measurement is None:
+        raise DriftError(
+            f"anchor {anchor.key!r} ({anchor.label}) has no measurement; every "
+            "anchor is checked or the run is not anchored"
+        )
+    if measurement.quantity != anchor.quantity:
+        raise DriftError(
+            f"anchor {anchor.key!r} measures {anchor.quantity!r}, but the "
+            f"measurement offered is {measurement.quantity!r}. These are "
+            "different quantities and were conflated once already (#165): "
+            "detection recall is gate-invariant, in_field moves with every gate"
+        )
+    if measurement.arm is not None and measurement.arm not in ANCHOR_ARMS:
+        raise DriftError(
+            f"anchor {anchor.key!r} was measured on arm {measurement.arm!r}, which "
+            f"has no counterpart in the reference set; anchor against arms "
+            f"{', '.join(ANCHOR_ARMS)} only"
+        )
+    if not anchor.holds_at(detector_version):
+        raise DriftError(
+            f"anchor {anchor.key!r} has no committed value at detector "
+            f"v{detector_version}; it was measured at {anchor.detector_stamp}, and "
+            "a value quoted from the wrong version fails for a reason that has "
+            "nothing to do with the pipeline it is testing"
+        )
+    if (
+        measurement.detector_version is not None
+        and measurement.detector_version != detector_version
+    ):
+        raise DriftError(
+            f"anchor {anchor.key!r} was measured at detector "
+            f"v{measurement.detector_version}, but the run is built at "
+            f"v{detector_version}; anchor against the version the run is built at"
+        )
+
+    components: list[ComponentCheck] = []
+    for name, committed in anchor.committed.items():
+        if name not in measurement.values:
+            raise DriftError(
+                f"anchor {anchor.key!r} is missing its {name!r} component; a row "
+                "quoting two numbers cannot pass on one of them"
+            )
+        value = float(measurement.values[name])
+        tolerance = float(anchor.tolerance[name])
+        flipped = name in anchor.sign_checked and (
+            isnan(value) or _sign(value) != _sign(committed)
+        )
+        components.append(
+            ComponentCheck(
+                name=name,
+                committed=committed,
+                measured=value,
+                tolerance=tolerance,
+                matched=_matches(value, committed, tolerance) and not flipped,
+                sign_flipped=flipped,
+            )
+        )
+    return AnchorCheck(
+        anchor=anchor,
+        measurement=measurement,
+        components=tuple(components),
+        explanation=explanation,
+    )
+
+
+def _describe(check: AnchorCheck) -> str:
+    bits = []
+    for c in check.components:
+        if c.matched:
+            continue
+        if c.sign_flipped:
+            bits.append(
+                f"{c.name}: got {c.measured:+.4g}, §4b committed "
+                f"{c.committed:+.4g} — the sign flipped, which the "
+                "reference-contamination tolerance does not cover"
+            )
+        else:
+            bits.append(
+                f"{c.name}: got {c.measured:.6g}, committed {c.committed:.6g} "
+                f"(tolerance ±{c.tolerance:g})"
+            )
+    return f"{check.anchor.key} ({check.anchor.label}) — " + "; ".join(bits)
+
+
+def _index(
+    measurements: Iterable[Measurement],
+    *,
+    explained: Mapping[str, str],
+    arms: Sequence[str],
+) -> dict[str, Measurement]:
+    """One measurement per anchor, with the two refusals that precede any check."""
+    unknown = set(explained) - set(ANCHORS_BY_KEY)
+    if unknown:
+        raise DriftError(
+            f"explanation offered for unknown anchor(s): {', '.join(sorted(unknown))}"
+        )
+    refused = [a for a in arms if a not in ANCHOR_ARMS]
+    if refused:
+        raise DriftError(
+            f"arm(s) {', '.join(refused)} have no counterpart in the reference set "
+            f"and are measured, never anchored; anchor against "
+            f"{', '.join(ANCHOR_ARMS)} only"
+        )
+
+    by_anchor: dict[str, Measurement] = {}
+    for m in measurements:
+        if m.anchor not in ANCHORS_BY_KEY:
+            raise DriftError(f"measurement offered for unknown anchor {m.anchor!r}")
+        if m.anchor in by_anchor:
+            raise DriftError(
+                f"two measurements offered for anchor {m.anchor!r}; an anchor has "
+                "one measured value or it has none"
+            )
+        by_anchor[m.anchor] = m
+    return by_anchor
+
+
+def check_geometry(
+    measurements: Iterable[Measurement],
+    *,
+    detector_version: int = DETECTOR_VERSION,
+    explained: Mapping[str, str] | None = None,
+    arms: Sequence[str] = ANCHOR_ARMS,
+) -> tuple[AnchorCheck, ...]:
+    """The three geometry anchors alone, checked without raising on a mismatch.
+
+    The group :func:`check_anchors` runs first. Exposed on its own so a command
+    that cannot reach the gate-dependent measurements still *reports* what the
+    store's geometry did, rather than printing nothing and leaving the reader to
+    infer whether it was checked.
+    """
+    explained = dict(explained or {})
+    by_anchor = _index(measurements, explained=explained, arms=arms)
+    return tuple(
+        _check_one(a, by_anchor.get(a.key), detector_version=detector_version,
+                   explanation=explained.get(a.key))
+        for a in GEOMETRY_ANCHORS
+    )
+
+
+def check_anchors(
+    measurements: Iterable[Measurement],
+    *,
+    detector_version: int = DETECTOR_VERSION,
+    explained: Mapping[str, str] | None = None,
+    arms: Sequence[str] = ANCHOR_ARMS,
+    sample: GeometryMeasurement | None = None,
+) -> AnchorReport:
+    """Check every anchor, geometry first, and fail loudly on a mismatch.
+
+    Raises :class:`replay.reference.DriftError` — the study's existing drift
+    mechanism — on the first group that fails. The **geometry** anchors are checked
+    and reported apart from the gate-dependent ones, and a geometry failure stops
+    the check: if the store's own geometry does not reproduce, no gate-dependent
+    figure measured over that store is worth investigating yet.
+
+    ``explained`` maps an anchor key to a written cause. A divergence with a cause
+    is recorded as a divergence and does not raise (the plan's "reproduce it, or
+    explain the divergence in writing"); it never prints as a match. A divergence
+    without one raises.
+    """
+    explained = dict(explained or {})
+    measurements = list(measurements)
+    by_anchor = _index(measurements, explained=explained, arms=arms)
+
+    geometry = check_geometry(
+        measurements, detector_version=detector_version, explained=explained,
+        arms=arms,
+    )
+    failed = [c for c in geometry if not c.passes]
+    if failed:
+        raise DriftError(
+            "the geometry anchors did not reproduce, so the gate-dependent "
+            "anchors were not read — these are measured from his bars and hold "
+            "whatever the detector does, so a failure here is the store or the "
+            "indicators and nothing downstream is worth investigating yet:\n  "
+            + "\n  ".join(_describe(c) for c in failed)
+        )
+
+    gate_dependent = tuple(
+        _check_one(a, by_anchor.get(a.key), detector_version=detector_version,
+                   explanation=explained.get(a.key))
+        for a in GATE_DEPENDENT_ANCHORS
+    )
+    failed = [c for c in gate_dependent if not c.passes]
+    if failed:
+        raise DriftError(
+            f"the gate-dependent anchors did not reproduce at detector "
+            f"v{detector_version}:\n  "
+            + "\n  ".join(_describe(c) for c in failed)
+        )
+
+    return AnchorReport(
+        detector_version=detector_version,
+        arms=tuple(arms),
+        geometry=geometry,
+        gate_dependent=gate_dependent,
+        sample=sample,
+    )
+
+
+# -- reporting ----------------------------------------------------------------
+
+
+def _component_dict(c: ComponentCheck) -> dict[str, Any]:
+    return {
+        "component": c.name,
+        "committed": c.committed,
+        "measured": None if isnan(c.measured) else c.measured,
+        "tolerance": None if c.tolerance == _FREE else c.tolerance,
+        "divergence": None if isnan(c.measured) else c.divergence,
+        "matched": c.matched,
+        "sign_flipped": c.sign_flipped,
+    }
+
+
+def _check_dict(check: AnchorCheck) -> dict[str, Any]:
+    a = check.anchor
+    return {
+        "anchor": a.key,
+        "label": a.label,
+        "kind": a.kind,
+        "quantity": a.quantity,
+        "unit": a.unit,
+        "source": a.source,
+        "detector_stamp": a.detector_stamp,
+        "measured_at_detector": list(a.measured_at),
+        "first_measurement": a.first_measurement,
+        "tolerance_reason": a.tolerance_reason,
+        "note": a.note,
+        "superseded": [{"value": p.value, "why": p.why} for p in a.superseded],
+        "arm": check.measurement.arm if check.measurement else None,
+        "verdict": check.verdict,
+        "explanation": check.explanation,
+        "components": [_component_dict(c) for c in check.components],
+    }
+
+
+def anchors_report(contract: RunContract, report: AnchorReport) -> dict[str, Any]:
+    """The anchor report as a stamped, serialisable payload.
+
+    Geometry and gate-dependent are separate keys, not one list with a field to
+    filter on: the plan's order is a claim about what is worth reading when, and a
+    reader who has to sort the rows to recover it will not.
+    """
+    body: dict[str, Any] = {
+        "detector_version": report.detector_version,
+        "arms_anchored": list(report.arms),
+        "arms_measured_never_anchored": [
+            arm for arm in sorted(ARM_SPECS) if arm not in ANCHOR_ARMS
+        ],
+        "geometry": [_check_dict(c) for c in report.geometry],
+        "gate_dependent": [_check_dict(c) for c in report.gate_dependent],
+        "geometry_only": report.geometry_only,
+        "passes": report.passes,
+    }
+    if report.sample is not None:
+        s = report.sample
+        body["geometry_sample"] = {
+            "n": s.n,
+            "without_bars": s.without_bars,
+            "short_history": s.short_history,
+            "no_prior_session": s.no_prior_session,
+        }
+    return stamp_result(contract, body)
+
+
+def _format_check(check: AnchorCheck) -> list[str]:
+    a = check.anchor
+    lines = [f"  {a.label}", f"    stamp     {a.detector_stamp} — {a.source}"]
+    for c in check.components:
+        mark = "ok " if c.matched else "!! "
+        measured = "n/a" if isnan(c.measured) else f"{c.measured:.6g}"
+        tolerance = "free" if c.tolerance == _FREE else f"±{c.tolerance:g}"
+        lines.append(
+            f"    {mark}{c.name:<20} committed {c.committed:<10.6g} "
+            f"measured {measured:<10} ({tolerance} {a.unit})"
+        )
+        if c.sign_flipped:
+            lines.append(
+                "       ⚠ the sign of §4b's gap flipped — not covered by the "
+                "reference-contamination tolerance"
+            )
+    if a.first_measurement:
+        lines.append(
+            "    ⚠ first measurement: no second measurement agrees with it, so a "
+            "mismatch is investigated in both directions"
+        )
+    if a.tolerance_reason:
+        lines.append(f"    tolerance {a.tolerance_reason}")
+    for pin in a.superseded:
+        lines.append(f"    superseded {pin.value} — {pin.why}")
+    if check.explanation:
+        lines.append(f"    divergence written up: {check.explanation}")
+    lines.append(f"    verdict   {check.verdict}")
+    return lines
+
+
+def format_anchors(report: AnchorReport) -> str:
+    """The anchor table as a page a terminal can print, in the plan's order."""
+    lines = [
+        f"anchors — detector v{report.detector_version}, "
+        f"arms {', '.join(report.arms)} "
+        f"(arm{'s' if len(ARM_SPECS) - len(ANCHOR_ARMS) > 1 else ''} "
+        f"{', '.join(a for a in sorted(ARM_SPECS) if a not in ANCHOR_ARMS)} "
+        "measured, never anchored)",
+        "",
+        "geometry — measured from his bars; these hold whatever the detector does",
+        "",
+    ]
+    for check in report.geometry:
+        lines += _format_check(check) + [""]
+    if report.sample is not None:
+        s = report.sample
+        lines += [
+            f"  sample: {s.n} trades  (no bars {s.without_bars}, short history "
+            f"{s.short_history}, no prior session {s.no_prior_session})",
+            "",
+        ]
+    if report.geometry_only:
+        lines += [
+            "gate-dependent — NOT CHECKED",
+            "  the geometry anchors did not reproduce, so nothing downstream is "
+            "worth investigating yet",
+            "",
+        ]
+        return "\n".join(lines).rstrip() + "\n"
+    lines += [
+        "gate-dependent — these move with coverage and with the gates",
+        "",
+    ]
+    for check in report.gate_dependent:
+        lines += _format_check(check) + [""]
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# -- command-line entry point -------------------------------------------------
+
+
+def _field_measurements(path: str) -> list[Measurement]:
+    """The two field anchors, read from a JSON the field pass wrote.
+
+    Deliberately not computed here. Detection recall and ``in_field`` come from a
+    funnel and a discrimination grid over the run's own field, which is the run
+    (#198), not a side-car to it; inventing them here would anchor the new pipeline
+    against the old pipeline's outputs and report a pass for it.
+
+    Schema — the numbers the two passes already print::
+
+        {"detection_recall": {"passed": 549, "of": 656},
+         "in_field": {"in_field": 397, "of": 656, "gap_pp": 1.95,
+                      "detector_version": 3}}
+    """
+    body = json.loads(Path(path).read_text())
+    out: list[Measurement] = []
+    if "detection_recall" in body:
+        row = body["detection_recall"]
+        out.append(
+            Measurement(
+                anchor="detection_recall",
+                quantity=QUANTITY_DETECTION_RECALL,
+                values={"passed": row["passed"], "of": row["of"]},
+                arm=row.get("arm"),
+            )
+        )
+    if "in_field" in body:
+        row = body["in_field"]
+        out.append(
+            Measurement(
+                anchor="in_field",
+                quantity=QUANTITY_IN_FIELD,
+                values={
+                    "in_field": row["in_field"],
+                    "of": row["of"],
+                    "gap_pp": row["gap_pp"],
+                },
+                arm=row.get("arm"),
+                detector_version=row.get("detector_version"),
+            )
+        )
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Check the six anchors against a built store, and write the result.
+
+    The command that reproduces Phase 6::
+
+        python -m backtest.anchors --store data/backtest.duckdb \\
+            --field-measurements references/backtest_field_anchors.json \\
+            --out-json references/backtest_anchors.json
+
+    Geometry and coverage are measured here off the store and the reference set.
+    The two field anchors are **read**, not computed: they come from the run's own
+    funnel and discrimination grid, and a command that recomputed them from the
+    reference study's outputs would anchor the new pipeline against the old one.
+    Without them the command reports what it checked and exits non-zero, because a
+    partially anchored run is not an anchored run.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the backtest bar store")
+    parser.add_argument("--reference", default=str(DEFAULT_REFERENCE_JSON),
+                        help="path to the executed-trade reference JSON")
+    parser.add_argument("--market", default=ANCHOR_MARKET,
+                        help="the market his entries are anchored in")
+    parser.add_argument("--field-measurements", default=None,
+                        help="JSON carrying the run's detection-recall and in_field "
+                             "measurements (see _field_measurements)")
+    parser.add_argument("--explain", action="append", default=[],
+                        metavar="ANCHOR=CAUSE",
+                        help="record a written cause for a diverging anchor "
+                             "(repeatable); a divergence without one fails")
+    parser.add_argument("--out-json", default=None,
+                        help="where to write the contract-stamped result")
+    args = parser.parse_args(argv)
+
+    explained: dict[str, str] = {}
+    for item in args.explain:
+        key, _, cause = item.partition("=")
+        if not cause.strip():
+            raise SystemExit(f"--explain {item!r} carries no cause")
+        explained[key.strip()] = cause.strip()
+
+    store = Store.open(args.store)
+    try:
+        trades = load_trades(args.reference)
+        geometry = measure_geometry(store, trades, market=args.market)
+        coverage = build_report(trades, store, market=args.market)
+    finally:
+        store.close()
+
+    measurements = [*geometry_measurements(geometry), coverage_measurement(coverage)]
+
+    if not args.field_measurements:
+        # Report the geometry, then refuse: the two field anchors were never
+        # offered, and a run anchored on four of six is not anchored.
+        report = AnchorReport(
+            detector_version=DETECTOR_VERSION,
+            arms=ANCHOR_ARMS,
+            geometry=check_geometry(measurements, explained=explained),
+            gate_dependent=(),
+            geometry_only=True,
+            sample=geometry,
+        )
+        print(format_anchors(report))
+        print(
+            "--field-measurements was not given, so detection recall and in_field "
+            "were not checked; the run is not anchored"
+        )
+        return 1
+
+    measurements += _field_measurements(args.field_measurements)
+
+    try:
+        report = check_anchors(
+            measurements, explained=explained, sample=geometry
+        )
+    except DriftError as exc:
+        print(str(exc))
+        return 1
+
+    print(format_anchors(report))
+    if args.out_json:
+        payload = anchors_report(DEFAULT_CONTRACT, report)
+        Path(args.out_json).write_text(json.dumps(payload, indent=1) + "\n")
+        print(f"wrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/backtest/anchors.py
+++ b/backend/backtest/anchors.py
@@ -58,7 +58,10 @@ What the tolerance may **not** absorb is a difference large enough to flip the s
 of §4b's gap. That is the bug this table is looking for, so the gap rides on the
 same anchor as a **sign-checked** component (:attr:`Anchor.sign_checked`): its
 magnitude is free to move, its sign is not, and a flip fails the anchor whatever
-the trade count did.
+the trade count did. **Nor can a write-up waive it** — every other divergence may
+be explained in writing and recorded as a divergence, but a failure a free-text
+argument can wave through is not a failure, and this is the one the table exists
+to find.
 
 Arms B and C only
 -----------------
@@ -74,7 +77,7 @@ import argparse
 import json
 from dataclasses import dataclass
 from datetime import date
-from math import inf, isnan
+from math import isnan
 from pathlib import Path
 from statistics import median
 from typing import Any, Iterable, Mapping, Sequence
@@ -87,6 +90,7 @@ from replay.discrimination_grid import (
 from replay.funnel import STAGE_DETECTION, StageRecall
 from replay.reference import (
     DEFAULT_REFERENCE_JSON,
+    R_SHARE_TOL,
     REFERENCE_FIGURES,
     DriftError,
     ExecutedTrade,
@@ -115,6 +119,12 @@ ANCHOR_MARKET = "US"
 # the one fact that decides it.
 ANCHOR_ARMS: tuple[str, ...] = tuple(
     arm for arm, spec in sorted(ARM_SPECS.items()) if spec.comparable_to_reference
+)
+
+# The arms an anchor may never be taken against, derived from the same table for
+# the same reason: a fourth arm's comparability is one fact, read in one place.
+MEASURED_NEVER_ANCHORED: tuple[str, ...] = tuple(
+    arm for arm in sorted(ARM_SPECS) if arm not in ANCHOR_ARMS
 )
 
 # The two kinds of anchor. Geometry is measured from his bars and holds whatever
@@ -149,8 +159,11 @@ CONTAMINATION_TRADES = 7
 RANGE_TOL_ADR = 0.02
 ADR_TOL = 0.001  # 0.10 percentage points, on a fraction
 
-# The sign-checked component's own tolerance: the gap's *magnitude* is free.
-_FREE = inf
+# A component with no tolerance at all: its value is free to move and only its
+# sign is anchored. Spelled as an absence rather than an infinite float, so the
+# three readers below test for "no tolerance" instead of comparing against a
+# sentinel that could be arrived at by arithmetic.
+FREE: None = None
 
 
 @dataclass(frozen=True)
@@ -186,7 +199,7 @@ class Anchor:
     kind: str
     quantity: str
     committed: Mapping[str, float]
-    tolerance: Mapping[str, float]
+    tolerance: Mapping[str, float | None]
     unit: str
     source: str
     measured_at: tuple[int, ...]
@@ -284,12 +297,23 @@ GATE_DEPENDENT_ANCHORS: tuple[Anchor, ...] = (
             "blind_spot_trades": REFERENCE_FIGURES["blind_spot_trades"],
             "distinct_tickers": REFERENCE_FIGURES["distinct_tickers"],
             "total_rows": REFERENCE_FIGURES["total_rows"],
+            "rows_with_outcomes": REFERENCE_FIGURES["rows_with_outcomes"],
+            # The last pin, carried so this route is no weaker than
+            # :func:`~replay.reference.assert_matches_reference`: the hole is
+            # bounded in *realised R* as well as in names, and a run that
+            # reproduced the counts while moving the share would pass a coverage
+            # check having changed which trades are missing.
+            "blind_spot_r_share": REFERENCE_FIGURES["blind_spot_r_share"],
         },
         tolerance={
             "blind_spot_tickers": 0,
             "blind_spot_trades": 0,
             "distinct_tickers": 0,
             "total_rows": 0,
+            "rows_with_outcomes": 0,
+            # A float quoted to 0.1%, so a smaller difference is rounding — the
+            # reference module's own band, read from it rather than restated.
+            "blind_spot_r_share": R_SHARE_TOL,
         },
         unit="count",
         source="findings §2",
@@ -341,7 +365,7 @@ GATE_DEPENDENT_ANCHORS: tuple[Anchor, ...] = (
         tolerance={
             "in_field": CONTAMINATION_TRADES,
             "of": 0,
-            "gap_pp": _FREE,
+            "gap_pp": FREE,
         },
         unit="trades",
         source="findings §4b",
@@ -363,7 +387,10 @@ GATE_DEPENDENT_ANCHORS: tuple[Anchor, ...] = (
         superseded=(
             Pin("349 of 656 at detector v2",
                 "the live gate has moved v2 → v3; the v2 → v3 widening admits 48 "
-                "more of his trades without any of them changing"),
+                "more of his trades without any of them changing. Measured on the "
+                "same contaminated field as the live value (#162), so the "
+                "tolerance above is recorded on this row too — a run built at v2 "
+                "anchors on it under exactly the same band"),
             Pin("159 of 656 at detector v2",
                 "measured on the field the two-year rank retention had truncated "
                 "(#164)"),
@@ -402,7 +429,7 @@ class Measurement:
 
 
 @dataclass(frozen=True)
-class GeometryMeasurement:
+class GeometrySample:
     """The three geometry medians, measured over his entries at the eval session.
 
     ``n`` is how many trades carried all three; ``without_bars``,
@@ -465,7 +492,7 @@ def measure_geometry(
     trades: Iterable[ExecutedTrade],
     *,
     market: str = ANCHOR_MARKET,
-) -> GeometryMeasurement:
+) -> GeometrySample:
     """Measure the three geometry anchors off ``store`` at his evaluation sessions.
 
     Point-in-time throughout: every value is read at the last session strictly
@@ -507,7 +534,7 @@ def measure_geometry(
         ranges3.append(r3)
         ranges5.append(r5)
 
-    return GeometryMeasurement(
+    return GeometrySample(
         n=len(adrs),
         median_range_3bar_adr=median(ranges3) if ranges3 else None,
         median_range_5bar_adr=median(ranges5) if ranges5 else None,
@@ -519,7 +546,7 @@ def measure_geometry(
 
 
 def geometry_measurements(
-    measured: GeometryMeasurement,
+    measured: GeometrySample,
 ) -> list[Measurement]:
     """The three geometry medians as anchor measurements.
 
@@ -556,59 +583,98 @@ def coverage_measurement(report: ReferenceReport) -> Measurement:
             "blind_spot_trades": report.blind_spot_trades,
             "distinct_tickers": report.distinct_tickers,
             "total_rows": report.total_rows,
+            "rows_with_outcomes": report.rows_with_outcomes,
+            "blind_spot_r_share": report.blind_spot_r_share,
         },
     )
 
 
-def recall_measurement(stage: StageRecall, *, arm: str | None = None) -> Measurement:
-    """Detection recall, read off the funnel's **detection** stage.
+def detection_recall_measurement(
+    *, passed: int, of: int, stage: str, arm: str | None = None
+) -> Measurement:
+    """Detection recall, from a measurement that names the **stage** it came off.
 
-    Takes a :class:`~replay.funnel.StageRecall` and nothing else, which is what
-    makes the conflation #165 fixed unrepresentable here: the field-membership
-    anchor cannot be fed from this type, and this anchor cannot be fed from a grid
-    cell. A recall offered from another stage is refused — the liquidity stage's
-    recall is a real number and is not this anchor.
+    The narrow gate every route into this anchor goes through, in-process or from
+    a file. It exists because the conflation #165 fixed cannot be prevented by a
+    parameter name: what makes recall *recall* is that it was measured at the
+    funnel's detection stage, so the caller states which stage it read and a
+    measurement from any other one is refused. The liquidity stage's recall is a
+    real number and is not this anchor.
     """
-    if stage.stage != STAGE_DETECTION:
+    if stage != STAGE_DETECTION:
         raise DriftError(
             f"detection recall must be read off the funnel's detection stage; "
-            f"got the {stage.stage!r} stage"
+            f"got the {stage!r} stage"
         )
     return Measurement(
         anchor="detection_recall",
         quantity=QUANTITY_DETECTION_RECALL,
-        values={"passed": stage.passed, "of": stage.total},
+        values={"passed": passed, "of": of},
         arm=arm,
+    )
+
+
+def field_membership_measurement(
+    *,
+    in_field: int,
+    replayable: int,
+    gap_pp: float | None,
+    field_source: str,
+    detector_version: int | None,
+    arm: str | None = None,
+) -> Measurement:
+    """``in_field`` and §4b's gap, from a measurement that names its **field**.
+
+    The counterpart gate, and the reason both exist as functions rather than as
+    type signatures alone: the command reads its field anchors from a file, and a
+    guard that only holds for in-process callers does not hold on the one path the
+    documented reproduction command uses.
+
+    The field must be the **whole** one: the truncated field is the population
+    #164 found the two-year rank retention had emptied on 316 of 821 sessions, and
+    every figure taken over it is superseded.
+    """
+    if field_source != FIELD_WHOLE.name:
+        raise DriftError(
+            f"in_field is anchored on the whole field; got the "
+            f"{field_source!r} field, whose figures are superseded"
+        )
+    return Measurement(
+        anchor="in_field",
+        quantity=QUANTITY_IN_FIELD,
+        values={
+            "in_field": in_field,
+            "of": replayable,
+            "gap_pp": float("nan") if gap_pp is None else gap_pp,
+        },
+        arm=arm,
+        detector_version=detector_version,
+    )
+
+
+def recall_measurement(stage: StageRecall, *, arm: str | None = None) -> Measurement:
+    """Detection recall, read off a funnel report's :class:`StageRecall`."""
+    return detection_recall_measurement(
+        passed=stage.passed, of=stage.total, stage=stage.stage, arm=arm
     )
 
 
 def in_field_measurement(
     cell: CellMeasurement, *, replayable: int, arm: str | None = None
 ) -> Measurement:
-    """The ``in_field`` anchor and §4b's gap, read off one grid cell.
+    """``in_field`` and §4b's gap, read off one grid cell.
 
-    The cell must be the **whole** field: the truncated field is the population
-    #164 found the two-year rank retention had emptied on 316 of 821 sessions, and
-    every figure taken over it is superseded. The gap is the cell's own
+    The gap is the cell's own
     :meth:`~replay.discrimination_grid.CellMeasurement.edge` under the rubric §4b
     published it with, so the sign this anchor guards is the sign §4b states.
     """
-    if cell.field_source is not FIELD_WHOLE:
-        raise DriftError(
-            f"in_field is anchored on the whole field; got the "
-            f"{cell.field_source.name!r} field, whose figures are superseded"
-        )
-    gap = cell.edge(PUBLISHED_RUBRIC)
-    return Measurement(
-        anchor="in_field",
-        quantity=QUANTITY_IN_FIELD,
-        values={
-            "in_field": cell.in_field,
-            "of": replayable,
-            "gap_pp": float("nan") if gap is None else gap,
-        },
-        arm=arm,
+    return field_membership_measurement(
+        in_field=cell.in_field,
+        replayable=replayable,
+        gap_pp=cell.edge(PUBLISHED_RUBRIC),
+        field_source=cell.field_source.name,
         detector_version=cell.detector.version,
+        arm=arm,
     )
 
 
@@ -623,7 +689,7 @@ class ComponentCheck:
     name: str
     committed: float
     measured: float
-    tolerance: float
+    tolerance: float | None
     matched: bool
     sign_flipped: bool
 
@@ -646,10 +712,23 @@ class AnchorCheck:
         return bool(self.components) and all(c.matched for c in self.components)
 
     @property
+    def sign_flipped(self) -> bool:
+        """Whether a sign-checked component came back with the wrong sign."""
+        return any(c.sign_flipped for c in self.components)
+
+    @property
     def explained(self) -> bool:
         """A divergence with a cause written down. Recorded as a divergence, never
-        reported as a match — the plan's "or explain the divergence in writing"."""
-        return not self.matched and bool(self.explanation)
+        reported as a match — the plan's "or explain the divergence in writing".
+
+        **A sign flip is not explainable.** The whole reason §4b's gap rides on
+        this anchor is that a flip is the bug the table exists to find, and a
+        failure a free-text argument can wave through is not a failure. So the
+        tolerance cannot absorb it and neither can a write-up: it is the one
+        outcome here that must stop the run and be investigated in the pipeline
+        rather than in the report.
+        """
+        return not self.matched and bool(self.explanation) and not self.sign_flipped
 
     @property
     def passes(self) -> bool:
@@ -680,7 +759,7 @@ class AnchorReport:
     geometry: tuple[AnchorCheck, ...]
     gate_dependent: tuple[AnchorCheck, ...]
     geometry_only: bool = False
-    sample: GeometryMeasurement | None = None
+    sample: GeometrySample | None = None
 
     @property
     def checks(self) -> tuple[AnchorCheck, ...]:
@@ -691,10 +770,10 @@ class AnchorReport:
         return not self.geometry_only and all(c.passes for c in self.checks)
 
 
-def _matches(value: float, committed: float, tolerance: float) -> bool:
+def _matches(value: float, committed: float, tolerance: float | None) -> bool:
     if isnan(value):
         return False
-    if tolerance == _FREE:
+    if tolerance is FREE:
         return True
     return abs(value - committed) <= tolerance
 
@@ -753,7 +832,7 @@ def _check_one(
                 "quoting two numbers cannot pass on one of them"
             )
         value = float(measurement.values[name])
-        tolerance = float(anchor.tolerance[name])
+        tolerance = anchor.tolerance[name]
         flipped = name in anchor.sign_checked and (
             isnan(value) or _sign(value) != _sign(committed)
         )
@@ -842,11 +921,26 @@ def check_geometry(
     infer whether it was checked.
     """
     explained = dict(explained or {})
-    by_anchor = _index(measurements, explained=explained, arms=arms)
+    return _check_group(
+        GEOMETRY_ANCHORS,
+        _index(measurements, explained=explained, arms=arms),
+        detector_version=detector_version,
+        explained=explained,
+    )
+
+
+def _check_group(
+    anchors: Sequence[Anchor],
+    by_anchor: Mapping[str, Measurement],
+    *,
+    detector_version: int,
+    explained: Mapping[str, str],
+) -> tuple[AnchorCheck, ...]:
+    """One group's checks, in the group's own order."""
     return tuple(
         _check_one(a, by_anchor.get(a.key), detector_version=detector_version,
                    explanation=explained.get(a.key))
-        for a in GEOMETRY_ANCHORS
+        for a in anchors
     )
 
 
@@ -856,7 +950,7 @@ def check_anchors(
     detector_version: int = DETECTOR_VERSION,
     explained: Mapping[str, str] | None = None,
     arms: Sequence[str] = ANCHOR_ARMS,
-    sample: GeometryMeasurement | None = None,
+    sample: GeometrySample | None = None,
 ) -> AnchorReport:
     """Check every anchor, geometry first, and fail loudly on a mismatch.
 
@@ -872,12 +966,11 @@ def check_anchors(
     without one raises.
     """
     explained = dict(explained or {})
-    measurements = list(measurements)
     by_anchor = _index(measurements, explained=explained, arms=arms)
 
-    geometry = check_geometry(
-        measurements, detector_version=detector_version, explained=explained,
-        arms=arms,
+    geometry = _check_group(
+        GEOMETRY_ANCHORS, by_anchor, detector_version=detector_version,
+        explained=explained,
     )
     failed = [c for c in geometry if not c.passes]
     if failed:
@@ -889,10 +982,9 @@ def check_anchors(
             + "\n  ".join(_describe(c) for c in failed)
         )
 
-    gate_dependent = tuple(
-        _check_one(a, by_anchor.get(a.key), detector_version=detector_version,
-                   explanation=explained.get(a.key))
-        for a in GATE_DEPENDENT_ANCHORS
+    gate_dependent = _check_group(
+        GATE_DEPENDENT_ANCHORS, by_anchor, detector_version=detector_version,
+        explained=explained,
     )
     failed = [c for c in gate_dependent if not c.passes]
     if failed:
@@ -919,7 +1011,7 @@ def _component_dict(c: ComponentCheck) -> dict[str, Any]:
         "component": c.name,
         "committed": c.committed,
         "measured": None if isnan(c.measured) else c.measured,
-        "tolerance": None if c.tolerance == _FREE else c.tolerance,
+        "tolerance": c.tolerance,
         "divergence": None if isnan(c.measured) else c.divergence,
         "matched": c.matched,
         "sign_flipped": c.sign_flipped,
@@ -958,9 +1050,7 @@ def anchors_report(contract: RunContract, report: AnchorReport) -> dict[str, Any
     body: dict[str, Any] = {
         "detector_version": report.detector_version,
         "arms_anchored": list(report.arms),
-        "arms_measured_never_anchored": [
-            arm for arm in sorted(ARM_SPECS) if arm not in ANCHOR_ARMS
-        ],
+        "arms_measured_never_anchored": list(MEASURED_NEVER_ANCHORED),
         "geometry": [_check_dict(c) for c in report.geometry],
         "gate_dependent": [_check_dict(c) for c in report.gate_dependent],
         "geometry_only": report.geometry_only,
@@ -983,7 +1073,7 @@ def _format_check(check: AnchorCheck) -> list[str]:
     for c in check.components:
         mark = "ok " if c.matched else "!! "
         measured = "n/a" if isnan(c.measured) else f"{c.measured:.6g}"
-        tolerance = "free" if c.tolerance == _FREE else f"±{c.tolerance:g}"
+        tolerance = "free" if c.tolerance is FREE else f"±{c.tolerance:g}"
         lines.append(
             f"    {mark}{c.name:<20} committed {c.committed:<10.6g} "
             f"measured {measured:<10} ({tolerance} {a.unit})"
@@ -1057,37 +1147,40 @@ def _field_measurements(path: str) -> list[Measurement]:
     (#198), not a side-car to it; inventing them here would anchor the new pipeline
     against the old pipeline's outputs and report a pass for it.
 
-    Schema — the numbers the two passes already print::
+    It goes through the same two gates an in-process caller does
+    (:func:`detection_recall_measurement`, :func:`field_membership_measurement`),
+    which is why each row must name **what it measured** rather than only its
+    numbers: the ``stage`` the recall came off and the ``field`` the membership was
+    counted over. Without those the file could offer the funnel's recall under the
+    ``in_field`` key and be believed, and the command is the one path the
+    documented reproduction uses.
 
-        {"detection_recall": {"passed": 549, "of": 656},
+    Schema — the numbers the two passes already print, and what they were::
+
+        {"detection_recall": {"passed": 549, "of": 656, "stage": "detection"},
          "in_field": {"in_field": 397, "of": 656, "gap_pp": 1.95,
-                      "detector_version": 3}}
+                      "field": "whole", "detector_version": 3}}
     """
     body = json.loads(Path(path).read_text())
     out: list[Measurement] = []
     if "detection_recall" in body:
         row = body["detection_recall"]
         out.append(
-            Measurement(
-                anchor="detection_recall",
-                quantity=QUANTITY_DETECTION_RECALL,
-                values={"passed": row["passed"], "of": row["of"]},
+            detection_recall_measurement(
+                passed=row["passed"], of=row["of"], stage=row["stage"],
                 arm=row.get("arm"),
             )
         )
     if "in_field" in body:
         row = body["in_field"]
         out.append(
-            Measurement(
-                anchor="in_field",
-                quantity=QUANTITY_IN_FIELD,
-                values={
-                    "in_field": row["in_field"],
-                    "of": row["of"],
-                    "gap_pp": row["gap_pp"],
-                },
-                arm=row.get("arm"),
+            field_membership_measurement(
+                in_field=row["in_field"],
+                replayable=row["of"],
+                gap_pp=row["gap_pp"],
+                field_source=row["field"],
                 detector_version=row.get("detector_version"),
+                arm=row.get("arm"),
             )
         )
     return out
@@ -1161,9 +1254,12 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
-    measurements += _field_measurements(args.field_measurements)
-
     try:
+        # Inside the same guard as the check itself: a field row that does not
+        # name the whole field, or a recall row that does not name the detection
+        # stage, is a refusal of the same kind and reads better as one printed
+        # line than as a traceback.
+        measurements += _field_measurements(args.field_measurements)
         report = check_anchors(
             measurements, explained=explained, sample=geometry
         )

--- a/backend/replay/reference.py
+++ b/backend/replay/reference.py
@@ -87,7 +87,7 @@ REFERENCE_FIGURES: dict[str, float] = {
 
 # The blind-spot R share is a float; a change below this tolerance is rounding,
 # not drift (the #114 figure is quoted to 0.1%).
-_R_SHARE_TOL = 0.001
+R_SHARE_TOL = 0.001
 
 
 class DriftError(RuntimeError):
@@ -354,7 +354,7 @@ def assert_matches_reference(report: ReferenceReport) -> None:
     """Fail loudly if the recomputed counts diverge from the #114 figures.
 
     The integer counts must match exactly; the R share must match to within
-    :data:`_R_SHARE_TOL`. A mismatch means the reference set or the store moved,
+    :data:`R_SHARE_TOL`. A mismatch means the reference set or the store moved,
     which every later analysis rests on, so it raises rather than logs.
     """
     mismatches: list[str] = []
@@ -366,7 +366,7 @@ def assert_matches_reference(report: ReferenceReport) -> None:
             mismatches.append(f"{key}: got {actual}, #114 recorded {expected}")
 
     share_expected = REFERENCE_FIGURES["blind_spot_r_share"]
-    if abs(report.blind_spot_r_share - share_expected) > _R_SHARE_TOL:
+    if abs(report.blind_spot_r_share - share_expected) > R_SHARE_TOL:
         mismatches.append(
             f"blind_spot_r_share: got {report.blind_spot_r_share:.4f}, "
             f"#114 recorded {share_expected}"

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -8884,7 +8884,7 @@ from backtest.anchors import (
     QUANTITY_DETECTION_RECALL,
     QUANTITY_IN_FIELD,
     AnchorReport,
-    GeometryMeasurement,
+    GeometrySample,
     Measurement,
     anchors_report,
     check_anchors,
@@ -8898,7 +8898,7 @@ from backtest.anchors import (
     trailing_range_adr,
 )
 from backtest.anchors import main as anchors_main
-from backtest.simulate import ARM_A, ARM_B
+from backtest.simulate import ARM_A, ARM_B, ARM_C
 from replay.funnel import StageRecall
 from replay.discrimination_grid import (
     DETECTORS,
@@ -8932,6 +8932,8 @@ def _coverage_measurement(**overrides) -> Measurement:
         "blind_spot_trades": REFERENCE_FIGURES["blind_spot_trades"],
         "distinct_tickers": REFERENCE_FIGURES["distinct_tickers"],
         "total_rows": REFERENCE_FIGURES["total_rows"],
+        "rows_with_outcomes": REFERENCE_FIGURES["rows_with_outcomes"],
+        "blind_spot_r_share": REFERENCE_FIGURES["blind_spot_r_share"],
     }
     values.update(overrides)
     return Measurement(anchor="coverage_blind_spot",
@@ -9264,7 +9266,7 @@ def test_an_anchor_with_no_measurement_fails_rather_than_vanishing():
 def test_a_median_that_could_not_be_computed_fails_rather_than_passing():
     """An empty sample yields no median, which is a failure of the store — never
     an anchor quietly skipped."""
-    empty = GeometryMeasurement(
+    empty = GeometrySample(
         n=0, median_range_3bar_adr=None, median_range_5bar_adr=None,
         median_adr_at_entry_eve=None, without_bars=828, short_history=0,
         no_prior_session=0,
@@ -9311,7 +9313,7 @@ def test_an_explanation_for_an_anchor_that_does_not_exist_is_refused():
 def test_anchoring_uses_arms_b_and_c_only():
     """Arm A has no counterpart in the reference set, so it is measured and never
     anchored — and the fact is derived from the arm table, not restated here."""
-    assert ANCHOR_ARMS == (ARM_B, "C")
+    assert ANCHOR_ARMS == (ARM_B, ARM_C)
     assert ARM_A not in ANCHOR_ARMS
 
     with pytest.raises(DriftError) as excinfo:
@@ -9579,9 +9581,9 @@ def test_the_command_writes_a_stamped_result_when_every_anchor_is_offered(
     path, reference = _anchor_cli_store(tmp_path)
     field = tmp_path / "field.json"
     field.write_text(json.dumps({
-        "detection_recall": {"passed": 549, "of": 656},
+        "detection_recall": {"passed": 549, "of": 656, "stage": "detection"},
         "in_field": {"in_field": 395, "of": 656, "gap_pp": 1.9,
-                     "detector_version": 3},
+                     "field": "whole", "detector_version": 3},
     }))
     out_json = tmp_path / "anchors.json"
 
@@ -9617,9 +9619,9 @@ def test_the_command_fails_on_a_field_anchor_from_the_wrong_version(tmp_path):
     path, reference = _anchor_cli_store(tmp_path)
     field = tmp_path / "field.json"
     field.write_text(json.dumps({
-        "detection_recall": {"passed": 549, "of": 656},
+        "detection_recall": {"passed": 549, "of": 656, "stage": "detection"},
         "in_field": {"in_field": 349, "of": 656, "gap_pp": 2.02,
-                     "detector_version": 2},
+                     "field": "whole", "detector_version": 2},
     }))
 
     code = anchors_main([
@@ -9632,3 +9634,103 @@ def test_the_command_fails_on_a_field_anchor_from_the_wrong_version(tmp_path):
     ])
 
     assert code == 1
+
+
+# -- what the #197 review found unguarded --------------------------------------
+
+from backtest.anchors import MEASURED_NEVER_ANCHORED
+from backtest.simulate import ARM_SPECS
+from replay.reference import R_SHARE_TOL
+
+
+def test_a_sign_flip_cannot_be_waived_by_writing_it_up():
+    """The one failure this table exists to find, and the one no cause excuses.
+    Every other divergence may be explained in writing; a flip in the sign of
+    §4b's gap must stop the run and be investigated in the pipeline, or the anchor
+    is waivable by a free-text argument and guards nothing."""
+    flipped = _all_measurements(
+        cell={"in_field": 396, "picks_share": 0.1165, "field_share": 0.1360}
+    )
+
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(flipped, explained={"in_field": "a plausible-sounding cause"})
+
+    assert "sign" in str(excinfo.value)
+    # The same explain path *does* carry an ordinary divergence, so the refusal is
+    # specific to the sign rather than the write-up being broken.
+    assert check_anchors(
+        _all_measurements(recall={"passed": 500}),
+        explained={"detection_recall": "a written cause"},
+    ).passes
+
+
+def test_the_command_enforces_the_same_two_gates_its_adapters_do(tmp_path, capsys):
+    """The file path is the one the documented reproduction command uses, so the
+    conflation guard has to hold there too: a field row that does not name the
+    whole field, or a recall row that does not name the detection stage, is
+    refused rather than believed."""
+    path, reference = _anchor_cli_store(tmp_path)
+    explain = [
+        "--explain", "median_range_3bar_adr=one-name fixture",
+        "--explain", "median_range_5bar_adr=one-name fixture",
+        "--explain", "median_adr_at_entry_eve=one-name fixture",
+        "--explain", "coverage_blind_spot=one-name fixture",
+    ]
+
+    truncated = tmp_path / "truncated.json"
+    truncated.write_text(json.dumps({
+        "detection_recall": {"passed": 549, "of": 656, "stage": "detection"},
+        "in_field": {"in_field": 397, "of": 656, "gap_pp": 1.95,
+                     "field": "truncated", "detector_version": 3},
+    }))
+    assert anchors_main(["--store", str(path), "--reference", str(reference),
+                         "--field-measurements", str(truncated), *explain]) == 1
+    assert "whole field" in capsys.readouterr().out
+
+    wrong_stage = tmp_path / "stage.json"
+    wrong_stage.write_text(json.dumps({
+        "detection_recall": {"passed": 549, "of": 656, "stage": "liquidity"},
+        "in_field": {"in_field": 397, "of": 656, "gap_pp": 1.95,
+                     "field": "whole", "detector_version": 3},
+    }))
+    assert anchors_main(["--store", str(path), "--reference", str(reference),
+                         "--field-measurements", str(wrong_stage), *explain]) == 1
+    assert "detection stage" in capsys.readouterr().out
+
+
+def test_the_coverage_anchor_is_no_weaker_than_the_reference_assertion():
+    """It checks all five of the reference module's pins, the realised-R share
+    included. A run reproducing the counts while moving the share would have
+    changed *which* trades are missing, and a coverage check that passed it would
+    be weaker than the one this repo already had."""
+    anchor = ANCHORS_BY_KEY["coverage_blind_spot"]
+
+    assert set(anchor.committed) == set(REFERENCE_FIGURES)
+    assert anchor.committed["blind_spot_r_share"] == (
+        REFERENCE_FIGURES["blind_spot_r_share"]
+    )
+    # Pinned to the reference module's own band, not to a second one.
+    assert anchor.tolerance["blind_spot_r_share"] == R_SHARE_TOL
+
+    with pytest.raises(DriftError):
+        check_anchors(_all_measurements(coverage={"blind_spot_r_share": 0.25}))
+
+
+def test_the_contamination_tolerance_is_recorded_on_the_superseded_field_row_too():
+    """Both `in_field` values were measured on the contaminated field, so the v2
+    pin says so: a run built at v2 anchors on it under the same band, and a reader
+    who found the note only on the live row would think the pin was clean."""
+    v2 = next(
+        p for p in ANCHORS_BY_KEY["in_field"].superseded
+        if "at detector v2" in p.value
+    )
+
+    assert "#162" in v2.why
+    assert "contaminated field" in v2.why
+
+
+def test_the_arms_never_anchored_are_derived_once():
+    """The module's own rule — an arm's comparability is one fact, read in one
+    place — applied to the complement as well as to the set."""
+    assert MEASURED_NEVER_ANCHORED == (ARM_A,)
+    assert set(MEASURED_NEVER_ANCHORED) | set(ANCHOR_ARMS) == set(ARM_SPECS)

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -8848,3 +8848,787 @@ def test_the_ranking_runs_off_the_denominator_end_to_end(store, denominator):
     ).points
     body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
     assert sum(b["trades"] for b in body["buckets"]) == 1
+
+
+# -- anchor before believing (issue #197) --------------------------------------
+#
+# Phase 6's table, and the two things it exists to prevent. The run overlaps
+# ground the reference study already measured, so it reproduces those figures
+# before any new figure from it is read — a mismatch is a bug in the new store or
+# the new chain, and every downstream number inherits it.
+#
+# Four claims are load-bearing:
+#
+#   * **Geometry first, and apart.** The three medians are measured from his bars
+#     and hold whatever the detector does. If they fail, the gate-dependent
+#     anchors are not read at all: nothing downstream is worth investigating yet.
+#   * **Every anchor carries its detector stamp and its superseded pins.** An
+#     anchor quoted from a stale pin fails for a reason that has nothing to do
+#     with the pipeline it is testing, and `in_field` at v2 is a different number
+#     from `in_field` at v3.
+#   * **Detection recall and `in_field` are different quantities** — the
+#     conflation #165 fixed, made unrepresentable rather than merely documented.
+#   * **The #162 tolerance covers a few trades, never a sign flip.** A fresh build
+#     shifts percentile denominators by ~0.5%; a difference that changes the sign
+#     of §4b's gap is the bug the table is looking for.
+
+from backtest.anchors import (
+    ANCHOR_ARMS,
+    ANCHORS,
+    ANCHORS_BY_KEY,
+    CONTAMINATION_TRADES,
+    GATE_DEPENDENT,
+    GATE_DEPENDENT_ANCHORS,
+    GEOMETRY,
+    GEOMETRY_ANCHORS,
+    QUANTITY_DETECTION_RECALL,
+    QUANTITY_IN_FIELD,
+    AnchorReport,
+    GeometryMeasurement,
+    Measurement,
+    anchors_report,
+    check_anchors,
+    check_geometry,
+    coverage_measurement,
+    format_anchors,
+    geometry_measurements,
+    in_field_measurement,
+    measure_geometry,
+    recall_measurement,
+    trailing_range_adr,
+)
+from backtest.anchors import main as anchors_main
+from backtest.simulate import ARM_A, ARM_B
+from replay.funnel import StageRecall
+from replay.discrimination_grid import (
+    DETECTORS,
+    FIELD_TRUNCATED,
+    FIELD_WHOLE,
+    CellMeasurement,
+)
+from replay.placement import RubricStarDistributions, StarDistribution
+from replay.reference import REFERENCE_FIGURES
+from screener.detection import DETECTOR_VERSION, range_3bar_adr
+from screener.indicators import adr as _adr_of
+
+
+def _geometry_measurements(
+    *, three: float = 1.31, five: float = 1.86, adr: float = 0.0608
+) -> list[Measurement]:
+    """The three geometry measurements, at their committed values by default."""
+    return [
+        Measurement(anchor="median_range_3bar_adr", quantity="bar-geometry",
+                    values={"median": three}),
+        Measurement(anchor="median_range_5bar_adr", quantity="bar-geometry",
+                    values={"median": five}),
+        Measurement(anchor="median_adr_at_entry_eve", quantity="bar-geometry",
+                    values={"median": adr}),
+    ]
+
+
+def _coverage_measurement(**overrides) -> Measurement:
+    values = {
+        "blind_spot_tickers": REFERENCE_FIGURES["blind_spot_tickers"],
+        "blind_spot_trades": REFERENCE_FIGURES["blind_spot_trades"],
+        "distinct_tickers": REFERENCE_FIGURES["distinct_tickers"],
+        "total_rows": REFERENCE_FIGURES["total_rows"],
+    }
+    values.update(overrides)
+    return Measurement(anchor="coverage_blind_spot",
+                       quantity="reference-coverage", values=values)
+
+
+def _recall(passed: int = 549, total: int = 656) -> StageRecall:
+    return StageRecall(stage=STAGE_DETECTION, passed=passed, total=total,
+                       passed_ex_continuation=passed, total_ex_continuation=total)
+
+
+def _cell(
+    *,
+    version: int = 3,
+    in_field: int = 397,
+    picks_share: float = 0.1360,
+    field_share: float = 0.1165,
+    field_source=FIELD_WHOLE,
+) -> CellMeasurement:
+    """A grid cell whose ≥3.5★ shares land on the pair §4b's v3 row reports.
+
+    The shares are built as histograms rather than stored as rates, because
+    ``CellMeasurement.edge`` reads them off the distributions and a cell carrying
+    a rate the histogram does not support would test nothing.
+    """
+    def dist(share: float, n: int = 10_000) -> StarDistribution:
+        hits = round(share * n)
+        return StarDistribution.from_stars([4.0] * hits + [1.0] * (n - hits))
+
+    return CellMeasurement(
+        detector=DETECTORS[version],
+        field_source=field_source,
+        measured_sessions=821,
+        sessions_with_detections=821,
+        field_detections=64_070,
+        placed=in_field,
+        in_field=in_field,
+        eval_field_detections=64_070,
+        by_rubric=[
+            RubricStarDistributions(
+                rubric_version=1,
+                picks=dist(picks_share),
+                field=dist(field_share),
+                top_thirty=103,
+            )
+        ],
+    )
+
+
+def _all_measurements(**kwargs) -> list[Measurement]:
+    """Every anchor's measurement, all at their committed values by default."""
+    return [
+        *_geometry_measurements(**kwargs.pop("geometry", {})),
+        _coverage_measurement(**kwargs.pop("coverage", {})),
+        recall_measurement(_recall(**kwargs.pop("recall", {}))),
+        in_field_measurement(
+            _cell(**kwargs.pop("cell", {})), replayable=kwargs.pop("replayable", 656)
+        ),
+    ]
+
+
+# -- the table itself ----------------------------------------------------------
+
+
+def test_the_table_holds_six_anchors_with_the_three_geometry_ones_first():
+    """The plan's order is a claim about what is worth reading when: geometry
+    anchors the store and the indicators, so it is checked before anything that
+    depends on a gate."""
+    assert len(ANCHORS) == 6
+    assert [a.key for a in ANCHORS[:3]] == [a.key for a in GEOMETRY_ANCHORS]
+    assert {a.kind for a in GEOMETRY_ANCHORS} == {GEOMETRY}
+    assert {a.kind for a in GATE_DEPENDENT_ANCHORS} == {GATE_DEPENDENT}
+    assert [a.committed["median"] for a in GEOMETRY_ANCHORS] == [1.31, 1.86, 0.0608]
+
+
+def test_every_anchor_is_stamped_with_the_detector_version_it_was_measured_at():
+    """Ticket criterion: a figure whose version is absent gets compared against a
+    run built at another one, which is exactly how the `in_field` row went wrong."""
+    stamps = {a.key: a.detector_stamp for a in ANCHORS}
+
+    # Geometry holds whatever the detector does, and says so rather than going
+    # unstamped — an empty stamp reads as "not recorded".
+    for anchor in GEOMETRY_ANCHORS:
+        assert stamps[anchor.key] == "detector-independent (bar geometry)"
+    # Gate-invariant, and measured under both versions' geometry.
+    assert ANCHORS_BY_KEY["detection_recall"].measured_at == (2, 3)
+    assert ANCHORS_BY_KEY["detection_recall"].holds_at(2)
+    # Per version, because the quantity is per version.
+    assert ANCHORS_BY_KEY["in_field"].measured_at == (3,)
+    assert not ANCHORS_BY_KEY["in_field"].holds_at(2)
+    assert stamps["in_field"] == "detector v3"
+
+
+def test_the_in_field_anchor_is_taken_at_the_live_detector_and_flagged_first():
+    """397 of 656 at v3 is a first measurement with no second one agreeing with
+    it, so a mismatch is investigated in both directions rather than charged
+    straight to the new pipeline."""
+    anchor = ANCHORS_BY_KEY["in_field"]
+
+    assert anchor.committed["in_field"] == 397
+    assert anchor.committed["of"] == 656
+    assert anchor.measured_at == (DETECTOR_VERSION,)
+    assert anchor.first_measurement is True
+    assert not ANCHORS_BY_KEY["detection_recall"].first_measurement
+
+
+def test_every_superseded_pin_is_recorded_beside_its_live_value():
+    """An anchor quoted from a stale pin fails for a reason unrelated to the
+    pipeline it is testing, so each superseded figure sits on the anchor with what
+    moved it — not in a comment and not in the plan alone."""
+    in_field = ANCHORS_BY_KEY["in_field"]
+    values = [p.value for p in in_field.superseded]
+
+    assert "349 of 656 at detector v2" in values
+    assert any("159 of 656" in v for v in values)
+    assert any("104 of 656" in v for v in values)
+    assert any("104 of 658" in v for v in values)
+    assert all(p.why for p in in_field.superseded)
+    # The other two gate-dependent rows have moved too, and carry their own.
+    assert any("380 of 658" in p.value
+               for p in ANCHORS_BY_KEY["detection_recall"].superseded)
+    assert ANCHORS_BY_KEY["coverage_blind_spot"].superseded
+
+
+def test_the_coverage_anchor_reads_the_reference_modules_own_pins():
+    """No second definition of the coverage figures: this table and
+    ``replay.reference.assert_matches_reference`` check the same numbers, so they
+    cannot come to disagree about what was committed."""
+    committed = ANCHORS_BY_KEY["coverage_blind_spot"].committed
+
+    assert committed["blind_spot_tickers"] == REFERENCE_FIGURES["blind_spot_tickers"]
+    assert committed["blind_spot_trades"] == REFERENCE_FIGURES["blind_spot_trades"]
+    assert committed["distinct_tickers"] == REFERENCE_FIGURES["distinct_tickers"]
+    assert committed["total_rows"] == REFERENCE_FIGURES["total_rows"]
+
+
+def test_the_field_rows_carry_the_reference_contamination_tolerance():
+    """Both `in_field` values were measured on the store that ranks five
+    references as candidates; the tolerance is that fix landing, and it says so."""
+    anchor = ANCHORS_BY_KEY["in_field"]
+
+    assert anchor.tolerance["in_field"] == CONTAMINATION_TRADES
+    assert "#162" in (anchor.tolerance_reason or "")
+    # Recorded on both field rows: the live v3 value and the superseded v2 one.
+    assert any("v2" in p.value for p in anchor.superseded)
+    # The denominator is not inside the tolerance — a changed replayable
+    # population is coverage drift, which the coverage anchor owns.
+    assert anchor.tolerance["of"] == 0
+
+
+# -- the check -----------------------------------------------------------------
+
+
+def test_the_six_anchors_check_through_the_drift_mechanism_and_report_apart():
+    """The happy path: every anchor at its committed value, geometry reported in
+    its own group ahead of the gate-dependent three."""
+    report = check_anchors(_all_measurements())
+
+    assert [c.anchor.key for c in report.geometry] == [
+        "median_range_3bar_adr", "median_range_5bar_adr", "median_adr_at_entry_eve",
+    ]
+    assert [c.anchor.key for c in report.gate_dependent] == [
+        "coverage_blind_spot", "detection_recall", "in_field",
+    ]
+    assert all(c.matched for c in report.checks)
+    assert report.passes
+
+
+def test_a_geometry_failure_stops_before_the_gate_dependent_anchors_are_read():
+    """If the store's own geometry does not reproduce, no figure measured over
+    that store is worth investigating yet — so the check says so and stops."""
+    measurements = [
+        *_geometry_measurements(three=1.31, five=2.60, adr=0.0608),
+        _coverage_measurement(),
+        recall_measurement(_recall()),
+        in_field_measurement(_cell(), replayable=656),
+    ]
+
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(measurements)
+
+    message = str(excinfo.value)
+    assert "median_range_5bar_adr" in message
+    assert "gate-dependent" in message and "not read" in message
+    # The gate-dependent anchors are absent from the failure entirely: reporting
+    # them here would invite investigating a number that cannot be trusted.
+    assert "in_field" not in message
+
+
+def test_a_gate_dependent_mismatch_fails_loudly_with_both_figures():
+    """The drift mechanism the study has used since #114: a mismatch raises rather
+    than logging, and names what came back against what was committed."""
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(_all_measurements(recall={"passed": 500}))
+
+    assert "detection_recall" in str(excinfo.value)
+    assert "500" in str(excinfo.value) and "549" in str(excinfo.value)
+
+
+def test_detection_recall_admits_no_tolerance():
+    """It is gate-invariant and exact: the funnel evaluates every stage
+    unconditionally, so nothing about a fresh build moves it by a trade."""
+    assert ANCHORS_BY_KEY["detection_recall"].tolerance == {"passed": 0, "of": 0}
+
+    with pytest.raises(DriftError):
+        check_anchors(_all_measurements(recall={"passed": 548}))
+
+
+def test_the_contamination_tolerance_absorbs_a_few_trades_on_the_field_row():
+    """A fresh build shifts percentile denominators by ~0.5%, which moves decile
+    membership at the margin. That is the fix landing, not a bug."""
+    report = check_anchors(
+        _all_measurements(cell={"in_field": 397 - CONTAMINATION_TRADES})
+    )
+
+    check = next(c for c in report.gate_dependent if c.anchor.key == "in_field")
+    assert check.matched
+    assert report.passes
+
+
+def test_a_field_difference_past_the_contamination_band_fails():
+    """The tolerance is bounded by what the denominator shift can do; past it the
+    difference is not a denominator shift."""
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(
+            _all_measurements(cell={"in_field": 397 - CONTAMINATION_TRADES - 1})
+        )
+
+    assert "in_field" in str(excinfo.value)
+
+
+def test_a_sign_flip_in_the_gap_fails_inside_the_trade_tolerance():
+    """The one thing the tolerance may not absorb. The trade count is well inside
+    the band, and the anchor fails anyway, because a gap that changes sign is the
+    bug this table exists to find."""
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(
+            _all_measurements(
+                cell={"in_field": 396, "picks_share": 0.1165, "field_share": 0.1360}
+            )
+        )
+
+    message = str(excinfo.value)
+    assert "gap_pp" in message
+    assert "sign" in message and "tolerance does not cover" in message
+
+
+def test_the_gaps_magnitude_is_free_to_move():
+    """Only the sign is anchored. The gap is a rate on two populations a fresh
+    build re-derives, so pinning its magnitude would fail every honest run."""
+    report = check_anchors(
+        _all_measurements(cell={"picks_share": 0.30, "field_share": 0.10})
+    )
+
+    gap = next(
+        c for a in report.gate_dependent if a.anchor.key == "in_field"
+        for c in a.components if c.name == "gap_pp"
+    )
+    assert gap.measured == pytest.approx(20.0)
+    assert gap.matched and not gap.sign_flipped
+
+
+def test_detection_recall_and_in_field_cannot_be_checked_against_each_other():
+    """The conflation #165 fixed, made unrepresentable. Offering the funnel's
+    recall as the field-membership measurement fails at the seam rather than
+    failing an anchor that should have passed."""
+    recall = recall_measurement(_recall())
+    misfiled = dataclasses.replace(recall, anchor="in_field")
+
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors([
+            *_geometry_measurements(), _coverage_measurement(),
+            recall, misfiled,
+        ])
+
+    message = str(excinfo.value)
+    assert "different quantities" in message and "#165" in message
+    assert QUANTITY_IN_FIELD in message and QUANTITY_DETECTION_RECALL in message
+
+
+def test_the_two_field_measurements_come_from_two_different_types():
+    """Structural, not documentary: recall is read off the funnel's detection
+    stage and `in_field` off a grid cell, so neither adapter can produce the
+    other's measurement."""
+    assert recall_measurement(_recall()).quantity == QUANTITY_DETECTION_RECALL
+    assert (
+        in_field_measurement(_cell(), replayable=656).quantity == QUANTITY_IN_FIELD
+    )
+    with pytest.raises(DriftError):
+        recall_measurement(dataclasses.replace(_recall(), stage="liquidity"))
+
+
+def test_in_field_is_anchored_on_the_whole_field_only():
+    """Every figure over the truncated field is superseded: the two-year rank
+    retention emptied 316 of 821 sessions, and #164 measured what that did."""
+    with pytest.raises(DriftError) as excinfo:
+        in_field_measurement(
+            _cell(field_source=FIELD_TRUNCATED), replayable=656
+        )
+
+    assert "whole field" in str(excinfo.value)
+
+
+def test_a_field_measurement_from_another_detector_version_is_refused():
+    """397 is v3's number. A run built at v3 checked against a v2 cell — or the
+    reverse — fails an anchor it should pass, which is the error the per-version
+    stamp exists to prevent."""
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(_all_measurements(cell={"version": 2, "in_field": 349}))
+
+    assert "v2" in str(excinfo.value) and "built at" in str(excinfo.value)
+
+    # And the anchor itself refuses to be quoted at a version it never measured.
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(_all_measurements(), detector_version=2)
+
+    assert "no committed value at detector v2" in str(excinfo.value)
+
+
+def test_an_anchor_with_no_measurement_fails_rather_than_vanishing():
+    """A partially anchored run is not an anchored run, and an anchor that is
+    silently absent from the report reads as one that passed."""
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors([*_geometry_measurements(), _coverage_measurement(),
+                       recall_measurement(_recall())])
+
+    assert "in_field" in str(excinfo.value) and "no measurement" in str(excinfo.value)
+
+
+def test_a_median_that_could_not_be_computed_fails_rather_than_passing():
+    """An empty sample yields no median, which is a failure of the store — never
+    an anchor quietly skipped."""
+    empty = GeometryMeasurement(
+        n=0, median_range_3bar_adr=None, median_range_5bar_adr=None,
+        median_adr_at_entry_eve=None, without_bars=828, short_history=0,
+        no_prior_session=0,
+    )
+
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors([
+            *geometry_measurements(empty), _coverage_measurement(),
+            recall_measurement(_recall()),
+            in_field_measurement(_cell(), replayable=656),
+        ])
+
+    assert "median_range_3bar_adr" in str(excinfo.value)
+
+
+def test_a_divergence_written_up_is_recorded_and_never_prints_as_a_match():
+    """The plan's "reproduce it, or explain the divergence in writing". A cause
+    lets the run proceed; the anchor still reports as diverged, so the write-up
+    cannot be mistaken for a reproduction."""
+    report = check_anchors(
+        _all_measurements(recall={"passed": 500}),
+        explained={"detection_recall": "the crawl resolves 3 names the replay "
+                                       "store never held; listed in the write-up"},
+    )
+
+    check = next(c for c in report.gate_dependent
+                 if c.anchor.key == "detection_recall")
+    assert not check.matched
+    assert check.explained and check.passes
+    assert check.verdict == "diverged (explained)"
+    assert report.passes
+
+
+def test_an_explanation_for_an_anchor_that_does_not_exist_is_refused():
+    """A typo in an anchor key would otherwise silently explain nothing while
+    reading as though it had explained something."""
+    with pytest.raises(DriftError):
+        check_anchors(_all_measurements(), explained={"in-field": "typo"})
+
+
+# -- arms B and C --------------------------------------------------------------
+
+
+def test_anchoring_uses_arms_b_and_c_only():
+    """Arm A has no counterpart in the reference set, so it is measured and never
+    anchored — and the fact is derived from the arm table, not restated here."""
+    assert ANCHOR_ARMS == (ARM_B, "C")
+    assert ARM_A not in ANCHOR_ARMS
+
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors(_all_measurements(), arms=(ARM_A,))
+
+    assert "no counterpart in the reference set" in str(excinfo.value)
+
+
+def test_a_measurement_tagged_with_arm_a_is_refused():
+    """The refusal reaches the measurement too: an anchor taken on arm A would be
+    an anchor against an exit the reference set never simulated."""
+    recall = recall_measurement(_recall(), arm=ARM_A)
+
+    with pytest.raises(DriftError) as excinfo:
+        check_anchors([
+            *_geometry_measurements(), _coverage_measurement(), recall,
+            in_field_measurement(_cell(), replayable=656),
+        ])
+
+    assert "arm 'A'" in str(excinfo.value)
+
+
+def test_an_arm_b_measurement_anchors_normally():
+    report = check_anchors([
+        *_geometry_measurements(), _coverage_measurement(),
+        recall_measurement(_recall(), arm=ARM_B),
+        in_field_measurement(_cell(), replayable=656, arm=ARM_B),
+    ])
+
+    assert report.passes
+    assert report.arms == ANCHOR_ARMS
+
+
+# -- the geometry, measured off the store --------------------------------------
+
+
+def _anchor_session(index: int) -> date:
+    return date(2020, 1, 1) + timedelta(days=index)
+
+
+def _geometry_bars(n: int = 40, *, spike_last: bool = False) -> list[Bar]:
+    """A quiet series of identical-shaped bars, optionally with a wild last one.
+
+    Every bar has the same 2% high/low span, so ADR and the trailing ranges are
+    hand-checkable, and the last bar is the *entry* session — a measurement that
+    read it instead of the eve would move by an order of magnitude.
+    """
+    bars = []
+    for i in range(n):
+        high, low = 102.0, 100.0
+        if spike_last and i == n - 1:
+            high, low = 300.0, 50.0
+        bars.append(
+            Bar(session=_anchor_session(i), open=101.0, high=high, low=low,
+                close=101.0, adj_close=101.0, volume=1_000_000)
+        )
+    return bars
+
+
+def test_the_five_bar_ruler_agrees_with_the_detectors_own_at_three_bars():
+    """There is no second definition of the trailing range: the k-generic ruler
+    here reduces to ``screener.detection.range_3bar_adr`` at k = 3, so the two
+    cannot drift into disagreeing about the same number."""
+    bars = _geometry_bars(30)
+    # A ragged tail, so the identity is tested on a series where k actually
+    # changes the answer rather than on flat bars where every k agrees.
+    bars[-1] = dataclasses.replace(bars[-1], high=110.0, low=99.0)
+    bars[-3] = dataclasses.replace(bars[-3], high=104.0, low=95.0)
+
+    idx = len(bars) - 1
+    adr_abs = _adr_of(bars) * bars[idx].close
+    theirs = range_3bar_adr(
+        [b.high for b in bars], [b.low for b in bars], idx, adr_abs
+    )
+
+    assert trailing_range_adr(bars, idx, 3) == pytest.approx(theirs)
+    # And k = 5 is at least as wide, which is the property that makes k = 3 the
+    # tightest window the cluster scan can see.
+    assert trailing_range_adr(bars, idx, 5) >= trailing_range_adr(bars, idx, 3)
+
+
+def test_the_geometry_is_measured_at_the_evaluation_session_not_the_entry(store):
+    """Point-in-time, like every other value entering a decision: the entry
+    session's own bar is ahead of the night the app would have had to name the
+    stock, so it never enters the anchor."""
+    bars = _geometry_bars(40, spike_last=True)
+    store.append_bars("US", "AAA", bars)
+    trades = parse_trades([_trade_record("AAA", bars[-1].session.isoformat())])
+
+    measured = measure_geometry(store, trades, market="US")
+
+    eve_index = len(bars) - 2
+    expected_3 = trailing_range_adr(bars, eve_index, 3)
+    assert measured.n == 1
+    assert measured.median_range_3bar_adr == pytest.approx(expected_3)
+    assert measured.median_adr_at_entry_eve == pytest.approx(_adr_of(bars[:-1]))
+    # The spike would have trebled it, which is what makes this test worth having.
+    assert trailing_range_adr(bars, len(bars) - 1, 3) > 3 * expected_3
+
+
+def test_a_trade_contributes_to_all_three_medians_or_to_none(store):
+    """The three figures are taken over one sample, so a divergence between them
+    can never be a difference in who was included."""
+    store.append_bars("US", "AAA", _geometry_bars(40))
+    store.append_bars("US", "SHORT", _geometry_bars(5))
+    entry = _anchor_session(39).isoformat()
+    trades = parse_trades([
+        _trade_record("AAA", entry),
+        _trade_record("SHORT", entry),
+        _trade_record("GONE", entry),
+    ])
+
+    measured = measure_geometry(store, trades, market="US")
+
+    assert measured.n == 1
+    assert measured.without_bars == 1     # GONE: the survivorship hole
+    assert measured.short_history == 1    # SHORT: fewer than 20 bars at the eve
+    assert measured.median_range_5bar_adr is not None
+
+
+def test_the_geometry_sample_size_rides_on_the_report(store):
+    """A median over a silently halved sample prints as a plausible number, so how
+    many trades stood behind it travels with it."""
+    store.append_bars("US", "AAA", _geometry_bars(40))
+    entry = _anchor_session(39).isoformat()
+    trades = parse_trades([_trade_record("AAA", entry), _trade_record("GONE", entry)])
+    measured = measure_geometry(store, trades, market="US")
+
+    report = check_anchors(
+        [
+            *geometry_measurements(
+                dataclasses.replace(
+                    measured,
+                    median_range_3bar_adr=1.31,
+                    median_range_5bar_adr=1.86,
+                    median_adr_at_entry_eve=0.0608,
+                )
+            ),
+            _coverage_measurement(),
+            recall_measurement(_recall()),
+            in_field_measurement(_cell(), replayable=656),
+        ],
+        sample=measured,
+    )
+    body = anchors_report(DEFAULT_CONTRACT, report)
+
+    assert body["geometry_sample"]["n"] == 1
+    assert body["geometry_sample"]["without_bars"] == 1
+
+
+def test_coverage_is_measured_off_the_reference_report(store):
+    """The coverage anchor reads the same report ``replay.reference`` builds — one
+    classification of the reference set, not a second one that could disagree."""
+    store.append_bars("US", "AAA", _geometry_bars(40))
+    entry = _anchor_session(39).isoformat()
+    trades = parse_trades([_trade_record("AAA", entry), _trade_record("GONE", entry)])
+
+    measurement = coverage_measurement(build_report(trades, store, market="US"))
+
+    assert measurement.values["blind_spot_tickers"] == 1
+    assert measurement.values["total_rows"] == 2
+
+
+# -- the result, and the command ------------------------------------------------
+
+
+def test_the_anchor_report_is_stamped_and_serialises():
+    """Like every figure the package emits: the contract rides on it, and the two
+    groups stay separate keys rather than one list a reader has to sort."""
+    report = check_anchors(_all_measurements())
+    body = anchors_report(DEFAULT_CONTRACT, report)
+
+    assert body[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
+    assert [c["anchor"] for c in body["geometry"]] == [
+        a.key for a in GEOMETRY_ANCHORS
+    ]
+    assert [c["anchor"] for c in body["gate_dependent"]] == [
+        a.key for a in GATE_DEPENDENT_ANCHORS
+    ]
+    assert body["arms_anchored"] == list(ANCHOR_ARMS)
+    assert body["arms_measured_never_anchored"] == [ARM_A]
+    assert json.loads(json.dumps(body)) == body
+
+
+def test_the_stamp_and_the_pins_ride_on_the_serialised_result():
+    """A report a reader can check without the plan open beside it."""
+    body = anchors_report(DEFAULT_CONTRACT, check_anchors(_all_measurements()))
+    in_field = next(c for c in body["gate_dependent"] if c["anchor"] == "in_field")
+
+    assert in_field["detector_stamp"] == "detector v3"
+    assert in_field["first_measurement"] is True
+    assert "#162" in in_field["tolerance_reason"]
+    assert len(in_field["superseded"]) == 4
+
+
+def test_the_printed_report_separates_the_two_kinds_of_anchor():
+    text = format_anchors(check_anchors(_all_measurements()))
+
+    assert "geometry — measured from his bars" in text
+    assert "gate-dependent — these move" in text
+    assert text.index("geometry — measured") < text.index("gate-dependent — these")
+    assert "measured, never anchored" in text
+
+
+def test_an_unchecked_gate_dependent_group_is_reported_as_unchecked():
+    """A run anchored on four of six is not anchored, and an empty section reads
+    as three passes unless it says otherwise."""
+    report = AnchorReport(
+        detector_version=DETECTOR_VERSION,
+        arms=ANCHOR_ARMS,
+        geometry=check_geometry(_geometry_measurements()),
+        gate_dependent=(),
+        geometry_only=True,
+    )
+
+    assert not report.passes
+    assert "NOT CHECKED" in format_anchors(report)
+
+
+def _anchor_cli_store(tmp_path) -> tuple[Path, Path]:
+    """A one-name store and a reference set whose geometry lands on the anchors.
+
+    The store is written to disk because the command opens one; the bars are
+    scaled so the three medians sit exactly on their committed values, which is
+    what lets the command's *pass* path be exercised without a 649-trade fixture.
+    """
+    path = tmp_path / "backtest_anchor.duckdb"
+    store = Store.open(path)
+    store.append_bars("US", "AAA", _geometry_bars(40))
+    store.close()
+
+    reference = tmp_path / "trades.json"
+    reference.write_text(
+        json.dumps([_trade_record("AAA", _anchor_session(39).isoformat())])
+    )
+    return path, reference
+
+
+def test_the_command_refuses_to_report_a_run_anchored_on_four_of_six(
+    tmp_path, capsys
+):
+    """Without the run's own field measurements the two gate-dependent field
+    anchors are not checked, and a report that printed the four it *could* check
+    would read as an anchored run. It says what it did not check, and fails."""
+    path, reference = _anchor_cli_store(tmp_path)
+
+    code = anchors_main([
+        "--store", str(path), "--reference", str(reference),
+    ])
+
+    assert code == 1
+    printed = capsys.readouterr().out
+    assert "NOT CHECKED" in printed
+    assert "the run is not anchored" in printed
+    # The geometry it did check is still reported — that is the point of running
+    # it at all before the field pass exists.
+    assert "Median trailing 3-bar range" in printed
+
+
+def test_the_command_writes_a_stamped_result_when_every_anchor_is_offered(
+    tmp_path, capsys
+):
+    """The whole Phase 6 path: geometry and coverage measured off the store, the
+    two field anchors read from the run's own pass, the result stamped."""
+    path, reference = _anchor_cli_store(tmp_path)
+    field = tmp_path / "field.json"
+    field.write_text(json.dumps({
+        "detection_recall": {"passed": 549, "of": 656},
+        "in_field": {"in_field": 395, "of": 656, "gap_pp": 1.9,
+                     "detector_version": 3},
+    }))
+    out_json = tmp_path / "anchors.json"
+
+    code = anchors_main([
+        "--store", str(path), "--reference", str(reference),
+        "--field-measurements", str(field),
+        "--out-json", str(out_json),
+        # The one-name fixture cannot reproduce his 649-trade medians or the
+        # 828-row coverage, so those divergences are written up — which is the
+        # other half of "reproduce it, or explain it".
+        "--explain", "median_range_3bar_adr=one-name fixture",
+        "--explain", "median_range_5bar_adr=one-name fixture",
+        "--explain", "median_adr_at_entry_eve=one-name fixture",
+        "--explain", "coverage_blind_spot=one-name fixture",
+    ])
+
+    assert code == 0
+    written = json.loads(out_json.read_text())
+    assert written[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
+    in_field = next(
+        c for c in written["gate_dependent"] if c["anchor"] == "in_field"
+    )
+    assert in_field["verdict"] == "match"       # 395 is inside the #162 band
+    assert written["passes"] is True
+    geometry = written["geometry"][0]
+    assert geometry["verdict"] == "diverged (explained)"
+    assert capsys.readouterr().out.count("diverged (explained)") >= 1
+
+
+def test_the_command_fails_on_a_field_anchor_from_the_wrong_version(tmp_path):
+    """The failure the per-version stamp exists to catch, through the command:
+    v2's 349 quoted at a run built on v3."""
+    path, reference = _anchor_cli_store(tmp_path)
+    field = tmp_path / "field.json"
+    field.write_text(json.dumps({
+        "detection_recall": {"passed": 549, "of": 656},
+        "in_field": {"in_field": 349, "of": 656, "gap_pp": 2.02,
+                     "detector_version": 2},
+    }))
+
+    code = anchors_main([
+        "--store", str(path), "--reference", str(reference),
+        "--field-measurements", str(field),
+        "--explain", "median_range_3bar_adr=one-name fixture",
+        "--explain", "median_range_5bar_adr=one-name fixture",
+        "--explain", "median_adr_at_entry_eve=one-name fixture",
+        "--explain", "coverage_blind_spot=one-name fixture",
+    ])
+
+    assert code == 1


### PR DESCRIPTION
Phase 6 of #182: the six figures already committed to this repo, checked before any new figure from the run is read. A mismatch is a bug in the new store or the new chain, and every downstream number inherits it.

Closes #197.

## What it does

`backtest.anchors` holds the table as data and checks it through the study's **existing** drift mechanism — `replay.reference.DriftError`, which has failed loudly since #114. Nothing here re-measures what already has a home: the anchors arrive as the existing measurement types (`StageRecall`, `CellMeasurement`, `ReferenceReport`) through adapters. The geometry is the one exception, and only because its committed figures came from a throwaway prototype rather than from a module anything can call.

**Geometry first, and apart.** The three medians hold whatever the detector does, so they anchor the store and the indicators; a failure there stops the check without reading the gate-dependent three. Measured against `data/replay.duckdb` they reproduce to the digit on the same 649-trade sample §3b reports: **1.3105 / 1.8633 / 6.0812%**.

**The two field rows stay distinct.** Recall is gate-invariant and exact; `in_field` is stamped v3, flagged a first measurement, and carries the #162 reference-contamination band — 7 trades, derived from the ~0.5% denominator shift on 656 rather than picked. What that band may never absorb is a flip in the sign of §4b's gap, which rides on the same anchor as a sign-checked component. A write-up cannot waive it either: every other anchor may be reproduced *or* explained in writing, that one may only be reproduced.

**Arms B and C only**, derived from `ARM_SPECS.comparable_to_reference` rather than restated.

## Reviewed

`/code-review` on both axes. Spec review confirmed every committed value matches the plan's Phase 6 table exactly, including all seven superseded pins. Two real holes came back and are fixed in the second commit: a sign flip was waivable via `--explain`, and the command's JSON path bypassed the adapters carrying the recall/`in_field` invariant — the one path the documented reproduction command uses.

## One finding for #198

The current `data/backtest.duckdb` **does not** pass the geometry anchors — 1.2752 / 1.7674 / 6.4277% over n=496, because 312 of his trades have no bars in that store against 170 in the replay store. That reads as a coverage difference in the crawl rather than a bar-geometry bug, but it is exactly the check Phase 6 exists to force. The anchors are left pinned at their committed values rather than widened to accommodate it.

838 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkH9J2RweF4Bw9hp37cNsQ
