### PR TITLE
Do the registered candidate dimensions predict, or only select? (#195)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -531,8 +531,11 @@ count ride on every cell, because a significance figure that moved between two r
 same data would be unreproducible with nothing in the output to show it. A statistic that is
 not a mean — a **score band** gap, a candidate's hit-minus-miss gap, a rank correlation — is
 resampled the same way through
-`backtest.ranking.bootstrap_symbol_statistic`, on the metric's own seed and cluster floor, so
-two intervals in one report were never built differently.
+`backtest.stats.bootstrap_symbol_statistic`, on the metric's own seed and cluster floor, so
+two intervals in one report were never built differently. A draw the statistic cannot evaluate
+is counted as **undefined**, never as a zero, and past a tenth of the draws the interval is
+refused rather than read off the rest — which would condition on the statistic having been
+computable, and those are the confident draws.
 _Avoid_: bootstrapping the trades, resampling the rows — the row is not the unit.
 
 **Priced posture**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -263,8 +263,8 @@ dimension cannot discriminate, not that removing it is free.
 
 **Candidate dimension**:
 A dimension **under measurement**, not in the rubric: computed on every detection in the
-replay, carried beside the star score, reported as a column of the **selection contrast**, and
-weighted by nothing. It is how ADR 0005's admission rule is exercised — a dimension earns a
+replay, carried beside the star score, reported as a column of the **selection contrast** and —
+since #195 — as a cohort of the **candidate outcome test**, and weighted by nothing. It is how ADR 0005's admission rule is exercised — a dimension earns a
 rubric slot on a measured non-zero gap with non-zero pooled spread, and until that measurement
 exists it must be unable to move a star, a sort or a board place. So it lives on a field member
 of its own (`RS line` on `replay.field.ScoredDetection.rs_line`), never inside `SevenDimScore`,
@@ -529,7 +529,8 @@ fortnight contributes three correlated rows — so bootstrapping *rows* makes th
 sample larger than it is and flatters every p-value. Seeded, and the seed and resample
 count ride on every cell, because a significance figure that moved between two runs of the
 same data would be unreproducible with nothing in the output to show it. A statistic that is
-not a mean — a **score band** gap, a rank correlation — is resampled the same way through
+not a mean — a **score band** gap, a candidate's hit-minus-miss gap, a rank correlation — is
+resampled the same way through
 `backtest.ranking.bootstrap_symbol_statistic`, on the metric's own seed and cluster floor, so
 two intervals in one report were never built differently.
 _Avoid_: bootstrapping the trades, resampling the rows — the row is not the unit.
@@ -594,6 +595,34 @@ of the weights. §4a's figures ride on the payload precisely so the two are neve
 one.
 _Avoid_: the ranking result, the decile test; and never quote it against §4a's **+5.59pp**
 as though the two were comparable.
+
+**Candidate outcome test**:
+The measurement of whether a **candidate dimension** predicts, rather than only selects
+(PRD #182, #195, `backtest.candidates`): after-cost R on the mechanical denominator, split
+by the candidate's own pre-registered cut, **per market**, with the **clustered bootstrap**
+on the hit-minus-miss gap. It is not ADR 0005's admission instrument and admits nothing —
+that rule reads a **selection contrast**, and the two are a different claim about the same
+dimension: one says he picked names the dimension fires on, the other says those names paid.
+So §5d's and §5e's figures ride on every cell under their own verdict key and are never
+summed with this one's. The verdict is the **gap's alone**, because ADR 0005 admits a
+dimension as a boolean; the rank correlation against the stored value is reported beside it
+and excluded, since only `Relative move` persists a degree to run it on. "No evidence it
+predicts" is never "the dimension does not predict".
+_Avoid_: the outcome contrast, the candidate regression; and never quote a gap here against
+a selection Δ as though the two were readings of one thing.
+
+**Absent group**:
+The third group of the **candidate outcome test**: the detections whose candidate value the
+row carries as `NULL`, meaning the question was never asked — `Relative move` where the name
+had not listed six months back or has no ADR, `RS line` where a price was missing at one of
+its two anchors. Kept apart from a miss and given its own n, because `Relative move`'s cut
+sits at **zero**: an absence coerced to a number would land exactly on the boundary and let
+the strictness of a comparison decide a verdict nobody measured. It enters **no gap**. What a
+shipped boolean would do with it — the pre-registered readers score absent `False` — is
+reported separately as the `rubric_reading` and never sets the verdict, because "what would
+this boolean have done" is a different question from "does the quantity predict".
+_Avoid_: treating absent as a miss, or as a zero; a **candidate dimension** is never carried
+forward and never excludes a name.
 
 **Not-taken detection**:
 A member of the replayed field on a session where he entered something else. Not a

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -175,6 +175,20 @@ that already keep :mod:`backtest.ranking` out: it is a command
 :class:`~backtest.run.ContractDrift`. The entry point is
 ``backtest.candidates.candidates_report``.
 
+Two small modules came out of that second measurement rather than being copied
+into it, because a second caller is what turns shared code into a module.
+:mod:`backtest.stats` holds the statistics more than one measurement needs — the
+tie rule, Spearman's rho, clustering by symbol, the clustered bootstrap over an
+arbitrary statistic, and the two places a report renders and counts an interval.
+It knows nothing about what is being measured, which is what lets one bootstrap
+serve a score band's gap and a candidate dimension's. :mod:`backtest.cohort` holds
+the join back to the persisted row: the detection index for a market, and the
+**total** join from simulated trades to the rows that produced them, whose refusal
+has to be the same in both callers because the argument for refusing is the same.
+:mod:`backtest.ranking` was where both lived when it was the only caller; leaving
+them there would have made it a measurement and the run's statistics library at
+once, changing for two reasons and imported by the module it should not own.
+
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean
 something else one import away (:mod:`screener.universe`, :mod:`replay.reference`),

--- a/backend/backtest/__init__.py
+++ b/backend/backtest/__init__.py
@@ -152,6 +152,29 @@ already keep :mod:`backtest.metric` out: it is a command
 :class:`~backtest.run.ContractDrift`. The entry point is
 ``backtest.ranking.ranking_report``.
 
+Issue #195 lands the second half of Phase 5's rubric question:
+:mod:`backtest.candidates`, which measures both registered candidate dimensions
+against **outcomes** rather than against the trader's selection. ADR 0005 admits a
+dimension on a selection contrast because that was the only instrument available
+when it was written; both registrations then failed on it — ``RS line`` refused for
+a wrong-way gap, ``Relative move`` positive on both fields and stalled 0.06pp
+inside a threshold the ADR itself calls a judgement. Here each candidate's cohort
+splits three ways, never two: hit and miss under the pre-registered cut applied at
+read time by the rubric's own reader, and **absent** where the question was never
+asked. That third group is load-bearing rather than tidy — ``Relative move``'s cut
+is zero, so an absence coerced to a number would land exactly on it — so absence
+carries its own n and enters no gap. The published selection figures ride on every
+candidate's cell under their own verdict key, because a dimension that ranks
+outcomes and one that matches a selection are two claims that can point opposite
+ways. Nothing here admits a dimension, and
+:func:`~backtest.candidates.check_not_admitted` makes that executable.
+
+:mod:`backtest.candidates`'s names are **not** re-exported here, for the reasons
+that already keep :mod:`backtest.ranking` out: it is a command
+(``python -m backtest.candidates``) and it imports both that module and
+:class:`~backtest.run.ContractDrift`. The entry point is
+``backtest.candidates.candidates_report``.
+
 The universe's names are not re-exported, and the reason is naming rather than
 import weight: ``classify``, ``Candidate`` and ``is_member`` each already mean
 something else one import away (:mod:`screener.universe`, :mod:`replay.reference`),

--- a/backend/backtest/candidates.py
+++ b/backend/backtest/candidates.py
@@ -1,0 +1,1032 @@
+"""Do the registered candidate dimensions predict, or only select? (issue #195).
+
+Both dimensions ADR 0005 has registered, measured against **outcomes** rather than
+against the trader's selection, per market, on the mechanical denominator.
+
+Why this measurement exists
+---------------------------
+ADR 0005 admits a dimension on a **selection contrast** — a candidate's hit rate
+among the detections the trader took against its hit rate among the ones he passed
+over, no outcome variable anywhere in it. That instrument was not chosen; it was
+what existed. The ADR's own "considered options" records the alternative as *not
+available*: findings §5a had found no dimension predicting MFE, and there was no
+out-of-sample outcome to regress against.
+
+Both registrations then ran into the limits of that instrument:
+
+* ``RS line`` was refused on criterion 4 for a wrong-way Δ (findings §5d), on a
+  dimension firing on one detection in ten in *both* groups.
+* ``Relative move`` came back positive on both fields and then stalled **0.06pp**
+  inside criterion 2's ~85% ceiling (§5e) — a threshold the ADR itself calls "the
+  one magnitude in this design with nothing behind it", now deciding an admission
+  by six hundredths of a point. The ADR declined to resolve it and recorded that
+  no third candidate should register until that threshold is argued on its own.
+
+This run gives the same two dimensions an outcome variable: **R after costs**, on
+trades taken mechanically over two markets and fourteen years, which no rubric
+weight was fitted to and no detection could see. A dimension that ranks *outcomes*
+is a different and stronger claim than one that matches his *selection*, and the
+two must never be conflated — so the published selection figures ride on every
+candidate's cell (:data:`SELECTION_CONTRAST`) under their own verdict key, beside
+the sentence saying why they cannot be added up.
+
+Three groups, because absence is not a miss
+-------------------------------------------
+Each candidate splits its cohort three ways, never two:
+
+* :data:`GROUP_HIT` and :data:`GROUP_MISS` — the pre-registered cut applied at
+  **read time** by the rubric's own reader (:data:`replay.contrast.CANDIDATES`),
+  off the value the persisted row carries. The row is never re-denominated: a
+  later argument about where the cut belongs re-reads these rows rather than
+  rewriting them, which is the whole point of persisting a value (#154).
+* :data:`GROUP_ABSENT` — the question was never asked. ``relative_move`` is
+  ``None`` when the name had not listed six months back or has no ADR;
+  ``rs_line`` is ``None`` when a price was missing at one of its two anchors.
+
+The absent group is not a convenience. ``Relative move``'s cut sits at **zero**,
+so an absence coerced to 0.0 would not merely be a guess — it would land exactly
+on the boundary and let the strictness of a comparison decide a verdict nobody
+measured. Absence therefore has its own group, its own n and its own cell, and it
+enters no gap.
+
+What the shipped boolean would do is reported too, and separately
+-----------------------------------------------------------------
+The pre-registered readers score an absent value ``False``, so a dimension shipped
+as a rubric row would put those trades on the miss side. That reading is worth
+having — it is what the rubric would actually apply — but it answers a different
+question from "does the measured quantity predict". It rides beside the primary
+gap as ``rubric_reading``, and :data:`VERDICT_RULE` puts it outside the verdict.
+
+One statistic decides, and it is the gap
+----------------------------------------
+ADR 0005 admits a dimension **as a boolean** (grading needs demonstrated signal,
+which a candidate by definition has none of), so the claim this run can act on is
+the gap between the two sides. Spearman's rho against the *stored value* is
+reported beside it, because ``Relative move`` persists a real number in ADR units
+and that is the grading question ADR 0004 would ask later — but it does not enter
+the verdict, for a reason that is structural rather than cautious: ``RS line``
+persists only a boolean, so a rule reading rho would mean different things for the
+two dimensions.
+
+Nothing here admits a dimension
+-------------------------------
+Not by construction and not by omission: :func:`check_not_admitted` refuses to run
+if a registered candidate has entered the live rubric, and :data:`ADMISSION_NOTE`
+says on the payload that admission is ADR 0005's instrument rather than this one's.
+The result is evidence that goes through the calibration rule like any other
+change.
+
+Everything else is the metric's
+-------------------------------
+The after-cost R of a trade, the per-market costs, the cell behind every group and
+the clustered bootstrap are :mod:`backtest.metric`'s and
+:func:`backtest.ranking.bootstrap_symbol_statistic`'s, on the same seed, cluster
+and floor — so this measurement and the headline can never disagree about what a
+trade paid, and two intervals in one run were never built differently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from replay.contrast import CANDIDATES
+from replay.field import ScoredDetection
+from screener.relative_strength import RELATIVE_MOVE_CUT
+from screener.score import DIMENSIONS
+from screener.store import Store
+
+from .contract import DEFAULT_CONTRACT, SCOPE_MARKETS_KEY, RunContract
+from .denominator import DenominatorStore, denominator_path
+from .metric import (
+    BOOTSTRAP_CLUSTER,
+    BOOTSTRAP_CONFIDENCE,
+    BOOTSTRAP_RESAMPLES,
+    BOOTSTRAP_SEED,
+    PRIMARY_ARM,
+    after_cost_r,
+    check_costs,
+    check_one_market_one_arm,
+    expectancy_cell,
+)
+from .ranking import bootstrap_symbol_statistic, spearman
+from .result import stamp_result
+from .run import ContractDrift
+from .simulate import SimulatedTrade, simulate_market
+
+# -- the three groups ---------------------------------------------------------
+
+# A hit, a miss, and the rows where the question was never asked. Three tokens
+# rather than a boolean and a flag, because every count, cell and share in the
+# report is keyed by one of them and a two-valued split with an exception beside
+# it is the shape that lets an absence quietly become a miss.
+GROUP_HIT = "hit"
+GROUP_MISS = "miss"
+GROUP_ABSENT = "absent"
+
+GROUPS: tuple[str, ...] = (GROUP_HIT, GROUP_MISS, GROUP_ABSENT)
+
+# The two sides a gap is taken between. Named, because the gap is exactly the
+# comparison the absent group is kept out of.
+ASKED_GROUPS: tuple[str, ...] = (GROUP_HIT, GROUP_MISS)
+
+
+# -- what kind of value a candidate persists ----------------------------------
+
+# A candidate whose row carries a **degree** — a real number a correlation can be
+# run against. ``Relative move``'s ADR units are the only one.
+VALUE_GRADED = "graded"
+# A candidate whose row carries only the answer. ``RS line`` is a comparison of
+# two ratios, so what persists is the verdict and there is no degree to rank.
+VALUE_BOOLEAN = "boolean"
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One registered candidate dimension, and how to read a persisted row for it.
+
+    :data:`CANDIDATES` supplies the name and the pre-registered boolean reader;
+    everything else here is what an *outcome* measurement additionally needs and a
+    selection contrast never did — how to reach the stored value, whether that
+    value is a degree or a verdict, and what an absent one means.
+
+    ``hit`` is the registry's own reader and is never re-implemented: the cut the
+    contrast read and the cut this measurement reads are one function, so the two
+    studies can never disagree about which side of the line a row fell.
+    """
+
+    name: str
+    hit: Callable[[ScoredDetection], bool]
+    value: Callable[[ScoredDetection], Any]
+    value_kind: str
+    cut: str
+    absent_means: str
+
+
+# How to read each registered candidate's stored value, keyed by the name the
+# registry uses. Kept apart from :data:`CANDIDATES` because that tuple is ADR
+# 0005's register of what has been *pre-registered*, and a measurement module
+# adding an entry to it could promote a column after its gap was visible.
+_VALUE_READERS: dict[str, dict[str, Any]] = {
+    "RS line": {
+        "value": lambda d: d.rs_line,
+        "value_kind": VALUE_BOOLEAN,
+        "cut": "RS_today >= RS_at_base_start, over the detection's own base",
+        "absent_means": (
+            "a price was missing at one of the two anchors, so the question was "
+            "never asked — which is a different fact from asking it and getting no"
+        ),
+    },
+    "Relative move": {
+        "value": lambda d: d.relative_move,
+        "value_kind": VALUE_GRADED,
+        "cut": (
+            f"the 6m index-relative move in ADR units, strictly above "
+            f"{RELATIVE_MOVE_CUT:.1f}"
+        ),
+        "absent_means": (
+            "the name had not listed six months ago, or has no ADR — never zero, "
+            "which is a real value sitting exactly on the cut"
+        ),
+    },
+}
+
+
+def check_registry(
+    registered: Sequence[tuple[str, int, Callable[[ScoredDetection], bool]]] = (
+        CANDIDATES
+    ),
+) -> None:
+    """Refuse to measure if a registered candidate has no value reader here.
+
+    #195 asks for **both** registered candidates, and a third registration would
+    make that sentence mean something new. This module cannot read a row for a
+    dimension it has never heard of — it would not know where the value lives or
+    what an absent one means — so a new registration stops the measurement instead
+    of being quietly left out of a report that still claims to cover the register.
+    """
+    unknown = sorted({name for name, _w, _r in registered} - set(_VALUE_READERS))
+    if unknown:
+        raise ContractDrift(
+            f"registered candidate(s) {unknown} have no value reader in "
+            "backtest.candidates: this measurement covers the whole register, so "
+            "a new registration is a change to make here rather than a column to "
+            "leave out"
+        )
+
+
+def _under_test() -> tuple[Candidate, ...]:
+    """The register, in its own order, with this module's readers attached."""
+    check_registry()
+    return tuple(
+        Candidate(name=name, hit=hit, **_VALUE_READERS[name])
+        for name, _weight, hit in CANDIDATES
+    )
+
+
+CANDIDATES_UNDER_TEST: tuple[Candidate, ...] = _under_test()
+
+
+def named_candidate(name: str) -> Candidate:
+    """One candidate by the name the register uses."""
+    for candidate in CANDIDATES_UNDER_TEST:
+        if candidate.name == name:
+            return candidate
+    raise KeyError(
+        f"{name!r} is not a registered candidate dimension; "
+        f"{[c.name for c in CANDIDATES_UNDER_TEST]} are"
+    )
+
+
+# -- nothing here admits a dimension ------------------------------------------
+
+ADMISSION_NOTE = (
+    "this measurement admits no dimension and retires none. ADR 0005's admission "
+    "instrument is the selection contrast, and an outcome claim is not one — it "
+    "is evidence that goes through the calibration rule like any other change. "
+    "Neither candidate's weight, the rubric version, nor the register moves here"
+)
+
+
+def check_not_admitted(
+    dimensions: Sequence[tuple[str, int]] = DIMENSIONS,
+) -> None:
+    """Refuse if a registered candidate has entered the live rubric.
+
+    A candidate is a dimension **under measurement**, weighted by nothing and
+    unable to move a star, a sort or a board place. One that had reached
+    :data:`screener.score.DIMENSIONS` would make this a report about a live rubric
+    row under a banner saying the opposite, and #195's last criterion — that
+    neither dimension is admitted by this ticket — would be false in a way no
+    reader of the output could see.
+    """
+    live = {name for name, _weight in dimensions}
+    admitted = sorted(live & {c.name for c in CANDIDATES_UNDER_TEST})
+    if admitted:
+        raise ContractDrift(
+            f"{admitted} is in the live rubric: this measurement reports on "
+            "candidate dimensions, which are weighted by nothing, and an admitted "
+            "one is a different subject under the same name"
+        )
+
+
+# -- the selection contrast, carried so the two claims are never merged -------
+
+# What ADR 0005's instrument measured on each candidate, quoted from
+# `references/qullamaggie-replay-findings.md` rather than recomputed. It rides on
+# every candidate's cell because the danger is not that a reader disbelieves §5d
+# or §5e — it is that a reader reads the selection Δ and the outcome gap as two
+# readings of one claim, when they are two claims that can point opposite ways.
+#
+# Both figures are the **live detector v3** column, which is the field ADR 0005
+# requires a verdict to be read on.
+SELECTION_CONTRAST: dict[str, dict[str, Any]] = {
+    "RS line": {
+        "instrument": "selection contrast",
+        "measures": "his taken detections against the ones he passed over",
+        "source": "findings §5d",
+        "detector": "v3 (live)",
+        "taken_hit_rate": 0.100,
+        "taken_n": 140,
+        "not_taken_hit_rate": 0.121,
+        "not_taken_n": 34543,
+        "delta_pp": -2.1,
+        "pooled_spread": 0.326,
+        "adr_0005_verdict": "not admitted",
+        "why": (
+            "refused on criterion 4, a wrong-way gap, with the anchor named as "
+            "the mechanism: base_start is a local high under both detector "
+            "branches, so the rule asks a name to hold its ratio to the index "
+            "measured from a local maximum"
+        ),
+    },
+    "Relative move": {
+        "instrument": "selection contrast",
+        "measures": "his taken detections against the ones he passed over",
+        "source": "findings §5e",
+        "detector": "v3 (live)",
+        "taken_hit_rate": 0.886,
+        "taken_n": 140,
+        "not_taken_hit_rate": 0.8494,
+        "not_taken_n": 34543,
+        "delta_pp": 3.6,
+        "pooled_spread": 0.357,
+        "adr_0005_verdict": "not admitted",
+        "why": (
+            "positive on both fields, and then 0.06pp inside criterion 2's ~85% "
+            "ceiling — 0.29 standard errors from a threshold the ADR calls a "
+            "judgement rather than a measurement. The criteria do not separate, "
+            "so nothing shipped"
+        ),
+    },
+}
+
+SELECTION_CONTRAST_NOTE = (
+    "the selection contrast and this measurement are a different claim about the "
+    "same dimension, and neither converts into the other: one says the trader "
+    "picked names the dimension fires on, the other says the names it fires on "
+    "paid. A dimension can select and not predict — his edge would be "
+    "discretionary — and it can predict and not select, which is a candidate he "
+    "was never using. So the two verdicts are reported side by side under their "
+    "own keys and are never summed, averaged or read as confirmation of each other"
+)
+
+OUT_OF_SAMPLE_NOTE = (
+    "the outcome variable is R after costs on trades taken mechanically over a "
+    "window his record does not cover; no rubric weight was fitted to it and no "
+    "detection could see it"
+)
+
+NOT_CUT_PER_YEAR = (
+    "reported per market and not per year, unlike the ranking test: two "
+    "candidates, three groups and three statistics each already make this the "
+    "widest cell in the run, and a per year row would multiply the interval count "
+    "by the length of the window to answer a question #195 does not ask. The "
+    "window row is the measurement"
+)
+
+MULTIPLE_TESTING_NOTE = (
+    "one more view of a dataset that already carried nine before any sweep; "
+    "pre-specified by #195 and computed once, not chosen after the fact"
+)
+
+
+# -- the rows the statistics run on -------------------------------------------
+
+
+@dataclass(frozen=True)
+class CandidateTrade:
+    """One simulated trade beside the persisted detection row it came from.
+
+    Joined rather than stored together, for the reason the ranking gives: the
+    simulator takes an entry and an exit and has no business carrying a candidate
+    dimension, and the denominator's row is where both values already live.
+    """
+
+    trade: SimulatedTrade
+    detection: ScoredDetection
+
+    @property
+    def symbol(self) -> str:
+        return self.trade.symbol
+
+    @property
+    def market(self) -> str:
+        return self.trade.market
+
+
+@dataclass(frozen=True)
+class CandidateOutcome:
+    """One closed trade reduced to what a statistic needs, for one candidate.
+
+    ``value`` is the **degree** the row persisted, and is ``None`` both when the
+    row was absent and when the candidate stores only a verdict — the two are
+    already told apart by ``group``, and a correlation has nothing to run on in
+    either case. Costs are already applied: one place turns a trade into a number,
+    :func:`~backtest.metric.after_cost_r`, and this is where it is called.
+    """
+
+    symbol: str
+    group: str
+    value: float | None
+    r: float
+
+
+def group_of(candidate: Candidate, detection: ScoredDetection) -> str:
+    """Which of the three groups a persisted row falls in, read at read time.
+
+    Absence is tested **first** and on the stored value itself, so no absent row
+    can reach the cut. That order is the whole guard: ``Relative move``'s cut is
+    zero, and a ``None`` coerced to a float would sit exactly on it.
+    """
+    if candidate.value(detection) is None:
+        return GROUP_ABSENT
+    return GROUP_HIT if candidate.hit(detection) else GROUP_MISS
+
+
+def split(
+    candidate: Candidate, cohort: Sequence[CandidateTrade]
+) -> dict[str, list[CandidateTrade]]:
+    """The cohort partitioned into the three groups, every group present.
+
+    A group with no trades comes back empty rather than missing, so a report can
+    show its zero: an absent row and a group nobody measured are indistinguishable
+    after the fact.
+    """
+    groups: dict[str, list[CandidateTrade]] = {g: [] for g in GROUPS}
+    for row in cohort:
+        groups[group_of(candidate, row.detection)].append(row)
+    return groups
+
+
+def _graded_value(candidate: Candidate, detection: ScoredDetection) -> float | None:
+    """The stored degree, or ``None`` where the candidate keeps only a verdict."""
+    if candidate.value_kind != VALUE_GRADED:
+        return None
+    value = candidate.value(detection)
+    return None if value is None else float(value)
+
+
+def outcomes(
+    candidate: Candidate,
+    cohort: Sequence[CandidateTrade],
+    contract: RunContract,
+) -> list[CandidateOutcome]:
+    """The cohort's **closed** trades as rows, after costs, in cohort order.
+
+    A trade still running has no R, and marking one to the last close would invent
+    an exit the rules never gave — systematically, for every name still open. It
+    counts toward its group's ``trades`` and toward nothing else.
+    """
+    rows: list[CandidateOutcome] = []
+    for row in cohort:
+        r = after_cost_r(row.trade, contract)
+        if r is None:
+            continue
+        rows.append(
+            CandidateOutcome(
+                symbol=row.symbol,
+                group=group_of(candidate, row.detection),
+                value=_graded_value(candidate, row.detection),
+                r=r,
+            )
+        )
+    return rows
+
+
+def symbol_clusters(
+    rows: Sequence[CandidateOutcome],
+) -> list[tuple[CandidateOutcome, ...]]:
+    """The rows grouped one cluster per symbol, in symbol order.
+
+    The unit of independence, and it is the **whole** cohort's rows rather than one
+    group's: a resample draws symbols from the field that was measured, and each
+    statistic then reads the rows it is about. Clustering per group instead would
+    resample two populations independently and lose the fact that one name can sit
+    in only one of them.
+
+    Ordered by symbol so a resample under a fixed seed is reproducible.
+    """
+    grouped: dict[str, list[CandidateOutcome]] = {}
+    for row in rows:
+        grouped.setdefault(row.symbol, []).append(row)
+    return [tuple(grouped[symbol]) for symbol in sorted(grouped)]
+
+
+# -- the statistics -----------------------------------------------------------
+
+
+def _mean_gap(
+    rows: Sequence[CandidateOutcome],
+    *,
+    against: Sequence[str],
+) -> float | None:
+    """Mean R of the hit group minus mean R of ``against``, or ``None``.
+
+    ``None`` when either side is empty — which a resample can easily produce —
+    because a gap against a group nobody drew is undefined rather than zero, and
+    the difference matters to every interval built on it.
+    """
+    hit = [row.r for row in rows if row.group == GROUP_HIT]
+    other = [row.r for row in rows if row.group in against]
+    if not hit or not other:
+        return None
+    return sum(hit) / len(hit) - sum(other) / len(other)
+
+
+def outcome_gap(rows: Sequence[CandidateOutcome]) -> float | None:
+    """The measurement: what the dimension's hits paid, less what its misses paid.
+
+    Over the rows where the question was **asked**. An absent row is not a miss —
+    the dimension said nothing about that name — so it is no more part of this
+    comparison than a trade in another market would be.
+    """
+    return _mean_gap(rows, against=(GROUP_MISS,))
+
+
+def rubric_reading_gap(rows: Sequence[CandidateOutcome]) -> float | None:
+    """The same gap as a **shipped** boolean would compute it: absent reads as miss.
+
+    The pre-registered readers score an absent value ``False`` and never carry it
+    forward, so this is what the dimension would do as a rubric row. Reported
+    beside the measurement and outside the verdict: it answers "what would this
+    boolean have done", where :func:`outcome_gap` answers "does the quantity
+    predict", and only the second is a claim about the world.
+    """
+    return _mean_gap(rows, against=(GROUP_MISS, GROUP_ABSENT))
+
+
+def value_correlation(rows: Sequence[CandidateOutcome]) -> float | None:
+    """Spearman's rho between the stored **degree** and the outcome.
+
+    Over the rows that have a degree at all: an absent row is not a low one, and
+    ranking it anywhere — top, bottom or middle — would put a number nobody
+    measured into the figure.
+
+    ``None`` where the candidate stores only a verdict. There is no degree to rank
+    there, and correlating a boolean with the outcome would be the gap again under
+    a second name, which a reader would meet as a second piece of evidence.
+    """
+    graded = [row for row in rows if row.value is not None]
+    return spearman(
+        [row.value for row in graded if row.value is not None],
+        [row.r for row in graded],
+    )
+
+
+# -- the verdict --------------------------------------------------------------
+
+# The vocabulary :mod:`backtest.posture` and :mod:`backtest.ranking` established,
+# spelled identically so a reader joining two of this run's payloads is not
+# comparing "too_thin" against "too thin to say".
+VERDICT_PREDICTS = "predicts"
+VERDICT_NO_EVIDENCE = "no_evidence"
+VERDICT_TOO_THIN = "too_thin"
+
+VERDICT_PHRASE = {
+    VERDICT_PREDICTS: "predicts",
+    VERDICT_NO_EVIDENCE: "no evidence it predicts",
+    VERDICT_TOO_THIN: "too thin to say",
+}
+
+VERDICT_RULE = (
+    "'predicts' requires the hit-minus-miss gap to have a symbol-clustered "
+    "interval entirely above zero. The gap is the whole verdict: ADR 0005 admits "
+    "a dimension as a boolean, so the boolean's gap is the claim anything could "
+    "act on. The correlation against the stored value is reported beside it and "
+    "does not enter — only one of the two registered candidates persists a degree "
+    "to run it on, so a rule reading it would mean different things for the two. "
+    "The rubric reading, which folds absence into the miss side, does not enter "
+    "either: it says what a shipped boolean would have done, not whether the "
+    "quantity predicts. A cohort whose hit or miss side is below the cluster "
+    "floor, or whose interval was refused for undefined resamples, is 'too thin "
+    "to say' — the gap is taken between those two sides. The verdict reads the "
+    "95% interval's lower bound, a one-sided 2.5% test and stricter than the "
+    "one-sided p printed beside it. 'no evidence it predicts' is never 'the "
+    "dimension does not predict': one sample cannot license that"
+)
+
+
+def verdict(*, gap: dict[str, Any], sides: Sequence[dict[str, Any]]) -> str:
+    """The verdict :data:`VERDICT_RULE` spells out, read off the gap alone.
+
+    ``sides`` are the hit and miss cells; a suppressed interval on either makes the
+    gap unreadable however wide the cohort as a whole is.
+    """
+    if any(cell["bootstrap"]["suppressed"] is not None for cell in sides):
+        return VERDICT_TOO_THIN
+    if gap["value"] is None or gap["bootstrap"]["ci_low"] is None:
+        return VERDICT_TOO_THIN
+    return VERDICT_PREDICTS if gap["bootstrap"]["ci_low"] > 0 else VERDICT_NO_EVIDENCE
+
+
+# -- joining a trade to the row that produced it ------------------------------
+
+DetectionIndex = Mapping[tuple[date, str], ScoredDetection]
+
+
+def candidate_index(
+    denominator: DenominatorStore, market: str, *, include_burn_in: bool = False
+) -> dict[tuple[date, str], ScoredDetection]:
+    """Every persisted detection row for one market, keyed by session and symbol.
+
+    The whole row rather than the two values, because the readers take a
+    :class:`~replay.field.ScoredDetection` — the same argument the selection
+    contrast hands them, so neither study can be reading a differently shaped
+    input.
+
+    Burn-in sessions are excluded by default, matching
+    :func:`~backtest.simulate.walk_detections`, so the index and the trades cover
+    the same sessions rather than nearly the same ones.
+    """
+    index: dict[tuple[date, str], ScoredDetection] = {}
+    for header in denominator.sessions(
+        market, burn_in=None if include_burn_in else False
+    ):
+        for scored in denominator.detections(market, header.session):
+            index[(header.session, scored.symbol)] = scored
+    return index
+
+
+def candidate_trades(
+    trades: Sequence[SimulatedTrade], index: DetectionIndex
+) -> list[CandidateTrade]:
+    """Join each trade to its persisted row, refusing a trade that has none.
+
+    The join is **total** or it is a bug: every simulated trade came from a
+    persisted detection. Dropping an unmatched one would shrink the cohort with
+    nothing in the output to say which trades left, and the trades most likely to
+    go missing are not a random sample of them.
+    """
+    out: list[CandidateTrade] = []
+    for trade in trades:
+        key = (trade.detection_session, trade.symbol)
+        if key not in index:
+            raise ValueError(
+                f"no persisted detection row for {trade.symbol} detected "
+                f"{trade.detection_session}: the join from trade to row is total, "
+                "and a missing row is a broken denominator rather than a trade to "
+                "drop"
+            )
+        out.append(CandidateTrade(trade=trade, detection=index[key]))
+    return out
+
+
+# -- the report ---------------------------------------------------------------
+
+
+def _group_cell(
+    contract: RunContract,
+    candidate: Candidate,
+    group: str,
+    rows: Sequence[CandidateTrade],
+    *,
+    market: str,
+    closed_total: int,
+) -> dict[str, Any]:
+    """One group's cell: the metric's own expectancy cell, plus what group it is.
+
+    The body is :func:`~backtest.metric.expectancy_cell` unmodified, so a group
+    reports the same fields the headline does and a reader comparing the two is
+    comparing figures built the same way.
+    """
+    closed = sum(1 for row in rows if row.trade.r_multiple is not None)
+    cell: dict[str, Any] = {
+        "group": group,
+        "share_of_closed": (closed / closed_total) if closed_total else 0.0,
+        **expectancy_cell(
+            contract, [row.trade for row in rows], market=market, label=group
+        ),
+    }
+    if group == GROUP_ABSENT:
+        # Said on the cell rather than only in the module docstring, because this
+        # is the one number a reader is most likely to mistake for a miss.
+        cell["absent_means"] = candidate.absent_means
+        cell["enters_the_gap"] = False
+    return cell
+
+
+def _gap_cell(
+    rows: Sequence[CandidateOutcome],
+    clusters: Sequence[Sequence[CandidateOutcome]],
+) -> dict[str, Any]:
+    """The hit-minus-miss gap with its clustered interval."""
+    return {
+        "statistic": "mean after-cost R, hit minus miss",
+        "reads_absence_as": "absent — it enters neither side",
+        "enters_the_verdict": True,
+        "value": outcome_gap(rows),
+        "bootstrap": bootstrap_symbol_statistic(clusters, outcome_gap),
+    }
+
+
+def _rubric_reading_cell(
+    rows: Sequence[CandidateOutcome],
+    clusters: Sequence[Sequence[CandidateOutcome]],
+) -> dict[str, Any]:
+    """The same gap as a shipped boolean would compute it, and its interval."""
+    return {
+        "statistic": "mean after-cost R, hit minus (miss and absent)",
+        "reads_absence_as": (
+            "a miss — the pre-registered readers score an absent value False, so "
+            "this is what the dimension would do as a rubric row"
+        ),
+        "enters_the_verdict": False,
+        "value": rubric_reading_gap(rows),
+        "bootstrap": bootstrap_symbol_statistic(clusters, rubric_reading_gap),
+    }
+
+
+def _value_cell(
+    candidate: Candidate,
+    rows: Sequence[CandidateOutcome],
+    clusters: Sequence[Sequence[CandidateOutcome]],
+) -> dict[str, Any]:
+    """Spearman's rho against the stored degree, or the reason there is none."""
+    graded = candidate.value_kind == VALUE_GRADED
+    unavailable = None if graded else (
+        f"{candidate.name} persists a boolean, not a degree: there is no value to "
+        "rank, and correlating a verdict with the outcome would restate the gap"
+    )
+    return {
+        "statistic": "spearman_rho",
+        "ties": "averaged",
+        "against": "the persisted value, over the rows that have one",
+        "enters_the_verdict": False,
+        "value_kind": candidate.value_kind,
+        "unavailable": unavailable,
+        "rho": value_correlation(rows) if graded else None,
+        "pairs": sum(1 for row in rows if row.value is not None),
+        "bootstrap": bootstrap_symbol_statistic(
+            clusters, value_correlation, unavailable=unavailable
+        ),
+    }
+
+
+def market_candidate(
+    contract: RunContract,
+    candidate: Candidate,
+    cohort: Sequence[CandidateTrade],
+    *,
+    market: str,
+) -> dict[str, Any]:
+    """One candidate's outcome measurement over one market's cohort.
+
+    The three groups, the gap the verdict is read off, the shipped boolean's
+    reading, the correlation against the stored degree, and the selection contrast
+    ADR 0005 measured — under its own key, with its own verdict, never merged into
+    this one's.
+    """
+    check_costs(contract, market)
+    check_one_market_one_arm(
+        [row.trade for row in cohort],
+        market=market,
+        what=f"a candidate dimension's outcome ({candidate.name})",
+    )
+
+    groups = split(candidate, cohort)
+    rows = outcomes(candidate, cohort, contract)
+    clusters = symbol_clusters(rows)
+    closed_total = len(rows)
+    cells = {
+        group: _group_cell(
+            contract, candidate, group, groups[group],
+            market=market, closed_total=closed_total,
+        )
+        for group in GROUPS
+    }
+    gap = _gap_cell(rows, clusters)
+    return {
+        "candidate": candidate.name,
+        "market": market,
+        "arm": PRIMARY_ARM,
+        "cut": candidate.cut,
+        "cut_applied": (
+            "at read time, by the rubric's own reader, off the value the persisted "
+            "row carries — no row is re-denominated"
+        ),
+        "value_kind": candidate.value_kind,
+        "absent_means": candidate.absent_means,
+        "trades": len(cohort),
+        "symbols": len({row.symbol for row in cohort}),
+        "closed": closed_total,
+        "groups": cells,
+        "gap": gap,
+        "rubric_reading": _rubric_reading_cell(rows, clusters),
+        "value_correlation": _value_cell(candidate, rows, clusters),
+        "verdict": verdict(
+            gap=gap, sides=[cells[group] for group in ASKED_GROUPS]
+        ),
+        "selection_contrast": SELECTION_CONTRAST[candidate.name],
+    }
+
+
+def market_candidates(
+    contract: RunContract,
+    cohort: Sequence[CandidateTrade],
+    *,
+    market: str,
+) -> dict[str, Any]:
+    """Every registered candidate over one market, in the register's own order."""
+    return {
+        "market": market,
+        "trades": len(cohort),
+        "symbols": len({row.symbol for row in cohort}),
+        "candidates": [
+            market_candidate(contract, candidate, cohort, market=market)
+            for candidate in CANDIDATES_UNDER_TEST
+        ],
+    }
+
+
+def _intervals_reported(markets_body: Sequence[dict[str, Any]]) -> int:
+    """How many significance intervals this report actually states.
+
+    Every group, gap, rubric reading and correlation of every candidate in every
+    market, because each is a statement made at nominal alpha. Suppressed
+    intervals are not counted: a cell that refused to say anything made no claim to
+    correct for.
+    """
+    def in_cell(cell: dict[str, Any]) -> int:
+        bodies = [cell["groups"][group] for group in GROUPS]
+        bodies += [cell["gap"], cell["rubric_reading"], cell["value_correlation"]]
+        return sum(1 for b in bodies if b["bootstrap"]["ci_low"] is not None)
+
+    return sum(
+        sum(in_cell(cell) for cell in market["candidates"])
+        for market in markets_body
+    )
+
+
+def candidates_report(
+    contract: RunContract,
+    cohort: Sequence[CandidateTrade],
+    *,
+    markets: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """The whole measurement as one stamped payload, market by market.
+
+    ``markets`` defaults to the contract's own scope, so a market that produced no
+    trade reports its zeros rather than vanishing. There is deliberately no pooled
+    figure and no pooled verdict: findings §8 measured that magnitudes do not
+    transfer, and the way to stop a pooled number being quoted is for it never to
+    have been computed.
+    """
+    check_registry()
+    check_not_admitted()
+    named = tuple(markets) if markets else tuple(contract.value(SCOPE_MARKETS_KEY))
+    markets_body = [
+        market_candidates(
+            contract, [row for row in cohort if row.market == market], market=market
+        )
+        for market in named
+    ]
+    return stamp_result(
+        contract,
+        {
+            "question": (
+                "do the registered candidate dimensions predict outcomes, or only "
+                "match the trader's selection?"
+            ),
+            "arm": PRIMARY_ARM,
+            "registered": [
+                {
+                    "candidate": candidate.name,
+                    "cut": candidate.cut,
+                    "value_kind": candidate.value_kind,
+                    "absent_means": candidate.absent_means,
+                }
+                for candidate in CANDIDATES_UNDER_TEST
+            ],
+            "out_of_sample": OUT_OF_SAMPLE_NOTE,
+            "selection_contrast_note": SELECTION_CONTRAST_NOTE,
+            "admission": ADMISSION_NOTE,
+            "verdict_rule": VERDICT_RULE,
+            "not_cut_per_year": NOT_CUT_PER_YEAR,
+            "groups": {
+                "reported": list(GROUPS),
+                "in_the_gap": list(ASKED_GROUPS),
+                "rule": (
+                    "absence is a group, never a value on the cut: the question "
+                    "was not asked of those names, so they enter no gap"
+                ),
+            },
+            "multiple_testing": {
+                "note": MULTIPLE_TESTING_NOTE,
+                "intervals_reported": _intervals_reported(markets_body),
+                "alpha_is_nominal": True,
+                "reading": (
+                    "two candidates, three groups and three statistics each; the "
+                    "gap rows are the measurement and the rest are diagnostics"
+                ),
+            },
+            "bootstrap": {
+                "cluster": BOOTSTRAP_CLUSTER,
+                "resamples": BOOTSTRAP_RESAMPLES,
+                "seed": BOOTSTRAP_SEED,
+                "confidence": BOOTSTRAP_CONFIDENCE,
+            },
+            "markets": markets_body,
+        },
+    )
+
+
+# -- printing it, and the command that produces it ----------------------------
+
+
+def _interval(boot: dict[str, Any]) -> str:
+    """One interval as a phrase, or the reason there is none."""
+    if boot["ci_low"] is None:
+        return f"{boot['clusters']} {boot['cluster']}s — no interval"
+    return (
+        f"[{boot['ci_low']:+.2f}, {boot['ci_high']:+.2f}] p={boot['p_value']:.3f} "
+        f"on {boot['clusters']} {boot['cluster']}s"
+    )
+
+
+def _group_line(cell: dict[str, Any]) -> str:
+    """One group as a line: what it is, its n, what it paid and how sure that is.
+
+    n sits immediately beside the expectancy and never on a line of its own,
+    because a group's expectancy without its count is unreadable — six trades and
+    six hundred print the same number.
+    """
+    head = f"  {cell['group']:<7} n={cell['closed']:<5}"
+    if cell["closed"] == 0:
+        return f"{head} no closed trades ({cell['trades']} taken)"
+    return (
+        f"{head} {cell['expectancy_r']:+.3f}R  win {cell['win_rate']:.1%}  "
+        f"{cell['symbols']} symbols  {_interval(cell['bootstrap'])}"
+    )
+
+
+def _value_line(cell: dict[str, Any]) -> str:
+    if cell["rho"] is None:
+        return f"  rho    — {cell['unavailable']}"
+    return (
+        f"  rho    {cell['rho']:+.3f} over {cell['pairs']} valued trades  "
+        f"{_interval(cell['bootstrap'])}"
+    )
+
+
+def _candidate_lines(cell: dict[str, Any]) -> list[str]:
+    """One candidate's block: the older claim, then the groups, then the new one."""
+    prior = cell["selection_contrast"]
+    gap, rubric = cell["gap"], cell["rubric_reading"]
+    value = "undefined" if gap["value"] is None else f"{gap['value']:+.3f}R"
+    rubric_value = (
+        "undefined" if rubric["value"] is None else f"{rubric['value']:+.3f}R"
+    )
+    lines = [
+        f"{cell['market']} — {cell['candidate']} ({cell['trades']} trades, "
+        f"{cell['symbols']} symbols)",
+        f"  selection contrast ({prior['source']}, detector {prior['detector']}): "
+        f"Δ {prior['delta_pp']:+.1f}pp — {prior['adr_0005_verdict']}",
+    ]
+    lines += [_group_line(cell["groups"][group]) for group in GROUPS]
+    lines += [
+        f"  gap    hit − miss {value}  {_interval(gap['bootstrap'])}",
+        f"  as shipped (absent read as a miss) {rubric_value}  "
+        f"{_interval(rubric['bootstrap'])}",
+        _value_line(cell["value_correlation"]),
+        f"  verdict: {VERDICT_PHRASE[cell['verdict']]}",
+    ]
+    return lines
+
+
+def format_candidates(report: dict[str, Any]) -> str:
+    """The measurement as a page a terminal can print.
+
+    The selection contrast prints **above** each candidate's outcome figures rather
+    than as a footnote, so a reader meets the claim ADR 0005 already measured, and
+    the reason it is a different claim, before meeting a number that could be
+    mistaken for a second reading of it.
+    """
+    lines: list[str] = [
+        f"{report['question']} — arm {report['arm']}",
+        f"  {report['out_of_sample']}",
+        f"  {report['selection_contrast_note'].split(':')[0]}",
+        f"  {report['admission']}",
+        f"  bootstrap {report['bootstrap']['resamples']}× clustered by "
+        f"{report['bootstrap']['cluster']}, seed {report['bootstrap']['seed']}",
+    ]
+    for body in report["markets"]:
+        for cell in body["candidates"]:
+            lines.append("")
+            lines += _candidate_lines(cell)
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Measure both registered candidates against outcomes, and record it::
+
+        python -m backtest.candidates --store data/backtest.duckdb \\
+            --out-json references/backtest_candidate_outcomes.json
+
+    Both markets by default, arm B only — the pre-registered arm. Reads the bar
+    store and the denominator beside it, and writes neither.
+    """
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--store", required=True, help="path to the backtest bar store")
+    parser.add_argument(
+        "--market", action="append", default=None,
+        help="narrow to one market (repeatable); defaults to the contract's scope",
+    )
+    parser.add_argument(
+        "--out-json", default=None,
+        help="where to write the machine-readable, contract-stamped result",
+    )
+    args = parser.parse_args(argv)
+
+    contract = DEFAULT_CONTRACT
+    markets = tuple(args.market) if args.market else tuple(
+        contract.value(SCOPE_MARKETS_KEY)
+    )
+    store = Store.open(args.store)
+    denominator = DenominatorStore.open(denominator_path(args.store))
+    try:
+        cohort: list[CandidateTrade] = []
+        for market in markets:
+            trades = simulate_market(
+                store, denominator, market, contract, arms=(PRIMARY_ARM,)
+            )
+            cohort += candidate_trades(trades, candidate_index(denominator, market))
+    finally:
+        denominator.close()
+        store.close()
+
+    report = candidates_report(contract, cohort, markets=markets)
+    if args.out_json:
+        Path(args.out_json).write_text(json.dumps(report, indent=1) + "\n")
+    print(format_candidates(report))
+    if args.out_json:
+        print(f"\nwrote {args.out_json}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/backtest/candidates.py
+++ b/backend/backtest/candidates.py
@@ -17,10 +17,15 @@ Both registrations then ran into the limits of that instrument:
 * ``RS line`` was refused on criterion 4 for a wrong-way Δ (findings §5d), on a
   dimension firing on one detection in ten in *both* groups.
 * ``Relative move`` came back positive on both fields and then stalled **0.06pp**
-  inside criterion 2's ~85% ceiling (§5e) — a threshold the ADR itself calls "the
-  one magnitude in this design with nothing behind it", now deciding an admission
-  by six hundredths of a point. The ADR declined to resolve it and recorded that
-  no third candidate should register until that threshold is argued on its own.
+  inside criterion 1's ~85% not-taken hit-rate ceiling (§5e). That ceiling and
+  criterion 2's ~15% disagreement floor are **one threshold read from two sides**
+  — disagreement with ``Prior move`` is exactly ``1 − hit rate`` — which is why
+  the two criteria are the same number and land together: on the literal reading
+  criterion 1 admits the dimension, on any reading honouring the tilde criterion 2
+  refuses it. The ADR calls that magnitude "the one magnitude in this design with
+  nothing behind it", and it now decides an admission by six hundredths of a
+  point. The ADR declined to resolve it and recorded that no third candidate
+  should register until the threshold is argued on its own.
 
 This run gives the same two dimensions an outcome variable: **R after costs**, on
 trades taken mechanically over two markets and fourteen years, which no rubric
@@ -80,7 +85,7 @@ Everything else is the metric's
 -------------------------------
 The after-cost R of a trade, the per-market costs, the cell behind every group and
 the clustered bootstrap are :mod:`backtest.metric`'s and
-:func:`backtest.ranking.bootstrap_symbol_statistic`'s, on the same seed, cluster
+:mod:`backtest.stats`', on the same seed, cluster
 and floor — so this measurement and the headline can never disagree about what a
 trade paid, and two intervals in one run were never built differently.
 """
@@ -92,7 +97,7 @@ import json
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Sequence
 
 from replay.contrast import CANDIDATES
 from replay.field import ScoredDetection
@@ -100,6 +105,7 @@ from screener.relative_strength import RELATIVE_MOVE_CUT
 from screener.score import DIMENSIONS
 from screener.store import Store
 
+from .cohort import DetectionIndex, detection_index, join_detections
 from .contract import DEFAULT_CONTRACT, SCOPE_MARKETS_KEY, RunContract
 from .denominator import DenominatorStore, denominator_path
 from .metric import (
@@ -113,10 +119,16 @@ from .metric import (
     check_one_market_one_arm,
     expectancy_cell,
 )
-from .ranking import bootstrap_symbol_statistic, spearman
 from .result import stamp_result
 from .run import ContractDrift
 from .simulate import SimulatedTrade, simulate_market
+from .stats import (
+    bootstrap_symbol_statistic,
+    cluster_by_symbol,
+    format_interval,
+    intervals_reported,
+    spearman,
+)
 
 # -- the three groups ---------------------------------------------------------
 
@@ -146,7 +158,7 @@ VALUE_BOOLEAN = "boolean"
 
 
 @dataclass(frozen=True)
-class Candidate:
+class CandidateDimension:
     """One registered candidate dimension, and how to read a persisted row for it.
 
     :data:`CANDIDATES` supplies the name and the pre-registered boolean reader;
@@ -162,37 +174,53 @@ class Candidate:
     name: str
     hit: Callable[[ScoredDetection], bool]
     value: Callable[[ScoredDetection], Any]
-    value_kind: str
     cut: str
     absent_means: str
+    # The **degree** reader, or ``None`` where the row keeps only a verdict. One
+    # field carries that fact rather than a ``value_kind`` string switched on at
+    # three sites: a candidate either has a number to rank or it does not, and
+    # :attr:`value_kind` is derived from it so the label and the behaviour cannot
+    # drift apart.
+    degree: Callable[[ScoredDetection], float | None] | None = None
+
+    @property
+    def value_kind(self) -> str:
+        """What the persisted row carries, for the payload and the printed page."""
+        return VALUE_GRADED if self.degree is not None else VALUE_BOOLEAN
 
 
-# How to read each registered candidate's stored value, keyed by the name the
-# registry uses. Kept apart from :data:`CANDIDATES` because that tuple is ADR
-# 0005's register of what has been *pre-registered*, and a measurement module
-# adding an entry to it could promote a column after its gap was visible.
-_VALUE_READERS: dict[str, dict[str, Any]] = {
-    "RS line": {
-        "value": lambda d: d.rs_line,
-        "value_kind": VALUE_BOOLEAN,
-        "cut": "RS_today >= RS_at_base_start, over the detection's own base",
-        "absent_means": (
+def _relative_move_degree(detection: ScoredDetection) -> float | None:
+    """``Relative move``'s stored degree — the value itself, in ADR units."""
+    return detection.relative_move
+
+
+# How to read each registered candidate's persisted row, keyed by the name the
+# register uses. Kept apart from :data:`CANDIDATES` because that tuple is ADR
+# 0005's register of what has been *pre-registered*, and a measurement module able
+# to add an entry to it is a module able to promote a column after its gap is
+# visible.
+_READERS: dict[str, dict[str, Any]] = {
+    "RS line": dict(
+        value=lambda d: d.rs_line,
+        degree=None,
+        cut="RS_today >= RS_at_base_start, over the detection's own base",
+        absent_means=(
             "a price was missing at one of the two anchors, so the question was "
             "never asked — which is a different fact from asking it and getting no"
         ),
-    },
-    "Relative move": {
-        "value": lambda d: d.relative_move,
-        "value_kind": VALUE_GRADED,
-        "cut": (
+    ),
+    "Relative move": dict(
+        value=lambda d: d.relative_move,
+        degree=_relative_move_degree,
+        cut=(
             f"the 6m index-relative move in ADR units, strictly above "
             f"{RELATIVE_MOVE_CUT:.1f}"
         ),
-        "absent_means": (
+        absent_means=(
             "the name had not listed six months ago, or has no ADR — never zero, "
             "which is a real value sitting exactly on the cut"
         ),
-    },
+    ),
 }
 
 
@@ -209,7 +237,7 @@ def check_registry(
     what an absent one means — so a new registration stops the measurement instead
     of being quietly left out of a report that still claims to cover the register.
     """
-    unknown = sorted({name for name, _w, _r in registered} - set(_VALUE_READERS))
+    unknown = sorted({name for name, _w, _r in registered} - set(_READERS))
     if unknown:
         raise ContractDrift(
             f"registered candidate(s) {unknown} have no value reader in "
@@ -219,19 +247,19 @@ def check_registry(
         )
 
 
-def _under_test() -> tuple[Candidate, ...]:
+def _under_test() -> tuple[CandidateDimension, ...]:
     """The register, in its own order, with this module's readers attached."""
     check_registry()
     return tuple(
-        Candidate(name=name, hit=hit, **_VALUE_READERS[name])
+        CandidateDimension(name=name, hit=hit, **_READERS[name])
         for name, _weight, hit in CANDIDATES
     )
 
 
-CANDIDATES_UNDER_TEST: tuple[Candidate, ...] = _under_test()
+CANDIDATES_UNDER_TEST: tuple[CandidateDimension, ...] = _under_test()
 
 
-def named_candidate(name: str) -> Candidate:
+def named_candidate(name: str) -> CandidateDimension:
     """One candidate by the name the register uses."""
     for candidate in CANDIDATES_UNDER_TEST:
         if candidate.name == name:
@@ -297,6 +325,7 @@ SELECTION_CONTRAST: dict[str, dict[str, Any]] = {
         "delta_pp": -2.1,
         "pooled_spread": 0.326,
         "adr_0005_verdict": "not admitted",
+        "recorded_as": "refused on criterion 4 — a wrong-way gap",
         "why": (
             "refused on criterion 4, a wrong-way gap, with the anchor named as "
             "the mechanism: base_start is a local high under both detector "
@@ -316,11 +345,14 @@ SELECTION_CONTRAST: dict[str, dict[str, Any]] = {
         "delta_pp": 3.6,
         "pooled_spread": 0.357,
         "adr_0005_verdict": "not admitted",
+        "recorded_as": "on_the_bound — the criteria do not separate",
         "why": (
-            "positive on both fields, and then 0.06pp inside criterion 2's ~85% "
-            "ceiling — 0.29 standard errors from a threshold the ADR calls a "
-            "judgement rather than a measurement. The criteria do not separate, "
-            "so nothing shipped"
+            "positive on both fields, and then 0.06pp inside criterion 1's ~85% "
+            "not-taken hit-rate ceiling — 0.29 standard errors from it. That "
+            "ceiling and criterion 2's ~15% disagreement floor are one threshold "
+            "read from two sides, so the two criteria give opposite answers on "
+            "the same number, and the ADR calls that magnitude a judgement rather "
+            "than a measurement. The criteria do not separate, so nothing shipped"
         ),
     },
 }
@@ -359,7 +391,7 @@ MULTIPLE_TESTING_NOTE = (
 
 
 @dataclass(frozen=True)
-class CandidateTrade:
+class DetectedTrade:
     """One simulated trade beside the persisted detection row it came from.
 
     Joined rather than stored together, for the reason the ranking gives: the
@@ -396,7 +428,7 @@ class CandidateOutcome:
     r: float
 
 
-def group_of(candidate: Candidate, detection: ScoredDetection) -> str:
+def group_of(candidate: CandidateDimension, detection: ScoredDetection) -> str:
     """Which of the three groups a persisted row falls in, read at read time.
 
     Absence is tested **first** and on the stored value itself, so no absent row
@@ -409,31 +441,38 @@ def group_of(candidate: Candidate, detection: ScoredDetection) -> str:
 
 
 def split(
-    candidate: Candidate, cohort: Sequence[CandidateTrade]
-) -> dict[str, list[CandidateTrade]]:
+    candidate: CandidateDimension, cohort: Sequence[DetectedTrade]
+) -> dict[str, list[DetectedTrade]]:
     """The cohort partitioned into the three groups, every group present.
 
     A group with no trades comes back empty rather than missing, so a report can
     show its zero: an absent row and a group nobody measured are indistinguishable
     after the fact.
     """
-    groups: dict[str, list[CandidateTrade]] = {g: [] for g in GROUPS}
+    groups: dict[str, list[DetectedTrade]] = {g: [] for g in GROUPS}
     for row in cohort:
         groups[group_of(candidate, row.detection)].append(row)
     return groups
 
 
-def _graded_value(candidate: Candidate, detection: ScoredDetection) -> float | None:
-    """The stored degree, or ``None`` where the candidate keeps only a verdict."""
-    if candidate.value_kind != VALUE_GRADED:
+def _graded_value(
+    candidate: CandidateDimension, detection: ScoredDetection
+) -> float | None:
+    """The stored degree, or ``None`` where the candidate keeps only a verdict.
+
+    The one site that asks whether a candidate has a degree at all, and it asks the
+    reader rather than a label: a candidate with no ``degree`` has nothing to
+    return, and a row with an absent value has nothing either.
+    """
+    if candidate.degree is None:
         return None
-    value = candidate.value(detection)
+    value = candidate.degree(detection)
     return None if value is None else float(value)
 
 
 def outcomes(
-    candidate: Candidate,
-    cohort: Sequence[CandidateTrade],
+    candidate: CandidateDimension,
+    cohort: Sequence[DetectedTrade],
     contract: RunContract,
 ) -> list[CandidateOutcome]:
     """The cohort's **closed** trades as rows, after costs, in cohort order.
@@ -456,25 +495,6 @@ def outcomes(
             )
         )
     return rows
-
-
-def symbol_clusters(
-    rows: Sequence[CandidateOutcome],
-) -> list[tuple[CandidateOutcome, ...]]:
-    """The rows grouped one cluster per symbol, in symbol order.
-
-    The unit of independence, and it is the **whole** cohort's rows rather than one
-    group's: a resample draws symbols from the field that was measured, and each
-    statistic then reads the rows it is about. Clustering per group instead would
-    resample two populations independently and lose the fact that one name can sit
-    in only one of them.
-
-    Ordered by symbol so a resample under a fixed seed is reproducible.
-    """
-    grouped: dict[str, list[CandidateOutcome]] = {}
-    for row in rows:
-        grouped.setdefault(row.symbol, []).append(row)
-    return [tuple(grouped[symbol]) for symbol in sorted(grouped)]
 
 
 # -- the statistics -----------------------------------------------------------
@@ -586,54 +606,21 @@ def verdict(*, gap: dict[str, Any], sides: Sequence[dict[str, Any]]) -> str:
 
 # -- joining a trade to the row that produced it ------------------------------
 
-DetectionIndex = Mapping[tuple[date, str], ScoredDetection]
-
-
-def candidate_index(
-    denominator: DenominatorStore, market: str, *, include_burn_in: bool = False
-) -> dict[tuple[date, str], ScoredDetection]:
-    """Every persisted detection row for one market, keyed by session and symbol.
-
-    The whole row rather than the two values, because the readers take a
-    :class:`~replay.field.ScoredDetection` — the same argument the selection
-    contrast hands them, so neither study can be reading a differently shaped
-    input.
-
-    Burn-in sessions are excluded by default, matching
-    :func:`~backtest.simulate.walk_detections`, so the index and the trades cover
-    the same sessions rather than nearly the same ones.
-    """
-    index: dict[tuple[date, str], ScoredDetection] = {}
-    for header in denominator.sessions(
-        market, burn_in=None if include_burn_in else False
-    ):
-        for scored in denominator.detections(market, header.session):
-            index[(header.session, scored.symbol)] = scored
-    return index
-
-
 def candidate_trades(
     trades: Sequence[SimulatedTrade], index: DetectionIndex
-) -> list[CandidateTrade]:
-    """Join each trade to its persisted row, refusing a trade that has none.
+) -> list[DetectedTrade]:
+    """Join each trade to the persisted row that produced it.
 
-    The join is **total** or it is a bug: every simulated trade came from a
-    persisted detection. Dropping an unmatched one would shrink the cohort with
-    nothing in the output to say which trades left, and the trades most likely to
-    go missing are not a random sample of them.
+    The join is :func:`~backtest.cohort.join_detections`' — **total**, so a trade
+    with no row raises rather than being dropped; that module holds the argument.
+    What this adds is only the row type: a trade beside the whole detection row,
+    because both candidate values are read off it at report time by the readers
+    :data:`CANDIDATES` supplies.
     """
-    out: list[CandidateTrade] = []
-    for trade in trades:
-        key = (trade.detection_session, trade.symbol)
-        if key not in index:
-            raise ValueError(
-                f"no persisted detection row for {trade.symbol} detected "
-                f"{trade.detection_session}: the join from trade to row is total, "
-                "and a missing row is a broken denominator rather than a trade to "
-                "drop"
-            )
-        out.append(CandidateTrade(trade=trade, detection=index[key]))
-    return out
+    return [
+        DetectedTrade(trade=trade, detection=detection)
+        for trade, detection in join_detections(trades, index)
+    ]
 
 
 # -- the report ---------------------------------------------------------------
@@ -641,9 +628,9 @@ def candidate_trades(
 
 def _group_cell(
     contract: RunContract,
-    candidate: Candidate,
+    candidate: CandidateDimension,
     group: str,
-    rows: Sequence[CandidateTrade],
+    rows: Sequence[DetectedTrade],
     *,
     market: str,
     closed_total: int,
@@ -670,24 +657,18 @@ def _group_cell(
     return cell
 
 
-def _gap_cell(
-    rows: Sequence[CandidateOutcome],
-    clusters: Sequence[Sequence[CandidateOutcome]],
-) -> dict[str, Any]:
+def _gap_cell(rows: Sequence[CandidateOutcome]) -> dict[str, Any]:
     """The hit-minus-miss gap with its clustered interval."""
     return {
         "statistic": "mean after-cost R, hit minus miss",
         "reads_absence_as": "absent — it enters neither side",
         "enters_the_verdict": True,
         "value": outcome_gap(rows),
-        "bootstrap": bootstrap_symbol_statistic(clusters, outcome_gap),
+        "bootstrap": bootstrap_symbol_statistic(cluster_by_symbol(rows), outcome_gap),
     }
 
 
-def _rubric_reading_cell(
-    rows: Sequence[CandidateOutcome],
-    clusters: Sequence[Sequence[CandidateOutcome]],
-) -> dict[str, Any]:
+def _rubric_reading_cell(rows: Sequence[CandidateOutcome]) -> dict[str, Any]:
     """The same gap as a shipped boolean would compute it, and its interval."""
     return {
         "statistic": "mean after-cost R, hit minus (miss and absent)",
@@ -697,18 +678,22 @@ def _rubric_reading_cell(
         ),
         "enters_the_verdict": False,
         "value": rubric_reading_gap(rows),
-        "bootstrap": bootstrap_symbol_statistic(clusters, rubric_reading_gap),
+        "bootstrap": bootstrap_symbol_statistic(
+            cluster_by_symbol(rows), rubric_reading_gap
+        ),
     }
 
 
 def _value_cell(
-    candidate: Candidate,
-    rows: Sequence[CandidateOutcome],
-    clusters: Sequence[Sequence[CandidateOutcome]],
+    candidate: CandidateDimension, rows: Sequence[CandidateOutcome]
 ) -> dict[str, Any]:
-    """Spearman's rho against the stored degree, or the reason there is none."""
-    graded = candidate.value_kind == VALUE_GRADED
-    unavailable = None if graded else (
+    """Spearman's rho against the stored degree, or the reason there is none.
+
+    ``rho`` is :func:`value_correlation` unconditionally: it already returns
+    ``None`` where no row carries a degree, and a second guard here would be a
+    second place for "this candidate has nothing to rank" to be decided.
+    """
+    unavailable = None if candidate.degree is not None else (
         f"{candidate.name} persists a boolean, not a degree: there is no value to "
         "rank, and correlating a verdict with the outcome would restate the gap"
     )
@@ -719,18 +704,18 @@ def _value_cell(
         "enters_the_verdict": False,
         "value_kind": candidate.value_kind,
         "unavailable": unavailable,
-        "rho": value_correlation(rows) if graded else None,
+        "rho": value_correlation(rows),
         "pairs": sum(1 for row in rows if row.value is not None),
         "bootstrap": bootstrap_symbol_statistic(
-            clusters, value_correlation, unavailable=unavailable
+            cluster_by_symbol(rows), value_correlation, unavailable=unavailable
         ),
     }
 
 
 def market_candidate(
     contract: RunContract,
-    candidate: Candidate,
-    cohort: Sequence[CandidateTrade],
+    candidate: CandidateDimension,
+    cohort: Sequence[DetectedTrade],
     *,
     market: str,
 ) -> dict[str, Any]:
@@ -750,7 +735,6 @@ def market_candidate(
 
     groups = split(candidate, cohort)
     rows = outcomes(candidate, cohort, contract)
-    clusters = symbol_clusters(rows)
     closed_total = len(rows)
     cells = {
         group: _group_cell(
@@ -759,7 +743,7 @@ def market_candidate(
         )
         for group in GROUPS
     }
-    gap = _gap_cell(rows, clusters)
+    gap = _gap_cell(rows)
     return {
         "candidate": candidate.name,
         "market": market,
@@ -776,8 +760,8 @@ def market_candidate(
         "closed": closed_total,
         "groups": cells,
         "gap": gap,
-        "rubric_reading": _rubric_reading_cell(rows, clusters),
-        "value_correlation": _value_cell(candidate, rows, clusters),
+        "rubric_reading": _rubric_reading_cell(rows),
+        "value_correlation": _value_cell(candidate, rows),
         "verdict": verdict(
             gap=gap, sides=[cells[group] for group in ASKED_GROUPS]
         ),
@@ -787,7 +771,7 @@ def market_candidate(
 
 def market_candidates(
     contract: RunContract,
-    cohort: Sequence[CandidateTrade],
+    cohort: Sequence[DetectedTrade],
     *,
     market: str,
 ) -> dict[str, Any]:
@@ -812,9 +796,10 @@ def _intervals_reported(markets_body: Sequence[dict[str, Any]]) -> int:
     correct for.
     """
     def in_cell(cell: dict[str, Any]) -> int:
-        bodies = [cell["groups"][group] for group in GROUPS]
-        bodies += [cell["gap"], cell["rubric_reading"], cell["value_correlation"]]
-        return sum(1 for b in bodies if b["bootstrap"]["ci_low"] is not None)
+        return intervals_reported(
+            [cell["groups"][group] for group in GROUPS]
+            + [cell["gap"], cell["rubric_reading"], cell["value_correlation"]]
+        )
 
     return sum(
         sum(in_cell(cell) for cell in market["candidates"])
@@ -824,7 +809,7 @@ def _intervals_reported(markets_body: Sequence[dict[str, Any]]) -> int:
 
 def candidates_report(
     contract: RunContract,
-    cohort: Sequence[CandidateTrade],
+    cohort: Sequence[DetectedTrade],
     *,
     markets: Sequence[str] | None = None,
 ) -> dict[str, Any]:
@@ -898,16 +883,6 @@ def candidates_report(
 # -- printing it, and the command that produces it ----------------------------
 
 
-def _interval(boot: dict[str, Any]) -> str:
-    """One interval as a phrase, or the reason there is none."""
-    if boot["ci_low"] is None:
-        return f"{boot['clusters']} {boot['cluster']}s — no interval"
-    return (
-        f"[{boot['ci_low']:+.2f}, {boot['ci_high']:+.2f}] p={boot['p_value']:.3f} "
-        f"on {boot['clusters']} {boot['cluster']}s"
-    )
-
-
 def _group_line(cell: dict[str, Any]) -> str:
     """One group as a line: what it is, its n, what it paid and how sure that is.
 
@@ -920,7 +895,7 @@ def _group_line(cell: dict[str, Any]) -> str:
         return f"{head} no closed trades ({cell['trades']} taken)"
     return (
         f"{head} {cell['expectancy_r']:+.3f}R  win {cell['win_rate']:.1%}  "
-        f"{cell['symbols']} symbols  {_interval(cell['bootstrap'])}"
+        f"{cell['symbols']} symbols  {format_interval(cell['bootstrap'])}"
     )
 
 
@@ -929,7 +904,7 @@ def _value_line(cell: dict[str, Any]) -> str:
         return f"  rho    — {cell['unavailable']}"
     return (
         f"  rho    {cell['rho']:+.3f} over {cell['pairs']} valued trades  "
-        f"{_interval(cell['bootstrap'])}"
+        f"{format_interval(cell['bootstrap'])}"
     )
 
 
@@ -946,12 +921,17 @@ def _candidate_lines(cell: dict[str, Any]) -> list[str]:
         f"{cell['symbols']} symbols)",
         f"  selection contrast ({prior['source']}, detector {prior['detector']}): "
         f"Δ {prior['delta_pp']:+.1f}pp — {prior['adr_0005_verdict']}",
+        # The outcome ADR 0005 actually recorded, not only that nothing shipped.
+        # "not admitted" covers a refusal on a wrong-way gap and a dimension that
+        # landed on its own bound, and those are different findings — a reader of
+        # the page should not have to open the JSON to tell them apart.
+        f"    recorded as: {prior['recorded_as']}",
     ]
     lines += [_group_line(cell["groups"][group]) for group in GROUPS]
     lines += [
-        f"  gap    hit − miss {value}  {_interval(gap['bootstrap'])}",
+        f"  gap    hit − miss {value}  {format_interval(gap['bootstrap'])}",
         f"  as shipped (absent read as a miss) {rubric_value}  "
-        f"{_interval(rubric['bootstrap'])}",
+        f"{format_interval(rubric['bootstrap'])}",
         _value_line(cell["value_correlation"]),
         f"  verdict: {VERDICT_PHRASE[cell['verdict']]}",
     ]
@@ -1009,12 +989,12 @@ def main(argv: list[str] | None = None) -> int:
     store = Store.open(args.store)
     denominator = DenominatorStore.open(denominator_path(args.store))
     try:
-        cohort: list[CandidateTrade] = []
+        cohort: list[DetectedTrade] = []
         for market in markets:
             trades = simulate_market(
                 store, denominator, market, contract, arms=(PRIMARY_ARM,)
             )
-            cohort += candidate_trades(trades, candidate_index(denominator, market))
+            cohort += candidate_trades(trades, detection_index(denominator, market))
     finally:
         denominator.close()
         store.close()

--- a/backend/backtest/cohort.py
+++ b/backend/backtest/cohort.py
@@ -1,0 +1,81 @@
+"""Joining a simulated trade back to the persisted row that produced it.
+
+Every measurement downstream of Phase 4 needs the same two things: an index of the
+denominator's detection rows for a market, and a **total** join from the trades
+the simulator took to the rows they came from. :mod:`backtest.ranking` needs the
+score off that row; :mod:`backtest.candidates` needs the two candidate values off
+the same row. The join itself is identical, and its refusal has to be, because the
+argument for refusing is the same one in both places.
+
+Why the join is total, and never a filter
+-----------------------------------------
+Every simulated trade came from a persisted detection: the simulator walks the
+denominator's own rows. So a trade with no row is a broken denominator, not a
+trade to drop. Dropping it quietly would shrink the cohort a measurement is
+computed over with nothing in the output to say which trades left — and the trades
+most likely to go missing are not a random sample of them, since whatever broke
+the row is likely to correlate with the market, the year or the name.
+
+Burn-in
+-------
+:func:`detection_index` excludes burn-in sessions by default, matching
+:func:`~backtest.simulate.walk_detections`, so an index and the trades built
+against it cover the same sessions rather than nearly the same ones. A warm-up
+session is computed and persisted like any other and simply never measured (PRD
+#182 story 76).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Mapping, Sequence
+
+from replay.field import ScoredDetection
+
+from .denominator import DenominatorStore
+from .simulate import SimulatedTrade
+
+# The key the denominator's own primary key uses: a symbol is detected at most
+# once on a session, so the join below is exact rather than nearest.
+DetectionIndex = Mapping[tuple[date, str], ScoredDetection]
+
+
+def detection_index(
+    denominator: DenominatorStore, market: str, *, include_burn_in: bool = False
+) -> dict[tuple[date, str], ScoredDetection]:
+    """Every persisted detection row for one market, keyed by session and symbol.
+
+    The whole row rather than a projection of it, because its two callers want
+    different parts — the star score, and the two candidate values — and an index
+    per caller would walk the store twice to produce two views of one table.
+    """
+    index: dict[tuple[date, str], ScoredDetection] = {}
+    for header in denominator.sessions(
+        market, burn_in=None if include_burn_in else False
+    ):
+        for scored in denominator.detections(market, header.session):
+            index[(header.session, scored.symbol)] = scored
+    return index
+
+
+def join_detections(
+    trades: Sequence[SimulatedTrade], index: DetectionIndex
+) -> list[tuple[SimulatedTrade, ScoredDetection]]:
+    """Pair each trade with its persisted row, refusing a trade that has none.
+
+    See the module docstring for why this raises rather than filters. The pairs
+    come back in the order the trades arrived, so a caller building its own row
+    type from them preserves whatever order the simulator produced.
+    """
+    out: list[tuple[SimulatedTrade, ScoredDetection]] = []
+    for trade in trades:
+        key = (trade.detection_session, trade.symbol)
+        if key not in index:
+            raise ValueError(
+                f"no persisted detection row for {trade.symbol} detected "
+                f"{trade.detection_session}: the join from trade to row is total, "
+                "and a missing row is a broken denominator rather than a trade to "
+                "drop"
+            )
+        out.append((trade, index[key]))
+    return out

--- a/backend/backtest/ranking.py
+++ b/backend/backtest/ranking.py
@@ -97,23 +97,22 @@ from __future__ import annotations
 
 import argparse
 import json
-import random
 from collections import Counter
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence, TypeVar
+from typing import Any, Sequence
 
 from replay.field import SEVEN_DIM_LABEL, SEVEN_DIM_MAX_POINTS, SevenDimScore
 from screener.score import DIMENSIONS
 from screener.store import Store
 
+from .cohort import DetectionIndex, detection_index, join_detections
 from .contract import DEFAULT_CONTRACT, SCOPE_MARKETS_KEY, RunContract
 from .denominator import DenominatorStore, denominator_path
 from .metric import (
     BOOTSTRAP_CLUSTER,
     BOOTSTRAP_CONFIDENCE,
-    BOOTSTRAP_MIN_CLUSTERS,
     BOOTSTRAP_RESAMPLES,
     BOOTSTRAP_SEED,
     PRIMARY_ARM,
@@ -122,7 +121,13 @@ from .metric import (
     check_one_market_one_arm,
     expectancy_cell,
     measured_years,
-    quantile,
+)
+from .stats import (
+    bootstrap_symbol_statistic,
+    cluster_by_symbol,
+    format_interval,
+    intervals_reported,
+    spearman,
 )
 from .result import stamp_result
 from .run import ContractDrift
@@ -408,14 +413,11 @@ def symbol_clusters(
 ) -> list[tuple[Outcome, ...]]:
     """The closed outcomes grouped one cluster per symbol, symbol order.
 
-    The unit of independence. Ordered by symbol so a resample under a fixed seed is
-    reproducible — clusters arriving in insertion order would move the interval
-    with the order the trades happened to be read in.
+    The unit of independence, and the clustering itself is
+    :func:`~backtest.stats.cluster_by_symbol`'s — this is the ranking's own rows
+    put through it.
     """
-    grouped: dict[str, list[Outcome]] = {}
-    for row in outcomes(cohort, contract):
-        grouped.setdefault(row.symbol, []).append(row)
-    return [tuple(grouped[symbol]) for symbol in sorted(grouped)]
+    return cluster_by_symbol(outcomes(cohort, contract))
 
 
 # -- the two statistics -------------------------------------------------------
@@ -439,62 +441,6 @@ def top_minus_bottom(
     return sum(top) / len(top) - sum(bottom) / len(bottom)
 
 
-def ranks(values: Sequence[float]) -> list[float]:
-    """Fractional ranks, ties taking the average of the positions they occupy.
-
-    Ties are the common case on an eight-point score, so this is the whole of why
-    the correlation is meaningful here: breaking them by arrival order would make
-    rho a function of the sort.
-
-    Public because :mod:`backtest.candidates` ranks a candidate dimension's stored
-    value against the same outcome, and a second implementation of a tie rule is a
-    second place for two rhos in one run to have been computed differently.
-    """
-    order = sorted(range(len(values)), key=lambda i: values[i])
-    out = [0.0] * len(values)
-    i = 0
-    while i < len(order):
-        j = i
-        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
-            j += 1
-        average = (i + j) / 2 + 1
-        for k in range(i, j + 1):
-            out[order[k]] = average
-        i = j + 1
-    return out
-
-
-def spearman(xs: Sequence[float], ys: Sequence[float]) -> float | None:
-    """Spearman's rho between two paired series, ties averaged.
-
-    The arithmetic alone, so the two callers that need it — the score against the
-    outcome here, and a candidate dimension's stored value against the same
-    outcome in :mod:`backtest.candidates` — read one tie rule and one variance
-    refusal rather than two that could drift apart.
-
-    ``None`` when either side has no variance. There is no correlation to report
-    there, and a zero would read as "measured and found nothing" rather than "not
-    measurable".
-    """
-    if len(xs) != len(ys):
-        raise ValueError(
-            f"a correlation needs paired series; {len(xs)} against {len(ys)} "
-            "is a join that lost rows on one side"
-        )
-    if len(xs) < 2:
-        return None
-    x, y = ranks(xs), ranks(ys)
-    n = len(xs)
-    mx, my = sum(x) / n, sum(y) / n
-    dx = [a - mx for a in x]
-    dy = [b - my for b in y]
-    sx = sum(a * a for a in dx) ** 0.5
-    sy = sum(b * b for b in dy) ** 0.5
-    if sx == 0.0 or sy == 0.0:
-        return None
-    return sum(a * b for a, b in zip(dx, dy)) / (sx * sy)
-
-
 def rank_correlation(rows: Sequence[Outcome]) -> float | None:
     """Spearman's rho between score and outcome — the whole-cohort ranking claim.
 
@@ -507,145 +453,6 @@ def rank_correlation(rows: Sequence[Outcome]) -> float | None:
     the same.
     """
     return spearman([float(row.points) for row in rows], [row.r for row in rows])
-
-
-# -- the bootstrap, over a statistic rather than over a mean -------------------
-
-# The bootstrap resamples clusters and hands the pooled rows to a statistic; it
-# reads no field of a row itself. So the row type is the caller's — an
-# :class:`Outcome` here, a candidate dimension's outcome in
-# :mod:`backtest.candidates` — and saying so in the signature is what keeps the
-# second caller from needing a second bootstrap with the same seed.
-Row = TypeVar("Row")
-
-
-# How much of a resample distribution may be undefined before the interval built
-# on the rest of it is refused.
-#
-# A resample is undefined exactly when it drew no symbol from the top band or none
-# from the bottom — the draws that carry the most uncertainty about a gap resting
-# on a thin edge. Dropping them and reading the interval off what is left
-# *conditions on the statistic having been computable*, which renormalises the
-# distribution towards the cases where it was, and those are the confident ones.
-# The correction goes the wrong way: it tightens the interval exactly where the
-# data is weakest.
-#
-# There is no honest value to substitute for an undefined draw — zero is a
-# measurement nobody made — so the remedy is to refuse the interval rather than to
-# repair it. A tenth is a judgement and is recorded as one: below it the
-# renormalisation moves a percentile bound by less than the resampling noise around
-# it, and above it the interval is describing a sub-population of the resamples.
-# The count always rides on the output, so a cell just under the line reads as one.
-MAX_UNDEFINED_SHARE = 0.10
-
-
-def bootstrap_symbol_statistic(
-    clusters: Sequence[Sequence[Row]],
-    statistic: Callable[[Sequence[Row]], float | None],
-    *,
-    resamples: int = BOOTSTRAP_RESAMPLES,
-    seed: int = BOOTSTRAP_SEED,
-    confidence: float = BOOTSTRAP_CONFIDENCE,
-    cluster: str = BOOTSTRAP_CLUSTER,
-    min_clusters: int = BOOTSTRAP_MIN_CLUSTERS,
-    max_undefined_share: float = MAX_UNDEFINED_SHARE,
-    unavailable: str | None = None,
-) -> dict[str, Any]:
-    """A clustered bootstrap of an arbitrary statistic over the pooled rows.
-
-    :func:`~backtest.metric.bootstrap_expectancy` resamples the same unit and takes
-    the pooled **mean**; a gap between two bands and a rank correlation are not
-    means of anything, so they need the resampled cohort itself. Hence a second
-    entry point rather than a second bootstrap: the seed, the resample count, the
-    confidence level, the cluster floor and the reported fields are all the
-    metric's, so two intervals in one report can never have been built differently.
-
-    Each resample draws ``len(clusters)`` clusters **with replacement** and pools
-    every row inside them, so a symbol is in or out as a whole. ``p_value`` is
-    one-sided — the share of resampled statistics at or below zero — which is the
-    shape of the claim: the question is whether a higher score pays *more*, not
-    whether it pays differently.
-
-    A resample the statistic cannot evaluate (an empty edge band, no variance) is
-    counted under ``undefined`` rather than defaulted to zero, because a resample
-    that could not answer is not a resample that answered no. Past
-    :data:`MAX_UNDEFINED_SHARE` of the draws the interval is **refused**: reading it
-    off the draws that did compute would condition on the statistic having been
-    computable, which is a condition satisfied disproportionately by the confident
-    draws. See that constant for the argument.
-
-    Below ``min_clusters`` no interval is reported at all, for the reason the
-    metric records: one symbol resampled two thousand times returns its own mean
-    two thousand times, which prints as a zero-width interval at p = 0 and is one
-    independent observation.
-
-    ``unavailable`` refuses before any resampling, for a statistic that could not
-    be computed on this cohort whatever was drawn — :mod:`backtest.candidates`
-    passes it for a rank correlation against a candidate that persists no degree.
-    The refusal is stated in the caller's words but reported in this function's
-    shape, so a cell that never ran a bootstrap and one that ran and refused are
-    read the same way by anything downstream.
-    """
-
-    n = len(clusters)
-    pooled = [row for cluster_rows in clusters for row in cluster_rows]
-    body: dict[str, Any] = {
-        "cluster": cluster,
-        "clusters": n,
-        "observations": len(pooled),
-        "resamples": resamples,
-        "seed": seed,
-        "confidence": confidence,
-        "min_clusters": min_clusters,
-        "undefined": 0,
-        "max_undefined_share": max_undefined_share,
-        "suppressed": None,
-    }
-    empty = {**body, "ci_low": None, "ci_high": None, "p_value": None}
-    if unavailable is not None:
-        return {**empty, "suppressed": unavailable}
-    if n < min_clusters:
-        return {
-            **empty,
-            "suppressed": (
-                f"{n} {cluster}s is fewer than {min_clusters}: too thin for an "
-                "interval, and a degenerate one would read as significance"
-            ),
-        }
-
-    rng = random.Random(seed)
-    indices = range(n)
-    drawn_values: list[float] = []
-    undefined = 0
-    for _ in range(resamples):
-        drawn = [row for i in indices for row in clusters[rng.choice(indices)]]
-        value = statistic(drawn)
-        if value is None:
-            undefined += 1
-            continue
-        drawn_values.append(value)
-    share_undefined = undefined / resamples if resamples else 1.0
-    if not drawn_values or share_undefined > max_undefined_share:
-        return {
-            **empty,
-            "undefined": undefined,
-            "suppressed": (
-                f"{share_undefined:.1%} of resamples could not be evaluated over "
-                f"{n} {cluster}s, past the {max_undefined_share:.0%} the interval "
-                "is allowed: reading it off the rest would condition on the draws "
-                "where the statistic was computable, which are the confident ones"
-            ),
-        }
-
-    drawn_values.sort()
-    tail = (1.0 - confidence) / 2.0
-    return {
-        **body,
-        "undefined": undefined,
-        "ci_low": quantile(drawn_values, tail),
-        "ci_high": quantile(drawn_values, 1.0 - tail),
-        "p_value": sum(1 for v in drawn_values if v <= 0.0) / len(drawn_values),
-    }
 
 
 # -- the verdict --------------------------------------------------------------
@@ -705,56 +512,22 @@ def verdict(
 
 # -- joining a trade to the score that produced it ----------------------------
 
-ScoreIndex = Mapping[tuple[date, str], SevenDimScore]
-
-
-def score_index(
-    denominator: DenominatorStore, market: str, *, include_burn_in: bool = False
-) -> dict[tuple[date, str], SevenDimScore]:
-    """Every persisted detection's score for one market, keyed by session and symbol.
-
-    The key is the pair the denominator's own primary key uses, so the join below
-    is exact: a symbol is detected at most once on a session.
-
-    Burn-in sessions are excluded by default for the reason they are flagged at
-    all — a warm-up session is persisted and never measured (story 76) — and the
-    default matches :func:`~backtest.simulate.walk_detections`, so the index and
-    the trades cover the same sessions rather than nearly the same ones.
-    """
-    index: dict[tuple[date, str], SevenDimScore] = {}
-    for header in denominator.sessions(
-        market, burn_in=None if include_burn_in else False
-    ):
-        for scored in denominator.detections(market, header.session):
-            check_seven_dimension_score(scored.score)
-            index[(header.session, scored.symbol)] = scored.score
-    return index
-
-
 def scored_trades(
-    trades: Sequence[SimulatedTrade], scores: ScoreIndex
+    trades: Sequence[SimulatedTrade], index: DetectionIndex
 ) -> list[ScoredTrade]:
-    """Join each trade to its detection's score, refusing a trade that has none.
+    """Join each trade to the score of the detection that produced it.
 
-    The join is **total** or it is a bug: every simulated trade came from a
-    persisted detection, and that detection carries a score. Dropping an unmatched
-    trade quietly would shrink the cohort the ranking is measured on with nothing
-    in the output to say which trades left — and the trades most likely to go
-    missing are not a random sample of them.
+    The join is :func:`~backtest.cohort.join_detections`' — **total**, so a trade
+    with no persisted row raises rather than being dropped; that module holds the
+    argument, which is the same one the candidate measurement relies on. What is
+    the ranking's own is the check at the door: a nine-point row arriving here
+    would be scored by something other than the replayed rubric and would silently
+    re-base every band, so it is refused before a cut is taken over it.
     """
     out: list[ScoredTrade] = []
-    for trade in trades:
-        key = (trade.detection_session, trade.symbol)
-        if key not in scores:
-            raise ValueError(
-                f"no persisted score for {trade.symbol} detected "
-                f"{trade.detection_session}: the join from trade to detection is "
-                "total, and a missing row is a broken denominator rather than a "
-                "trade to drop"
-            )
-        score = scores[key]
-        check_seven_dimension_score(score)
-        out.append(ScoredTrade(trade=trade, score=score))
+    for trade, detection in join_detections(trades, index):
+        check_seven_dimension_score(detection.score)
+        out.append(ScoredTrade(trade=trade, score=detection.score))
     return out
 
 
@@ -933,8 +706,7 @@ def _intervals_reported(markets_body: Sequence[dict[str, Any]]) -> int:
     anything made no claim to correct for.
     """
     def in_slice(body: dict[str, Any]) -> int:
-        cells = [*body["buckets"], body["gap"], body["spearman"]]
-        return sum(1 for c in cells if c["bootstrap"]["ci_low"] is not None)
+        return intervals_reported([*body["buckets"], body["gap"], body["spearman"]])
 
     return sum(
         in_slice(market) + sum(in_slice(year) for year in market["years"])
@@ -1013,16 +785,6 @@ def ranking_report(
 # -- printing it, and the command that produces it ----------------------------
 
 
-def _interval(boot: dict[str, Any]) -> str:
-    """One interval as a phrase, or the reason there is none."""
-    if boot["ci_low"] is None:
-        return f"{boot['clusters']} {boot['cluster']}s — too thin for an interval"
-    return (
-        f"[{boot['ci_low']:+.2f}, {boot['ci_high']:+.2f}] p={boot['p_value']:.3f} "
-        f"on {boot['clusters']} {boot['cluster']}s"
-    )
-
-
 def _bucket_line(cell: dict[str, Any]) -> str:
     """One bucket as a line: the band, its n, what it paid and how sure that is.
 
@@ -1039,7 +801,7 @@ def _bucket_line(cell: dict[str, Any]) -> str:
         return f"{head} no closed trades ({cell['trades']} taken)"
     return (
         f"{head} {cell['expectancy_r']:+.3f}R  win {cell['win_rate']:.1%}  "
-        f"{cell['symbols']} symbols  {_interval(cell['bootstrap'])}"
+        f"{cell['symbols']} symbols  {format_interval(cell['bootstrap'])}"
     )
 
 
@@ -1051,9 +813,9 @@ def _slice_lines(body: dict[str, Any], *, indent: str = "") -> list[str]:
     rho_value = "undefined" if rho["rho"] is None else f"{rho['rho']:+.3f}"
     lines += [
         f"{indent}  gap {gap['bottom']} → {gap['top']}: {value}  "
-        f"{_interval(gap['bootstrap'])}",
+        f"{format_interval(gap['bootstrap'])}",
         f"{indent}  rho {rho_value} over {rho['pairs']} trades  "
-        f"{_interval(rho['bootstrap'])}",
+        f"{format_interval(rho['bootstrap'])}",
         f"{indent}  verdict: {VERDICT_PHRASE[body['verdict']]}",
     ]
     return lines
@@ -1136,7 +898,7 @@ def main(argv: list[str] | None = None) -> int:
             trades = simulate_market(
                 store, denominator, market, contract, arms=(PRIMARY_ARM,)
             )
-            cohort += scored_trades(trades, score_index(denominator, market))
+            cohort += scored_trades(trades, detection_index(denominator, market))
     finally:
         denominator.close()
         store.close()

--- a/backend/backtest/ranking.py
+++ b/backend/backtest/ranking.py
@@ -102,7 +102,7 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Mapping, Sequence, TypeVar
 
 from replay.field import SEVEN_DIM_LABEL, SEVEN_DIM_MAX_POINTS, SevenDimScore
 from screener.score import DIMENSIONS
@@ -439,12 +439,16 @@ def top_minus_bottom(
     return sum(top) / len(top) - sum(bottom) / len(bottom)
 
 
-def _ranks(values: Sequence[float]) -> list[float]:
+def ranks(values: Sequence[float]) -> list[float]:
     """Fractional ranks, ties taking the average of the positions they occupy.
 
     Ties are the common case on an eight-point score, so this is the whole of why
     the correlation is meaningful here: breaking them by arrival order would make
     rho a function of the sort.
+
+    Public because :mod:`backtest.candidates` ranks a candidate dimension's stored
+    value against the same outcome, and a second implementation of a tie rule is a
+    second place for two rhos in one run to have been computed differently.
     """
     order = sorted(range(len(values)), key=lambda i: values[i])
     out = [0.0] * len(values)
@@ -460,23 +464,27 @@ def _ranks(values: Sequence[float]) -> list[float]:
     return out
 
 
-def rank_correlation(rows: Sequence[Outcome]) -> float | None:
-    """Spearman's rho between score and outcome — the whole-cohort ranking claim.
+def spearman(xs: Sequence[float], ys: Sequence[float]) -> float | None:
+    """Spearman's rho between two paired series, ties averaged.
 
-    Reported beside the gap because the two can disagree, and the disagreement is
-    informative: a rubric whose extremes separate while its middle is noise is a
-    different finding from one that ranks throughout, and the gap alone cannot
-    tell them apart.
+    The arithmetic alone, so the two callers that need it — the score against the
+    outcome here, and a candidate dimension's stored value against the same
+    outcome in :mod:`backtest.candidates` — read one tie rule and one variance
+    refusal rather than two that could drift apart.
 
-    ``None`` when either side has no variance — one score, or every trade paying
-    the same. There is no correlation to report there, and a zero would read as
-    "measured and found nothing" rather than "not measurable".
+    ``None`` when either side has no variance. There is no correlation to report
+    there, and a zero would read as "measured and found nothing" rather than "not
+    measurable".
     """
-    if len(rows) < 2:
+    if len(xs) != len(ys):
+        raise ValueError(
+            f"a correlation needs paired series; {len(xs)} against {len(ys)} "
+            "is a join that lost rows on one side"
+        )
+    if len(xs) < 2:
         return None
-    x = _ranks([float(row.points) for row in rows])
-    y = _ranks([row.r for row in rows])
-    n = len(rows)
+    x, y = ranks(xs), ranks(ys)
+    n = len(xs)
     mx, my = sum(x) / n, sum(y) / n
     dx = [a - mx for a in x]
     dy = [b - my for b in y]
@@ -487,7 +495,29 @@ def rank_correlation(rows: Sequence[Outcome]) -> float | None:
     return sum(a * b for a, b in zip(dx, dy)) / (sx * sy)
 
 
+def rank_correlation(rows: Sequence[Outcome]) -> float | None:
+    """Spearman's rho between score and outcome — the whole-cohort ranking claim.
+
+    Reported beside the gap because the two can disagree, and the disagreement is
+    informative: a rubric whose extremes separate while its middle is noise is a
+    different finding from one that ranks throughout, and the gap alone cannot
+    tell them apart.
+
+    ``None`` when either side has no variance — one score, or every trade paying
+    the same.
+    """
+    return spearman([float(row.points) for row in rows], [row.r for row in rows])
+
+
 # -- the bootstrap, over a statistic rather than over a mean -------------------
+
+# The bootstrap resamples clusters and hands the pooled rows to a statistic; it
+# reads no field of a row itself. So the row type is the caller's — an
+# :class:`Outcome` here, a candidate dimension's outcome in
+# :mod:`backtest.candidates` — and saying so in the signature is what keeps the
+# second caller from needing a second bootstrap with the same seed.
+Row = TypeVar("Row")
+
 
 # How much of a resample distribution may be undefined before the interval built
 # on the rest of it is refused.
@@ -510,8 +540,8 @@ MAX_UNDEFINED_SHARE = 0.10
 
 
 def bootstrap_symbol_statistic(
-    clusters: Sequence[Sequence[Outcome]],
-    statistic: Callable[[Sequence[Outcome]], float | None],
+    clusters: Sequence[Sequence[Row]],
+    statistic: Callable[[Sequence[Row]], float | None],
     *,
     resamples: int = BOOTSTRAP_RESAMPLES,
     seed: int = BOOTSTRAP_SEED,
@@ -519,6 +549,7 @@ def bootstrap_symbol_statistic(
     cluster: str = BOOTSTRAP_CLUSTER,
     min_clusters: int = BOOTSTRAP_MIN_CLUSTERS,
     max_undefined_share: float = MAX_UNDEFINED_SHARE,
+    unavailable: str | None = None,
 ) -> dict[str, Any]:
     """A clustered bootstrap of an arbitrary statistic over the pooled rows.
 
@@ -547,6 +578,13 @@ def bootstrap_symbol_statistic(
     metric records: one symbol resampled two thousand times returns its own mean
     two thousand times, which prints as a zero-width interval at p = 0 and is one
     independent observation.
+
+    ``unavailable`` refuses before any resampling, for a statistic that could not
+    be computed on this cohort whatever was drawn — :mod:`backtest.candidates`
+    passes it for a rank correlation against a candidate that persists no degree.
+    The refusal is stated in the caller's words but reported in this function's
+    shape, so a cell that never ran a bootstrap and one that ran and refused are
+    read the same way by anything downstream.
     """
 
     n = len(clusters)
@@ -564,6 +602,8 @@ def bootstrap_symbol_statistic(
         "suppressed": None,
     }
     empty = {**body, "ci_low": None, "ci_high": None, "p_value": None}
+    if unavailable is not None:
+        return {**empty, "suppressed": unavailable}
     if n < min_clusters:
         return {
             **empty,

--- a/backend/backtest/stats.py
+++ b/backend/backtest/stats.py
@@ -1,0 +1,303 @@
+"""The run's shared statistics — the pieces more than one measurement needs.
+
+:mod:`backtest.metric` owns the pre-registered headline and the arithmetic behind
+it: what a trade paid after costs, and the clustered bootstrap of a **mean**. That
+covers the headline and every cell shaped like it.
+
+It does not cover a statistic that is not a mean. A gap between two score bands, a
+gap between a candidate dimension's two sides, a rank correlation — none of these
+is the mean of anything, so none can be built by resampling clusters and averaging
+them. :mod:`backtest.ranking` grew the machinery for the first of those (#194) and
+:mod:`backtest.candidates` needed the same machinery for the second (#195), which
+is when it stopped being the ranking's business: a module that is both a
+measurement and the run's statistics library changes for two reasons, and the
+second caller would have had to import from the first.
+
+So this module holds what the two share, and holds it once:
+
+* :func:`ranks` and :func:`spearman` — one tie rule and one variance refusal, so
+  two rank correlations in one run were never computed differently.
+* :func:`cluster_by_symbol` — the unit of independence, applied to whatever row
+  type a measurement uses.
+* :func:`bootstrap_symbol_statistic` — the clustered bootstrap over an arbitrary
+  statistic, on :mod:`backtest.metric`'s own seed, resample count, confidence
+  level and cluster floor, so two intervals in one report can never have been
+  built differently.
+* :func:`format_interval` and :func:`intervals_reported` — the two places a
+  measurement renders and counts what it has claimed.
+
+Nothing here knows what is being measured. Every function takes the caller's own
+row type, which is what lets one bootstrap serve a score band gap and a candidate
+dimension's gap without either module knowing about the other.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any, Callable, Iterable, Mapping, Protocol, Sequence, TypeVar
+
+from .metric import (
+    BOOTSTRAP_CLUSTER,
+    BOOTSTRAP_CONFIDENCE,
+    BOOTSTRAP_MIN_CLUSTERS,
+    BOOTSTRAP_RESAMPLES,
+    BOOTSTRAP_SEED,
+    quantile,
+)
+
+
+class HasSymbol(Protocol):
+    """Any row that knows which name it belongs to.
+
+    The only thing clustering needs to know about a row. Stated as a protocol
+    rather than a base class so a measurement's row type stays a plain frozen
+    dataclass of exactly the fields its statistics read.
+    """
+
+    @property
+    def symbol(self) -> str: ...
+
+
+# The row type a measurement resamples. The bootstrap hands pooled rows to a
+# statistic and reads no field of one itself, so the type is the caller's — an
+# outcome bucketed by score band, a candidate dimension's outcome, whatever comes
+# next.
+Row = TypeVar("Row")
+SymbolRow = TypeVar("SymbolRow", bound=HasSymbol)
+
+
+# -- ranks and rank correlation -----------------------------------------------
+
+
+def ranks(values: Sequence[float]) -> list[float]:
+    """Fractional ranks, ties taking the average of the positions they occupy.
+
+    Ties are the common case on both quantities this run ranks — an eight-point
+    integral score, and a candidate dimension's value on a field most of which
+    sits one side of its cut — so the tie rule is the whole of why a correlation
+    is meaningful here. Breaking ties by arrival order would make rho a function
+    of the sort.
+    """
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    out = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        average = (i + j) / 2 + 1
+        for k in range(i, j + 1):
+            out[order[k]] = average
+        i = j + 1
+    return out
+
+
+def spearman(xs: Sequence[float], ys: Sequence[float]) -> float | None:
+    """Spearman's rho between two paired series, ties averaged.
+
+    ``None`` when either side has no variance. There is no correlation to report
+    there, and a zero would read as "measured and found nothing" rather than "not
+    measurable".
+
+    Unequal lengths are a **join that lost rows on one side**, not a series to
+    truncate, so they raise rather than silently correlating the overlap.
+    """
+    if len(xs) != len(ys):
+        raise ValueError(
+            f"a correlation needs paired series; {len(xs)} against {len(ys)} "
+            "is a join that lost rows on one side"
+        )
+    if len(xs) < 2:
+        return None
+    x, y = ranks(xs), ranks(ys)
+    n = len(xs)
+    mx, my = sum(x) / n, sum(y) / n
+    dx = [a - mx for a in x]
+    dy = [b - my for b in y]
+    sx = sum(a * a for a in dx) ** 0.5
+    sy = sum(b * b for b in dy) ** 0.5
+    if sx == 0.0 or sy == 0.0:
+        return None
+    return sum(a * b for a, b in zip(dx, dy)) / (sx * sy)
+
+
+# -- the unit of independence -------------------------------------------------
+
+
+def cluster_by_symbol(rows: Iterable[SymbolRow]) -> list[tuple[SymbolRow, ...]]:
+    """The rows grouped one cluster per symbol, in symbol order.
+
+    The cluster is the symbol because overlapping signals in one name are not
+    independent observations — a stock throwing three signals in a fortnight
+    contributes three correlated rows — so resampling *rows* would make the
+    effective sample larger than it is and flatter every p-value.
+
+    Ordered by symbol so a resample under a fixed seed is reproducible: clusters
+    arriving in insertion order would move an interval with the order the trades
+    happened to be read in.
+    """
+    grouped: dict[str, list[SymbolRow]] = {}
+    for row in rows:
+        grouped.setdefault(row.symbol, []).append(row)
+    return [tuple(grouped[symbol]) for symbol in sorted(grouped)]
+
+
+# -- the bootstrap, over a statistic rather than over a mean -------------------
+
+# How much of a resample distribution may be undefined before the interval built
+# on the rest of it is refused.
+#
+# A resample is undefined exactly when the statistic could not be evaluated on
+# what it drew — no symbol from the top band, none from the bottom, no variance on
+# one side. Those are the draws carrying the most uncertainty about a statistic
+# resting on a thin edge. Dropping them and reading the interval off what is left
+# *conditions on the statistic having been computable*, which renormalises the
+# distribution towards the cases where it was, and those are the confident ones.
+# The correction goes the wrong way: it tightens the interval exactly where the
+# data is weakest.
+#
+# There is no honest value to substitute for an undefined draw — zero is a
+# measurement nobody made — so the remedy is to refuse the interval rather than to
+# repair it. A tenth is a judgement and is recorded as one: below it the
+# renormalisation moves a percentile bound by less than the resampling noise
+# around it, and above it the interval is describing a sub-population of the
+# resamples. The count always rides on the output, so a cell just under the line
+# reads as one.
+MAX_UNDEFINED_SHARE = 0.10
+
+
+def bootstrap_symbol_statistic(
+    clusters: Sequence[Sequence[Row]],
+    statistic: Callable[[Sequence[Row]], float | None],
+    *,
+    resamples: int = BOOTSTRAP_RESAMPLES,
+    seed: int = BOOTSTRAP_SEED,
+    confidence: float = BOOTSTRAP_CONFIDENCE,
+    cluster: str = BOOTSTRAP_CLUSTER,
+    min_clusters: int = BOOTSTRAP_MIN_CLUSTERS,
+    max_undefined_share: float = MAX_UNDEFINED_SHARE,
+    unavailable: str | None = None,
+) -> dict[str, Any]:
+    """A clustered bootstrap of an arbitrary statistic over the pooled rows.
+
+    :func:`~backtest.metric.bootstrap_expectancy` resamples the same unit and takes
+    the pooled **mean**; a gap between two groups and a rank correlation are not
+    means of anything, so they need the resampled cohort itself. Hence a second
+    entry point rather than a second bootstrap: the seed, the resample count, the
+    confidence level, the cluster floor and the reported fields are all the
+    metric's.
+
+    Each resample draws ``len(clusters)`` clusters **with replacement** and pools
+    every row inside them, so a symbol is in or out as a whole. ``p_value`` is
+    one-sided — the share of resampled statistics at or below zero — which is the
+    shape of every claim built on this: whether the quantity pays *more*, not
+    whether it pays differently.
+
+    A resample the statistic cannot evaluate is counted under ``undefined`` rather
+    than defaulted to zero, because a resample that could not answer is not a
+    resample that answered no. Past :data:`MAX_UNDEFINED_SHARE` of the draws the
+    interval is **refused**; see that constant for the argument.
+
+    Below ``min_clusters`` no interval is reported at all, for the reason the
+    metric records: one symbol resampled two thousand times returns its own mean
+    two thousand times, which prints as a zero-width interval at p = 0 and is one
+    independent observation.
+
+    ``unavailable`` refuses before any resampling, for a statistic that could not
+    be computed on this cohort whatever was drawn — :mod:`backtest.candidates`
+    passes it for a rank correlation against a candidate that persists no degree.
+    The refusal is stated in the caller's words but reported in this function's
+    shape, so a cell that never ran a bootstrap and one that ran and refused are
+    read the same way by everything downstream.
+    """
+
+    n = len(clusters)
+    pooled = [row for cluster_rows in clusters for row in cluster_rows]
+    body: dict[str, Any] = {
+        "cluster": cluster,
+        "clusters": n,
+        "observations": len(pooled),
+        "resamples": resamples,
+        "seed": seed,
+        "confidence": confidence,
+        "min_clusters": min_clusters,
+        "undefined": 0,
+        "max_undefined_share": max_undefined_share,
+        "suppressed": None,
+    }
+    empty = {**body, "ci_low": None, "ci_high": None, "p_value": None}
+    if unavailable is not None:
+        return {**empty, "suppressed": unavailable}
+    if n < min_clusters:
+        return {
+            **empty,
+            "suppressed": (
+                f"{n} {cluster}s is fewer than {min_clusters}: too thin for an "
+                "interval, and a degenerate one would read as significance"
+            ),
+        }
+
+    rng = random.Random(seed)
+    indices = range(n)
+    drawn_values: list[float] = []
+    undefined = 0
+    for _ in range(resamples):
+        drawn = [row for i in indices for row in clusters[rng.choice(indices)]]
+        value = statistic(drawn)
+        if value is None:
+            undefined += 1
+            continue
+        drawn_values.append(value)
+    share_undefined = undefined / resamples if resamples else 1.0
+    if not drawn_values or share_undefined > max_undefined_share:
+        return {
+            **empty,
+            "undefined": undefined,
+            "suppressed": (
+                f"{share_undefined:.1%} of resamples could not be evaluated over "
+                f"{n} {cluster}s, past the {max_undefined_share:.0%} the interval "
+                "is allowed: reading it off the rest would condition on the draws "
+                "where the statistic was computable, which are the confident ones"
+            ),
+        }
+
+    drawn_values.sort()
+    tail = (1.0 - confidence) / 2.0
+    return {
+        **body,
+        "undefined": undefined,
+        "ci_low": quantile(drawn_values, tail),
+        "ci_high": quantile(drawn_values, 1.0 - tail),
+        "p_value": sum(1 for v in drawn_values if v <= 0.0) / len(drawn_values),
+    }
+
+
+# -- rendering and counting what was claimed ----------------------------------
+
+
+def format_interval(boot: Mapping[str, Any]) -> str:
+    """One interval as a phrase, or the count and the fact that there is none.
+
+    The *reason* an interval was refused rides on the payload under
+    ``suppressed``, and is deliberately not printed: the reasons are sentences,
+    and a page of them would bury the figures they qualify. What prints is the
+    cluster count, because a cell with no interval is still a measurement and its
+    n is what says how thin it was.
+    """
+    if boot["ci_low"] is None:
+        return f"{boot['clusters']} {boot['cluster']}s — no interval"
+    return (
+        f"[{boot['ci_low']:+.2f}, {boot['ci_high']:+.2f}] p={boot['p_value']:.3f} "
+        f"on {boot['clusters']} {boot['cluster']}s"
+    )
+
+
+def intervals_reported(cells: Iterable[Mapping[str, Any]]) -> int:
+    """How many of these cells actually state an interval.
+
+    The multiple-testing budget is the count of claims made at nominal alpha, and
+    a suppressed interval made no claim to correct for. Counted rather than
+    described, because a budget a reader has to infer from the length of a page is
+    a budget nobody is keeping.
+    """
+    return sum(1 for cell in cells if cell["bootstrap"]["ci_low"] is not None)

--- a/backend/replay/field.py
+++ b/backend/replay/field.py
@@ -158,7 +158,7 @@ class ScoredDetection:
     star_rank: int
     not_taken: bool
     taken: bool = False
-    rs_line: bool | None = False
+    rs_line: bool | None = None
     relative_move: float | None = None
 
 
@@ -267,7 +267,7 @@ def build_field(
             star_rank=rank,
             not_taken=any_entry and det.symbol not in entered,
             taken=det.symbol in entered,
-            rs_line=rs_line_of.get(det.symbol, False),
+            rs_line=rs_line_of.get(det.symbol),
             relative_move=relative_move_of.get(det.symbol),
         )
         for rank, (det, score) in enumerate(scored, start=1)

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -6861,6 +6861,8 @@ def _seed_figure_name(
     *,
     burn_in: bool = False,
     detect: bool = True,
+    rs_line: bool | None = False,
+    relative_move: float | None = None,
 ) -> Detection:
     """One authored name: its bars in the bar store, its detection in the denominator.
 
@@ -6874,6 +6876,11 @@ def _seed_figure_name(
     ``detect=False`` seeds the sessions and no detection, which is how a year gets
     a full trading calendar and an empty field — the shape a collapsed count has
     when it is a data hole rather than a short year.
+
+    The two candidate values default to what a name with no benchmark history
+    carries — a miss on ``rs_line``, absent on ``relative_move`` — and are
+    overridable, because the candidate-outcome section below reads exactly those
+    two columns off the persisted row.
     """
     bars = _fig_bars(start, closes)
     store.append_bars(market, symbol, bars)
@@ -6892,7 +6899,8 @@ def _seed_figure_name(
             ScoredDetection(
                 symbol=symbol, detection=det,
                 score=seven_dimension_score(det, prior_move=False),
-                star_rank=1, not_taken=False, rs_line=False, relative_move=None,
+                star_rank=1, not_taken=False, rs_line=rs_line,
+                relative_move=relative_move,
             )
         ])
     return det
@@ -8848,3 +8856,640 @@ def test_the_ranking_runs_off_the_denominator_end_to_end(store, denominator):
     ).points
     body = market_ranking(DEFAULT_CONTRACT, cohort, market="US")
     assert sum(b["trades"] for b in body["buckets"]) == 1
+
+
+# -- do the registered candidates predict, or only select? (issue #195) --------
+#
+# ADR 0005 admits a dimension on a **selection contrast** — taken detections
+# against not-taken ones, no outcome variable — because when it was written no
+# outcome variable existed. Both registered candidates were measured on that
+# instrument and neither shipped: `RS line` refused on criterion 4 for a wrong-way
+# gap (findings §5d), `Relative move` positive on both fields and then stalled
+# 0.06pp inside the one threshold the ADR itself calls a judgement (§5e).
+#
+# This section gives the same two dimensions an **outcome** variable. Four claims
+# are load-bearing, and each is an acceptance criterion of #195:
+#
+#   * **Both registered candidates, per market.** The list is derived from
+#     `replay.contrast.CANDIDATES` rather than typed here, so a registration this
+#     module cannot read is drift rather than a silently missing column.
+#   * **The cut is applied at read time**, off the value the persisted row
+#     carries, by the rubric's own reader. No row is re-denominated retroactively.
+#   * **Absence is absence.** `relative_move` is `None` when the name had not
+#     listed six months back — and zero is a real value sitting exactly on the
+#     pre-registered cut, so a coerced absence would be a hit-or-miss verdict
+#     nobody measured. It gets its own group, its own n, and it enters no gap.
+#   * **The outcome claim is never merged with the selection contrast.** They are
+#     two different claims about one dimension, and a reader who lines them up as
+#     one has read a stronger claim than either supports.
+#
+# Nothing here admits a dimension. `check_not_admitted` makes that executable
+# rather than a sentence in a docstring.
+
+from backtest.candidates import (
+    ADMISSION_NOTE,
+    CANDIDATES_UNDER_TEST,
+    GROUP_ABSENT,
+    GROUP_HIT,
+    GROUP_MISS,
+    GROUPS,
+    SELECTION_CONTRAST,
+    VALUE_BOOLEAN,
+    VALUE_GRADED,
+    VERDICT_RULE as VERDICT_RULE_CANDIDATES,
+    # Aliased for the reason the ranking section aliases its own: three verdict
+    # vocabularies now live in this namespace, and an unqualified
+    # `VERDICT_TOO_THIN` would let one section's assertion test another's
+    # constant.
+    VERDICT_NO_EVIDENCE as CANDIDATE_NO_EVIDENCE,
+    VERDICT_PREDICTS as CANDIDATE_PREDICTS,
+    VERDICT_TOO_THIN as CANDIDATE_TOO_THIN,
+    CandidateTrade,
+    candidate_index,
+    candidate_trades,
+    candidates_report,
+    check_not_admitted,
+    check_registry,
+    format_candidates,
+    group_of,
+    market_candidate,
+    named_candidate,
+    outcome_gap,
+    outcomes as candidate_outcomes,
+    rubric_reading_gap,
+    split,
+    value_correlation,
+)
+from backtest.ranking import spearman
+from replay.contrast import CANDIDATE_DIMENSIONS
+
+
+_RS_LINE = "RS line"
+_RELATIVE_MOVE = "Relative move"
+
+
+def _cdetection(
+    symbol: str,
+    session: date,
+    *,
+    rs_line: bool | None = None,
+    relative_move: float | None = None,
+) -> ScoredDetection:
+    """A persisted detection row carrying nothing but its two candidate values.
+
+    The detector record and the score are the fixture's filler — this section
+    measures what the candidate columns predict, and authoring a geometry to reach
+    them would put the detector's behaviour inside a test about outcomes.
+    """
+    det = Detection(
+        symbol=symbol, session=session, detector_version=DETECTOR_VERSION,
+        trigger=10.0, stop=9.0, stopw_adr=1.0,
+        base_len=10, move_gain=0.5, adr=0.05, close=9.5, cluster_k=3,
+        cluster_high=10.0, cluster_low=9.0, cluster_range_adr=1.0,
+        range_3bar_adr=1.0, line_ok=True, touch_zones=2, overshoot_adr=0.1,
+        slope=0.0, line_end=9.5, base_low=9.0, churn_l=0.2, sma20_rising=True,
+        dryup=0.8,
+    )
+    return ScoredDetection(
+        symbol=symbol,
+        detection=det,
+        score=SevenDimScore(
+            stars=2.0, points=4, max_points=SEVEN_DIM_MAX_POINTS,
+            breakdown=[], label=SEVEN_DIM_LABEL,
+        ),
+        star_rank=1,
+        not_taken=False,
+        rs_line=rs_line,
+        relative_move=relative_move,
+    )
+
+
+def _ctrade(
+    symbol: str,
+    r: float,
+    *,
+    rs_line: bool | None = None,
+    relative_move: float | None = None,
+    year: int = 2016,
+    month: int = 3,
+    market: str = "US",
+    arm: str = ARM_B,
+) -> CandidateTrade:
+    """One arm-B trade beside the persisted row that produced it.
+
+    Authored on :func:`_mtrade`, the metric section's own fixture, for the reason
+    the ranking section gives: the measurement is arithmetic over trades priced the
+    metric's way, and a second trade fixture would be a second cost model.
+    """
+    trade = _mtrade(symbol, year, r, market=market, arm=arm, month=month)
+    return CandidateTrade(
+        trade=trade,
+        detection=_cdetection(
+            symbol, trade.detection_session,
+            rs_line=rs_line, relative_move=relative_move,
+        ),
+    )
+
+
+def _ccohort(
+    hits: dict[str, float],
+    misses: dict[str, float],
+    absent: dict[str, float] | None = None,
+    *,
+    market: str = "US",
+) -> list[CandidateTrade]:
+    """A cohort split three ways on ``Relative move``'s stored value.
+
+    A hit is a positive value, a miss a negative one, and an absent row carries
+    ``None`` — never 0.0, which is a real value sitting exactly on the cut and is
+    the confusion this whole section exists to prevent.
+    """
+    rows = [_ctrade(s, r, relative_move=+1.5, market=market)
+            for s, r in hits.items()]
+    rows += [_ctrade(s, r, relative_move=-1.5, market=market)
+             for s, r in misses.items()]
+    rows += [_ctrade(s, r, relative_move=None, market=market)
+             for s, r in (absent or {}).items()]
+    return rows
+
+
+def _spread(prefix: str, r: float, n: int) -> dict[str, float]:
+    """``n`` distinct symbols all paying ``r`` — enough clusters to bootstrap."""
+    return {f"{prefix}{i}": r for i in range(n)}
+
+
+def _cbody(
+    cohort: list[CandidateTrade], name: str, *, market: str = "US"
+) -> dict[str, Any]:
+    """One candidate's cell over one market — the shape most tests below read."""
+    return market_candidate(
+        DEFAULT_CONTRACT, named_candidate(name), cohort, market=market
+    )
+
+
+def _cfind(report: dict[str, Any], market: str, name: str) -> dict[str, Any]:
+    """One candidate's cell out of a whole report."""
+    body = next(m for m in report["markets"] if m["market"] == market)
+    return next(c for c in body["candidates"] if c["candidate"] == name)
+
+
+def test_both_registered_candidates_are_measured_against_outcomes_per_market():
+    """#195's first criterion, and the reason the list is derived rather than typed.
+
+    The candidates under test are exactly the ones ADR 0005 has registered, read
+    off `replay.contrast.CANDIDATES`. A module holding its own list would keep
+    measuring a retired candidate, or quietly miss a third one, with nothing in the
+    output to say so.
+    """
+    assert [c.name for c in CANDIDATES_UNDER_TEST] == [
+        name for name, _weight in CANDIDATE_DIMENSIONS
+    ]
+    assert {c.name for c in CANDIDATES_UNDER_TEST} == {_RS_LINE, _RELATIVE_MOVE}
+
+    report = candidates_report(
+        DEFAULT_CONTRACT,
+        _ccohort(_spread("H", 1.0, 6), _spread("M", -0.2, 6)),
+        markets=("US", "IDX"),
+    )
+
+    assert [m["market"] for m in report["markets"]] == ["US", "IDX"]
+    for body in report["markets"]:
+        assert [c["candidate"] for c in body["candidates"]] == [
+            _RS_LINE, _RELATIVE_MOVE
+        ]
+
+
+def test_a_registration_this_module_cannot_read_is_drift_not_a_missing_column():
+    """A third candidate registered upstream must stop this measurement, loudly.
+
+    The registry here supplies what `CANDIDATES` does not — how to read the
+    **value** off the row, and what absence means for it — so a name it has never
+    heard of cannot be measured. Reporting the two it knows and dropping the third
+    would answer #195's "both registered candidates" with a number that had quietly
+    stopped meaning it.
+    """
+    with pytest.raises(ContractDrift, match="Third candidate"):
+        check_registry((("Third candidate", 0, lambda d: True),))
+
+
+def test_the_cut_is_applied_at_read_time_off_the_value_the_row_carries():
+    """#195's second criterion: the row owns the value, the reader owns the verdict.
+
+    Two rows on either side of the pre-registered cut land in different groups
+    while carrying their stored values unchanged — so a later argument about where
+    the cut belongs re-reads these rows rather than re-denominating them.
+    """
+    candidate = named_candidate(_RELATIVE_MOVE)
+    above = _cdetection("AAA", date(2016, 3, 1), relative_move=+0.25)
+    below = _cdetection("BBB", date(2016, 3, 1), relative_move=-0.25)
+
+    assert group_of(candidate, above) == GROUP_HIT
+    assert group_of(candidate, below) == GROUP_MISS
+    # The value is untouched by the reading: the cut is a question asked of the
+    # row, never a rewrite of it.
+    assert candidate.value(above) == +0.25
+    assert candidate.value(below) == -0.25
+
+
+def test_absence_is_its_own_group_and_never_a_value_sitting_on_the_cut():
+    """#195's third criterion, and the one with a trap under it.
+
+    ``Relative move``'s cut is **zero**. So an absent value coerced to 0.0 would
+    not merely be a guess — it would land exactly on the boundary, and the
+    strictness of the comparison would decide a verdict nobody measured. Absence
+    therefore gets its own group, and a row in it enters no gap.
+    """
+    candidate = named_candidate(_RELATIVE_MOVE)
+    missing = _cdetection("AAA", date(2016, 3, 1), relative_move=None)
+
+    assert group_of(candidate, missing) == GROUP_ABSENT
+    assert candidate.value(missing) is None
+
+    cohort = _ccohort(
+        _spread("H", 1.0, 6), _spread("M", -0.2, 6), _spread("Z", 9.9, 6)
+    )
+    groups = split(candidate, cohort)
+
+    assert sorted(groups) == sorted(GROUPS)
+    assert [len(groups[g]) for g in (GROUP_HIT, GROUP_MISS, GROUP_ABSENT)] == [6, 6, 6]
+    # The absent rows pay +9.9R and move the gap by nothing at all.
+    rows = candidate_outcomes(candidate, cohort, DEFAULT_CONTRACT)
+    asked = [row for row in rows if row.group != GROUP_ABSENT]
+    assert outcome_gap(rows) == outcome_gap(asked)
+
+
+def test_every_trade_lands_in_exactly_one_group_and_the_counts_add_up():
+    """The three groups partition the cohort, so nothing leaves between the split
+    and the report — and the absent count is reported rather than inferred from a
+    subtraction a reader has to perform."""
+    cohort = _ccohort(
+        _spread("H", 1.0, 6), _spread("M", -0.2, 5), _spread("Z", 0.4, 4)
+    )
+
+    body = _cbody(cohort, _RELATIVE_MOVE)
+
+    counts = {g: body["groups"][g]["trades"] for g in GROUPS}
+    assert counts == {GROUP_HIT: 6, GROUP_MISS: 5, GROUP_ABSENT: 4}
+    assert sum(counts.values()) == len(cohort) == body["trades"]
+
+
+def test_the_rubric_reading_folds_absence_into_the_miss_side_and_says_which():
+    """What the dimension would do **as shipped**, reported and never conflated.
+
+    The pre-registered readers score an absent value ``False``
+    (:func:`~screener.relative_strength.relative_move_hit`), so a shipped boolean
+    would put those rows on the miss side. That reading is worth having — it is the
+    one a rubric would actually apply — but it answers a different question from
+    "does the measured quantity predict", so it rides beside the primary gap under
+    its own name and never sets the verdict.
+    """
+    # The absent rows pay well, so folding them into the miss side must move the
+    # secondary gap and leave the primary one exactly where it was.
+    cohort = _ccohort(
+        _spread("H", 1.0, 6), _spread("M", -1.0, 6), _spread("Z", 3.0, 6)
+    )
+    candidate = named_candidate(_RELATIVE_MOVE)
+    rows = candidate_outcomes(candidate, cohort, DEFAULT_CONTRACT)
+
+    body = _cbody(cohort, _RELATIVE_MOVE)
+
+    assert body["gap"]["value"] == pytest.approx(outcome_gap(rows))
+    assert body["rubric_reading"]["value"] == pytest.approx(rubric_reading_gap(rows))
+    assert body["gap"]["value"] > body["rubric_reading"]["value"]
+    assert "absent" in body["rubric_reading"]["reads_absence_as"]
+    # And it is explicitly outside the verdict.
+    assert body["rubric_reading"]["enters_the_verdict"] is False
+
+
+def test_a_candidate_that_predicts_shows_a_gap_whose_interval_clears_zero():
+    """The claim under test, in the shape that would confirm it: the hit group
+    out-earns the miss group and the clustered interval sits entirely above zero."""
+    cohort = _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8))
+
+    body = _cbody(cohort, _RELATIVE_MOVE)
+
+    assert body["gap"]["value"] > 0
+    assert body["gap"]["bootstrap"]["ci_low"] > 0
+    assert body["verdict"] == CANDIDATE_PREDICTS
+
+
+def test_a_candidate_that_does_not_predict_reports_no_evidence_not_a_null_result():
+    """"No evidence it predicts" is never "the dimension does not predict".
+
+    One sample cannot license the second, and the vocabulary is where that
+    discipline lives — a report saying "no" would be a claim this run has no
+    standing to make.
+    """
+    cohort = _ccohort(_spread("H", 0.1, 8), _spread("M", 0.1, 8))
+
+    body = _cbody(cohort, _RELATIVE_MOVE)
+
+    assert body["verdict"] == CANDIDATE_NO_EVIDENCE
+    assert "never" in VERDICT_RULE_CANDIDATES
+    ci_low = body["gap"]["bootstrap"]["ci_low"]
+    assert ci_low is None or ci_low <= 0
+
+
+def test_a_side_too_thin_to_bootstrap_says_so_and_still_reports_its_n():
+    """A gap is taken **between** two sides, so a thin one makes it unreadable
+    however wide the other is. The n stays on the page: a thin cell is visible as
+    thin rather than absent."""
+    cohort = _ccohort(_spread("H", 2.0, 8), {"M0": -1.0, "M1": -1.0})
+
+    body = _cbody(cohort, _RELATIVE_MOVE)
+
+    assert body["verdict"] == CANDIDATE_TOO_THIN
+    assert body["groups"][GROUP_MISS]["closed"] == 2
+    assert body["groups"][GROUP_MISS]["bootstrap"]["suppressed"] is not None
+
+
+def test_significance_is_clustered_by_symbol_never_by_row():
+    """One name signalling repeatedly is one observation's worth of independence.
+
+    Two cohorts with the same rows and different symbol counts must not produce the
+    same interval — bootstrapping rows would make the second look as firm as the
+    first.
+    """
+    spread = _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8))
+    one_name = [
+        _ctrade("SAME", 2.0, relative_move=+1.5, month=1 + i) for i in range(8)
+    ] + [
+        _ctrade("OTHER", -1.0, relative_move=-1.5, month=1 + i) for i in range(8)
+    ]
+
+    wide = _cbody(spread, _RELATIVE_MOVE)
+    narrow = _cbody(one_name, _RELATIVE_MOVE)
+
+    assert wide["gap"]["bootstrap"]["clusters"] == 16
+    assert narrow["gap"]["bootstrap"]["clusters"] == 2
+    assert narrow["gap"]["bootstrap"]["suppressed"] is not None
+    assert narrow["verdict"] == CANDIDATE_TOO_THIN
+
+
+def test_the_stored_value_is_correlated_with_the_outcome_where_one_exists():
+    """The grading question ADR 0004 would ask later, asked here on the stored value.
+
+    ``Relative move`` persists a real number in ADR units, so the degree can be
+    ranked against the outcome. This is the statement the boolean cannot make, and
+    it runs over the rows where the value **exists** — an absent row is not a low
+    one.
+    """
+    cohort = [
+        _ctrade("A", -1.0, relative_move=-2.0),
+        _ctrade("B", 0.0, relative_move=-0.5),
+        _ctrade("C", 1.0, relative_move=+0.5),
+        _ctrade("D", 2.0, relative_move=+2.0),
+        _ctrade("E", 9.9, relative_move=None),
+    ]
+    candidate = named_candidate(_RELATIVE_MOVE)
+    rows = candidate_outcomes(candidate, cohort, DEFAULT_CONTRACT)
+
+    rho = value_correlation(rows)
+
+    assert rho == pytest.approx(1.0)
+    # The absent row is excluded rather than ranked at the bottom: it pays the
+    # most, and ranking it anywhere would move the figure.
+    assert rho == pytest.approx(
+        spearman(
+            [-2.0, -0.5, 0.5, 2.0], [r.r for r in rows if r.value is not None]
+        )
+    )
+
+
+def test_a_candidate_storing_only_a_boolean_reports_no_correlation_and_why():
+    """``RS line`` persists a boolean, not a degree.
+
+    So there is no value to rank, and the cell says that rather than printing a
+    correlation between a verdict and an outcome — which would be the gap again
+    under a second name, and would read as a second piece of evidence.
+    """
+    cohort = [
+        _ctrade("A", -1.0, rs_line=False),
+        _ctrade("B", 2.0, rs_line=True),
+    ]
+
+    body = _cbody(cohort, _RS_LINE)
+
+    assert named_candidate(_RS_LINE).value_kind == VALUE_BOOLEAN
+    assert named_candidate(_RELATIVE_MOVE).value_kind == VALUE_GRADED
+    assert body["value_correlation"]["rho"] is None
+    assert "boolean" in body["value_correlation"]["unavailable"]
+
+
+def test_the_verdict_is_the_gaps_and_the_correlation_is_stated_beside_it():
+    """One statistic decides, and the rule says which.
+
+    The gap is the claim ADR 0005 would act on — the dimension is admitted as a
+    boolean — so it is the gap's interval that reads the verdict. The correlation
+    is a statement about a *graded* form nothing has proposed, and only one of the
+    two candidates even has a value to compute it on; letting it into the verdict
+    would make the rule mean different things for the two dimensions.
+    """
+    cohort = _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8))
+
+    body = _cbody(cohort, _RELATIVE_MOVE)
+
+    assert body["verdict"] == CANDIDATE_PREDICTS
+    assert body["value_correlation"]["enters_the_verdict"] is False
+    assert "gap" in VERDICT_RULE_CANDIDATES
+
+
+def test_the_outcome_claim_is_reported_separately_from_the_selection_contrast():
+    """#195's fourth criterion: two claims about one dimension, never merged.
+
+    The published selection figures ride on the payload — the instrument, the Δ,
+    and the verdict ADR 0005 reached on it — beside a sentence saying why the two
+    cannot be added up. They are not the same claim: one says the trader picked
+    these names, the other says the names paid.
+    """
+    report = candidates_report(
+        DEFAULT_CONTRACT,
+        _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8)),
+        markets=("US",),
+    )
+
+    body = _cfind(report, "US", _RELATIVE_MOVE)
+    prior = body["selection_contrast"]
+
+    assert prior["instrument"] == "selection contrast"
+    assert prior["delta_pp"] == pytest.approx(3.6)
+    assert prior["adr_0005_verdict"] == "not admitted"
+    assert "different claim" in report["selection_contrast_note"]
+    # The two verdicts are separate keys, and neither is derived from the other.
+    assert body["verdict"] != prior["adr_0005_verdict"]
+    assert "selection" in format_candidates(report)
+
+
+def test_the_published_selection_figures_are_the_ones_5d_and_5e_measured():
+    """Quoted from the findings rather than recomputed, and pinned so a typo here
+    cannot rewrite a published result on its way onto this payload."""
+    assert SELECTION_CONTRAST[_RS_LINE]["delta_pp"] == pytest.approx(-2.1)
+    assert SELECTION_CONTRAST[_RS_LINE]["source"].endswith("§5d")
+    assert SELECTION_CONTRAST[_RELATIVE_MOVE]["delta_pp"] == pytest.approx(3.6)
+    assert SELECTION_CONTRAST[_RELATIVE_MOVE][
+        "not_taken_hit_rate"
+    ] == pytest.approx(0.8494)
+    assert SELECTION_CONTRAST[_RELATIVE_MOVE]["source"].endswith("§5e")
+
+
+def test_nothing_here_admits_a_dimension_to_the_rubric():
+    """#195's fifth criterion, made executable rather than promised in prose.
+
+    A candidate that had entered `screener.score.DIMENSIONS` would mean this
+    measurement was reporting on a live rubric row, which is a different thing
+    entirely — so it is refused at the door, and the payload states that admission
+    is ADR 0005's instrument and not this one's.
+    """
+    check_not_admitted()
+    assert all(weight == 0 for _name, weight in CANDIDATE_DIMENSIONS)
+    live = {name for name, _weight in DIMENSIONS}
+    assert live.isdisjoint({c.name for c in CANDIDATES_UNDER_TEST})
+
+    report = candidates_report(
+        DEFAULT_CONTRACT, _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8))
+    )
+
+    assert report["admission"] == ADMISSION_NOTE
+    assert "admits no dimension" in ADMISSION_NOTE
+
+
+def test_a_candidate_that_had_entered_the_rubric_is_refused():
+    """The other half of the same guard: the check has to be able to fire."""
+    with pytest.raises(ContractDrift, match="Relative move"):
+        check_not_admitted(dimensions=(("Relative move", 1),))
+
+
+def test_us_and_idx_never_pool_and_there_is_no_top_level_gap():
+    """Findings §8 measured that magnitudes do not transfer, so the way to stop a
+    pooled figure being quoted is for it never to have been computed."""
+    cohort = _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8))
+    cohort += _ccohort(_spread("J", 2.0, 8), _spread("K", -1.0, 8), market="IDX")
+
+    report = candidates_report(DEFAULT_CONTRACT, cohort, markets=("US", "IDX"))
+
+    assert "gap" not in report
+    assert "verdict" not in report
+    assert _cfind(report, "US", _RELATIVE_MOVE)["groups"][GROUP_HIT]["symbols"] == 8
+    assert _cfind(report, "IDX", _RELATIVE_MOVE)["groups"][GROUP_HIT]["symbols"] == 8
+
+
+def test_the_measurement_is_arm_bs_and_refuses_another_arms_trades():
+    """The pre-registered arm, for the reason the ranking gives: a cohort of arm A
+    trades under this banner would price a dimension against a result no headline
+    names."""
+    cohort = _ccohort(_spread("H", 2.0, 6), _spread("M", -1.0, 6))
+    cohort.append(_ctrade("X", 1.0, relative_move=+1.0, arm=ARM_A))
+
+    with pytest.raises(ValueError, match="arm"):
+        _cbody(cohort, _RELATIVE_MOVE)
+
+
+def test_a_market_that_produced_no_trade_reports_its_zeros_rather_than_vanishing():
+    """A silent market is a measurement — and possibly a data hole. An absent row
+    and a market nobody measured are indistinguishable after the fact."""
+    report = candidates_report(
+        DEFAULT_CONTRACT,
+        _ccohort(_spread("H", 2.0, 6), _spread("M", -1.0, 6)),
+        markets=("US", "IDX"),
+    )
+
+    idx = _cfind(report, "IDX", _RELATIVE_MOVE)
+    assert idx["trades"] == 0
+    assert idx["verdict"] == CANDIDATE_TOO_THIN
+    assert all(idx["groups"][g]["trades"] == 0 for g in GROUPS)
+
+
+def test_the_report_says_why_it_is_not_also_cut_per_year():
+    """The ranking reports per year and this does not, so the difference is stated
+    rather than left as an omission a reader has to notice."""
+    report = candidates_report(
+        DEFAULT_CONTRACT, _ccohort(_spread("H", 2.0, 6), _spread("M", -1.0, 6))
+    )
+
+    assert "per year" in report["not_cut_per_year"]
+    assert report["multiple_testing"]["intervals_reported"] >= 1
+
+
+def test_the_count_of_intervals_the_candidate_report_states_rides_on_it():
+    """Every group, gap and correlation is a claim at nominal alpha, so the budget
+    is counted rather than left for a reader to infer from the page's length."""
+    report = candidates_report(
+        DEFAULT_CONTRACT,
+        _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8)),
+        markets=("US",),
+    )
+
+    counted = 0
+    for body in report["markets"]:
+        for cell in body["candidates"]:
+            counted += sum(
+                1 for g in GROUPS
+                if cell["groups"][g]["bootstrap"]["ci_low"] is not None
+            )
+            counted += sum(
+                1
+                for key in ("gap", "rubric_reading", "value_correlation")
+                if cell[key]["bootstrap"]["ci_low"] is not None
+            )
+    assert report["multiple_testing"]["intervals_reported"] == counted
+
+
+def test_a_trade_with_no_persisted_detection_row_is_a_failure_not_a_drop():
+    """The join from trade to row is **total** or the denominator is broken.
+
+    Dropping an unmatched trade would shrink the cohort with nothing in the output
+    to say which trades left, and the ones most likely to go missing are not a
+    random sample.
+    """
+    with pytest.raises(ValueError, match="AAA"):
+        candidate_trades([_mtrade("AAA", 2016, 1.0)], {})
+
+
+def test_the_candidates_report_is_stamped_and_serialises():
+    """Stamped with the contract that produced it, like every other result in the
+    run, and JSON-clean so it can be committed beside them."""
+    report = candidates_report(
+        DEFAULT_CONTRACT, _ccohort(_spread("H", 2.0, 6), _spread("M", -1.0, 6))
+    )
+
+    assert report[CONTRACT_KEY] == DEFAULT_CONTRACT.to_dict()
+    assert json.loads(json.dumps(report)) == report
+
+
+def test_the_printed_page_shows_every_group_with_its_n_and_both_claims():
+    """A group's expectancy without its count is unreadable — six trades and six
+    hundred print the same number — and the selection contrast prints above the
+    outcome figures so a reader meets the older claim before the newer one."""
+    report = candidates_report(
+        DEFAULT_CONTRACT,
+        _ccohort(_spread("H", 2.0, 8), _spread("M", -1.0, 8), _spread("Z", 0.1, 3)),
+        markets=("US",),
+    )
+
+    page = format_candidates(report)
+
+    assert _RELATIVE_MOVE in page and _RS_LINE in page
+    assert "n=8" in page
+    assert "absent" in page
+    assert page.index("selection") < page.index("gap")
+
+
+def test_the_candidate_measurement_runs_off_the_denominator_end_to_end(
+    store, denominator
+):
+    """The seam that matters: persisted candidate values, the trades the simulator
+    took off the same detections, joined by the session they were decided on."""
+    _seed_figure_name(
+        store, denominator, "US", "AAA", date(2020, 1, 1), _FIG_FLAT + _FIG_WIN,
+        relative_move=+1.25,
+    )
+    trades = simulate_market(
+        store, denominator, "US", DEFAULT_CONTRACT, arms=(ARM_B,)
+    )
+
+    cohort = candidate_trades(trades, candidate_index(denominator, "US"))
+
+    assert [c.trade.symbol for c in cohort] == ["AAA"]
+    assert cohort[0].detection.relative_move == pytest.approx(1.25)
+    body = _cbody(cohort, _RELATIVE_MOVE)
+    assert body["groups"][GROUP_HIT]["trades"] == 1

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -2843,14 +2843,23 @@ def test_the_rs_line_does_not_move_a_replayed_star():
 
 def test_build_field_defaults_the_candidate_dimension_to_absent():
     """A caller with no index bars to hand builds the same field as before, with
-    every candidate reading ``False`` rather than raising."""
+    every candidate reading **absent** rather than raising.
+
+    Absent and not ``False``, which is what this defaulted to until #195 needed the
+    distinction to hold end to end: a caller that never computed the dimension has
+    not measured a decayed RS line, and a row saying ``False`` would put the whole
+    field on the miss side of a measurement that reports the two apart. The
+    reachable path always supplies a real value (:func:`session_rs_lines` keys
+    every detection), so this is the default made honest rather than a bug fixed —
+    but the honest default is the one that cannot lie if that path ever changes.
+    """
     dets = [_det("AAA", 6), _det("BBB", 3)]
 
     without = build_field(dets, [])
     with_rs = build_field(dets, [], rs_line_of={"AAA": True})
 
-    assert {d.symbol: d.rs_line for d in without} == {"AAA": False, "BBB": False}
-    assert {d.symbol: d.rs_line for d in with_rs} == {"AAA": True, "BBB": False}
+    assert {d.symbol: d.rs_line for d in without} == {"AAA": None, "BBB": None}
+    assert {d.symbol: d.rs_line for d in with_rs} == {"AAA": True, "BBB": None}
     # Supplying it changes neither the order nor the scores.
     assert [d.symbol for d in without] == [d.symbol for d in with_rs]
     assert [d.score for d in without] == [d.score for d in with_rs]
@@ -8326,10 +8335,10 @@ def test_the_report_says_why_the_states_are_not_also_cut_per_year(store):
 #   * **Clustered by symbol, as everywhere else.** A name detected three times in
 #     a fortnight is one observation's worth of independence, not three.
 
+from backtest.stats import MAX_UNDEFINED_SHARE, bootstrap_symbol_statistic
 from backtest.ranking import (
     APP_MAX_POINTS,
     IN_SAMPLE_GAP,
-    MAX_UNDEFINED_SHARE,
     SCORE_DIMENSIONS,
     SCORE_LABEL,
     SCORE_MAX_POINTS,
@@ -8342,14 +8351,12 @@ from backtest.ranking import (
     Band,
     ScoredTrade,
     bands,
-    bootstrap_symbol_statistic,
     check_seven_dimension_score,
     format_ranking,
     market_ranking,
     outcomes,
     rank_correlation,
     ranking_report,
-    score_index,
     scored_trades,
     symbol_clusters,
     top_minus_bottom,
@@ -8694,9 +8701,11 @@ def test_a_trade_with_no_score_row_is_a_failure_rather_than_a_silent_drop(store)
     the output to show which trades left.
     """
     trade = _mtrade("AAA", 2016, 1.0)
-    scores = {(trade.detection_session, "AAA"): _score(6)}
+    index = {(trade.detection_session, "AAA"): _cdetection("AAA", trade.detection_session)}
 
-    assert [s.score.points for s in scored_trades([trade], scores)] == [6]
+    assert [s.score.points for s in scored_trades([trade], index)] == [
+        _cdetection("AAA", trade.detection_session).score.points
+    ]
     with pytest.raises(ValueError):
         scored_trades([trade], {})
 
@@ -8846,7 +8855,7 @@ def test_the_ranking_runs_off_the_denominator_end_to_end(store, denominator):
     trades = simulate_market(
         store, denominator, "US", DEFAULT_CONTRACT, arms=(ARM_B,)
     )
-    scores = score_index(denominator, "US")
+    scores = detection_index(denominator, "US")
 
     cohort = scored_trades(trades, scores)
 
@@ -8904,8 +8913,7 @@ from backtest.candidates import (
     VERDICT_NO_EVIDENCE as CANDIDATE_NO_EVIDENCE,
     VERDICT_PREDICTS as CANDIDATE_PREDICTS,
     VERDICT_TOO_THIN as CANDIDATE_TOO_THIN,
-    CandidateTrade,
-    candidate_index,
+    DetectedTrade,
     candidate_trades,
     candidates_report,
     check_not_admitted,
@@ -8920,7 +8928,8 @@ from backtest.candidates import (
     split,
     value_correlation,
 )
-from backtest.ranking import spearman
+from backtest.cohort import detection_index
+from backtest.stats import spearman
 from replay.contrast import CANDIDATE_DIMENSIONS
 
 
@@ -8974,7 +8983,7 @@ def _ctrade(
     month: int = 3,
     market: str = "US",
     arm: str = ARM_B,
-) -> CandidateTrade:
+) -> DetectedTrade:
     """One arm-B trade beside the persisted row that produced it.
 
     Authored on :func:`_mtrade`, the metric section's own fixture, for the reason
@@ -8982,7 +8991,7 @@ def _ctrade(
     metric's way, and a second trade fixture would be a second cost model.
     """
     trade = _mtrade(symbol, year, r, market=market, arm=arm, month=month)
-    return CandidateTrade(
+    return DetectedTrade(
         trade=trade,
         detection=_cdetection(
             symbol, trade.detection_session,
@@ -8997,7 +9006,7 @@ def _ccohort(
     absent: dict[str, float] | None = None,
     *,
     market: str = "US",
-) -> list[CandidateTrade]:
+) -> list[DetectedTrade]:
     """A cohort split three ways on ``Relative move``'s stored value.
 
     A hit is a positive value, a miss a negative one, and an absent row carries
@@ -9019,7 +9028,7 @@ def _spread(prefix: str, r: float, n: int) -> dict[str, float]:
 
 
 def _cbody(
-    cohort: list[CandidateTrade], name: str, *, market: str = "US"
+    cohort: list[DetectedTrade], name: str, *, market: str = "US"
 ) -> dict[str, Any]:
     """One candidate's cell over one market — the shape most tests below read."""
     return market_candidate(
@@ -9487,9 +9496,51 @@ def test_the_candidate_measurement_runs_off_the_denominator_end_to_end(
         store, denominator, "US", DEFAULT_CONTRACT, arms=(ARM_B,)
     )
 
-    cohort = candidate_trades(trades, candidate_index(denominator, "US"))
+    cohort = candidate_trades(trades, detection_index(denominator, "US"))
 
     assert [c.trade.symbol for c in cohort] == ["AAA"]
     assert cohort[0].detection.relative_move == pytest.approx(1.25)
     body = _cbody(cohort, _RELATIVE_MOVE)
     assert body["groups"][GROUP_HIT]["trades"] == 1
+
+
+def test_a_row_that_never_computed_the_dimension_reads_absent_not_a_miss():
+    """The absence guard, followed one step further back than `group_of`.
+
+    `group_of` reads absence off the stored value, so its claim is only as good as
+    what the field wrote. A `ScoredDetection` built without the dimension computed
+    at all defaults its value to **absent** rather than to `False` — until #195
+    `rs_line` defaulted to `False`, which would have put a field nobody measured
+    entirely on the miss side of a measurement whose whole subject is telling the
+    two apart.
+    """
+    plain = build_field([_det("AAA", 6)], [])[0]
+
+    assert plain.rs_line is None
+    assert plain.relative_move is None
+    assert group_of(named_candidate(_RS_LINE), plain) == GROUP_ABSENT
+    assert group_of(named_candidate(_RELATIVE_MOVE), plain) == GROUP_ABSENT
+
+
+def test_the_page_says_what_adr_0005_recorded_not_only_that_nothing_shipped():
+    """"Not admitted" covers two different findings.
+
+    `RS line` was refused on a wrong-way gap; `Relative move` landed on its own
+    bound and the criteria failed to separate. A page printing only "not admitted"
+    would flatten a refusal and an unresolved threshold into one word, and the
+    second is the reason #195 exists.
+    """
+    report = candidates_report(
+        DEFAULT_CONTRACT,
+        _ccohort(_spread("H", 2.0, 6), _spread("M", -1.0, 6)),
+        markets=("US",),
+    )
+
+    page = format_candidates(report)
+
+    assert "criterion 4" in page
+    assert "on_the_bound" in page
+    assert (
+        _cfind(report, "US", _RELATIVE_MOVE)["selection_contrast"]["recorded_as"]
+        != _cfind(report, "US", _RS_LINE)["selection_contrast"]["recorded_as"]
+    )


### PR DESCRIPTION
Closes #195. PRD #182, Phase 5 — beside #194's ranking cell.

## What this measures

ADR 0005 admits a dimension on a **selection contrast**, because that was the only instrument that existed — its own "considered options" records an outcome regression as *not available*. Both registered candidates then hit the limits of it:

- `RS line` was refused on criterion 4 for a wrong-way Δ (§5d).
- `Relative move` came back positive on both fields and stalled **0.06pp** inside criterion 1's ~85% not-taken hit-rate ceiling (§5e) — a magnitude the ADR itself calls a judgement rather than a measurement, now deciding an admission by six hundredths of a point.

That threshold cannot be settled by the contrast that keeps colliding with it. This gives the same two dimensions an outcome variable instead: **R after costs**, on trades taken mechanically over two markets and fourteen years, which no rubric weight was fitted to and no detection could see.

## Acceptance criteria

- [x] Both registered candidates measured against outcomes, per market — the list is derived from `replay.contrast.CANDIDATES`, and a registration this module has no reader for is `ContractDrift` rather than a column quietly missing from a report still claiming to cover the register.
- [x] Value read off the persisted row, cut applied at read time — by the rubric's own reader, the same function the selection contrast reads, so no row is re-denominated and the two studies cannot disagree about which side of the line a row fell.
- [x] Absence handled as absence — its own group, its own n, and it enters no gap. Load-bearing rather than tidy: `Relative move`'s cut sits at **zero**, so an absence coerced to a number would land exactly on the boundary and let the strictness of a comparison decide a verdict nobody measured.
- [x] Reported separately from the selection contrast — §5d's and §5e's figures ride on every candidate's cell under their own `adr_0005_verdict` and `recorded_as` keys, beside a note on why neither claim converts into the other.
- [x] Neither dimension admitted — `check_not_admitted()` refuses the run if a candidate has entered the live rubric, so the criterion is executable rather than a sentence in a docstring.

## The verdict is the gap's alone

ADR 0005 admits a dimension **as a boolean**, so the boolean's gap is the only claim anything could act on. Spearman's rho against the stored degree is reported beside it and excluded — only `Relative move` persists a degree, so a rule reading rho would mean different things for the two dimensions. The `rubric_reading` gap (absence folded into the miss side, as the pre-registered readers score it) says what a *shipped* boolean would have done and is likewise outside the verdict.

## Review findings answered

Two parallel review axes ran against the first commit; `e50f130` answers both.

- **A threshold was attributed to the wrong criterion, at two sites.** The ~85% ceiling is criterion 1's, not criterion 2's, and the label inverted the sense — criterion 1 firing means *ship*. Both sites now say what §5e says: the ceiling and criterion 2's ~15% disagreement floor are one threshold read from two sides.
- **`ScoredDetection.rs_line` defaulted to `False`**, so a caller that never computed the dimension produced a field claiming every name was measured and decayed. The reachable path never does this, so it is a default made honest rather than a bug fixed — but the test covering it was already named `..._defaults_the_candidate_dimension_to_absent` while asserting `False`.
- **`Candidate` was a fourth name for something else one import away**, which the package docstring already legislates against → `CandidateDimension`, and `CandidateTrade` → `DetectedTrade`.
- **Two modules came out rather than being copied in.** `backtest.stats` holds the statistics with more than one caller; `backtest.cohort` holds the detection index and the total trade→row join. Leaving both in `ranking` made it a measurement *and* the run's statistics library — `ranking.py` sheds 262 lines.

## Not in this PR

No figures. `data/backtest.duckdb` holds bars and no replayed sessions, so there is no denominator to run this over yet — same position #194 shipped in. The run and its write-up are Phase 3 and Phase 7.

```
python -m backtest.candidates --store data/backtest.duckdb \
    --out-json references/backtest_candidate_outcomes.json
```

824 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TzKcv2nobNs8a2miB6SNA
