### PR TITLE
Attribute the in_field sign flip to two gates, and call it a property (#211)

### DIFF
--- a/backend/backtest/field_gate_isolation.py
+++ b/backend/backtest/field_gate_isolation.py
@@ -1,0 +1,895 @@
+"""Which gate reverses the rubric's edge inside the stateless field? (#211)
+
+#198 ran both markets end to end, then checked the six anchors against the run's
+own field. Five settle. ``in_field`` does not: it flips the sign of findings §4b's
+gap, from the committed **+1.95pp** to **−5.01pp**, and a sign flip is the one
+outcome the anchor table refuses to let a written cause waive
+(``references/backtest_anchor_divergence.md``).
+
+#198 isolated three suspects and cleared all three. The **bars**: of the 496 trades
+both stores can measure, all 496 carry bit-identical geometry. The **detector**:
+recall reproduces at 421/503 = 83.70% against the committed 83.69%. The
+**population**: hold the trade list fixed at the same 503 names, run the same grid
+over ``replay.duckdb`` under the app's universe, and the gap returns **+1.86** —
+the same sign as the pin and within a hair of it.
+
+What is left is the field. The run's field is built from the contract's stateless
+universe (:mod:`backtest.universe`), which differs from the app's by **more than one
+thing at a time**, and a compound explanation is not an explanation. This module
+takes the compound apart.
+
+**The direction the isolation runs.** #198's third measurement moves *towards* the
+app — a different store, a different universe. This module moves the other way and
+stays inside the run's own field: one store (``backtest.duckdb``), one population
+(the same 503 replayable trades), one detector, one window. The only thing that
+moves between cells is **which gates build the universe**, one gate at a time. A
+cell read against the baseline therefore differs from it by exactly one gate, which
+is what "attribute it to a gate rather than to the universe" requires.
+
+**Four gates, not three.** The divergence page names three differences from the
+app's universe — the ADR20 floor, the ADTV floor and the dropped hysteresis. There
+is a fourth, and it is the one the app has no counterpart for at all: the **trend
+gate**, ``close > SMA50`` (:func:`backtest.universe.passes_trend_gate`). The app's
+universe is liquidity, instrument type, listing age and density; it has neither a
+trend gate nor a volatility gate. So the trend gate is a variant here like the
+others, because a difference nobody listed is exactly the kind that ends up
+attributed to "the universe".
+
+**Dropping a gate needs a superset, so membership is rebuilt rather than read.**
+:func:`replay.gate_sweep.build_sweep_sessions` reads membership off the store's
+persisted ``universe`` rows, and those rows are the *intersection* of every gate.
+Adding a gate to them is a filter; **dropping** one admits names the run never
+stored, so this module recomputes membership from the candidate bars instead.
+
+That reconstruction is the load-bearing claim here, so it is checked rather than
+trusted, in two independent ways:
+
+- :func:`members_at` under the full gate set reproduces the store's own universe
+  rows **exactly** — same count, no extras, no omissions — on every measured
+  session (:func:`verify_reconstruction`, which :func:`run_isolation` stops on).
+- the gate predicates are pinned against :mod:`backtest.universe`'s own ``passes_*``
+  functions in the seam tests, over the same bars, so this module cannot drift from
+  the classifier it is standing in for.
+
+**The arithmetic is the classifier's, not an approximation of it.** Each window
+statistic is summed over its own slice, oldest bar first, exactly as
+:func:`screener.indicators.adr` and :func:`screener.indicators.sma` do — not
+differenced out of a running prefix sum, which would round differently and could
+move a name sitting exactly on a floor. Speed comes from computing each gate
+**once** per candidate and session rather than once per variant: the three
+predicates do not depend on which variant is being measured, so
+:func:`gate_flags_by_session` evaluates them in a single pass and every variant is
+then a boolean ``and`` over the same flags. That is also what makes "one variable
+moves" structural rather than merely intended — no variant can differ from another
+by a recomputation.
+
+**This module moves no constant.** Every gate here is evaluated at the contract's
+committed value; the variants differ only in which gates are *applied at all*.
+Restoring the sign by loosening a floor is explicitly not on the table (#211, ADR
+0002's evidence rule) — if a constant would have to move, that is the finding, and
+it is reported as one.
+
+**Read-only.** Membership is recomputed in memory and the ranks with it; nothing is
+written back to the store, and no live constant is assigned.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import json
+import time
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Callable, Mapping, Sequence
+
+from screener.bars import Bar
+from screener.detection import detect, detection_gate
+from screener.indicators import ADR_WINDOW
+from screener.ranks import rank_table
+from screener.store import Store
+from screener.universe import LIQUIDITY_WINDOW, is_common_stock
+
+from replay.caching_store import CachingStore
+from replay.discrimination_grid import (
+    DETECTORS,
+    DISCRIMINATION_STARS,
+    FIELD_SOURCES,
+    PUBLISHED_RUBRIC,
+    _cell_fields,
+    build_grid,
+    sessions_with_stored_ranks,
+)
+from replay.gate_sweep import SweepSession, gate_membership
+from replay.placement import field_match
+from replay.reference import (
+    DEFAULT_REFERENCE_JSON,
+    ExecutedTrade,
+    classify as classify_trades,
+    evaluation_session,
+    load_trades,
+)
+
+from .contract import DEFAULT_CONTRACT, UNIVERSE_LIQUIDITY_FLOOR_KEY, RunContract
+from .universe import ADR_FLOOR, TREND_WINDOW
+
+# The window the gate-dependent anchors were measured over, and the burn-in they
+# were measured with — the reference study's own window, restated here so a re-run
+# lands on #198's denominators rather than on a superset of them
+# (``backtest_anchor_divergence.md``, "The gate-dependent anchors").
+WINDOW_START = date(2019, 4, 1)
+WINDOW_END = date(2022, 12, 30)
+WINDOW_BURN_IN = 126
+
+# The market the reference set is traded on. IDX carries no executed trades, so the
+# anchor — and therefore this isolation — is a US measurement, and the contract's
+# IDX-only Rp 100 price trim never applies.
+ISOLATION_MARKET = "US"
+
+# The cell the anchor is quoted at: the live detector over the whole field
+# (``backtest_field_anchors.json``, ``detector_version: 3``, ``field: "whole"``).
+ANCHOR_DETECTOR = 3
+ANCHOR_FIELD = "whole"
+
+
+# -- the gates, as a set that can have one member removed ---------------------
+
+# The three gates :mod:`backtest.universe` intersects on US, named so a variant can
+# drop exactly one.
+TREND, ADR, LIQUIDITY = "trend", "adr", "liquidity"
+ALL_GATES = frozenset({TREND, ADR, LIQUIDITY})
+
+
+@dataclass(frozen=True)
+class GateVariant:
+    """One universe rule: the run's gates, minus at most one of them.
+
+    ``dropped`` is the whole point — a variant that drops nothing is the run's own
+    field and is the baseline every other cell is read against. Because exactly one
+    gate separates any variant from that baseline, a difference between them
+    attributes to that gate and to nothing else.
+    """
+
+    name: str
+    gates: frozenset[str]
+    note: str
+
+    @property
+    def dropped(self) -> frozenset[str]:
+        return ALL_GATES - self.gates
+
+
+# The baseline first, then one variant per gate. Each note says what the app's
+# universe does with the same gate, because the divergence being explained is
+# against the app's field.
+VARIANTS: tuple[GateVariant, ...] = (
+    GateVariant(
+        "all-three",
+        ALL_GATES,
+        "the run's own field — reproduces the committed -5.01pp",
+    ),
+    GateVariant(
+        "no-adr",
+        ALL_GATES - {ADR},
+        "drops the 3.5% ADR20 floor, which the app's universe does not have",
+    ),
+    GateVariant(
+        "no-trend",
+        ALL_GATES - {TREND},
+        "drops close > SMA50, which the app's universe does not have",
+    ),
+    GateVariant(
+        "no-liquidity",
+        ALL_GATES - {LIQUIDITY},
+        "drops the $10M ADTV floor, which the app sets at $20M instead",
+    ),
+    # The one two-gate cell, and it is here because the single drops above do not
+    # answer the question: none of them restores the sign, so "which gate" has no
+    # single-gate answer and the next thing to ask is whether *any* gate set does.
+    # This is the app's shape reached from inside the run's own field — liquidity
+    # alone, without the two gates the app has no counterpart for — so it separates
+    # "those two jointly" from "the field is narrow at all".
+    GateVariant(
+        "liquidity-only",
+        frozenset({LIQUIDITY}),
+        "drops both gates the app lacks, keeping only a liquidity floor",
+    ),
+)
+
+
+# -- one candidate's gate inputs ----------------------------------------------
+
+
+def _median(values: Sequence[float]) -> float:
+    """:func:`screener.universe._median`, which is private and must not be forked.
+
+    Restated rather than imported because it is not part of that module's surface;
+    a seam test pins the two against each other so this copy cannot drift.
+    """
+    n = len(values)
+    if n == 0:
+        return 0.0
+    ordered = sorted(values)
+    mid = n // 2
+    if n % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+@dataclass(frozen=True)
+class CandidateSeries:
+    """One candidate's gate inputs, held as parallel lists over its clean bars.
+
+    ``sessions`` is the symbol's bar calendar, oldest first, and every other list is
+    parallel to it. A session becomes an index ``k`` through :meth:`prefix_len` —
+    the number of bars strictly *before* it — so every gate reads ``[...k]`` and the
+    point-in-time claim is made in one place, exactly as
+    :func:`backtest.universe.is_member` makes it with a slice.
+
+    ``day_range`` holds ``None`` where a bar's low is non-positive, which is a
+    division the classifier would not survive. Two US symbols carry one such bar
+    each. ``None`` is not skipped and not treated as zero: a window containing one
+    **fails** the ADR gate, so a corrupt row can only ever exclude a name, never
+    admit one.
+    """
+
+    symbol: str
+    sessions: tuple[date, ...]
+    adj_close: tuple[float, ...]
+    day_range: tuple[float | None, ...]
+    dollar_volume: tuple[float, ...]
+
+    def prefix_len(self, session: date) -> int:
+        """How many bars fall strictly before ``session`` (``b.session < session``)."""
+        return bisect.bisect_left(self.sessions, session)
+
+    def passes_trend(self, k: int) -> bool:
+        """Latest adjusted close above SMA50 — :func:`backtest.universe.passes_trend_gate`.
+
+        ``False`` until 50 bars exist, which is where the listing-age floor actually
+        lives: :func:`screener.indicators.sma` returns ``None`` until its window is
+        full.
+        """
+        if k < TREND_WINDOW:
+            return False
+        window = self.adj_close[k - TREND_WINDOW:k]
+        return self.adj_close[k - 1] > sum(window) / TREND_WINDOW
+
+    def passes_adr(self, k: int) -> bool:
+        """ADR20 at or above the contract's 3.5% — :func:`backtest.universe.passes_adr_gate`."""
+        if k < ADR_WINDOW:
+            return False
+        window = self.day_range[k - ADR_WINDOW:k]
+        if None in window:
+            return False
+        return sum(window) / ADR_WINDOW >= ADR_FLOOR
+
+    def passes_liquidity(self, k: int, floor: float) -> bool:
+        """Median dollar volume at or above ``floor`` — the app's own measure.
+
+        Deliberately **not** gated on a full window, because
+        :func:`screener.universe.median_dollar_volume` is not: it medians whatever
+        the trailing 20 bars hold and returns ``0.0`` from none. That is unreachable
+        while the trend gate is in force — it needs 50 bars — and reachable the
+        moment the ``no-trend`` variant drops it, so copying the app's shortfall
+        behaviour rather than tidying it is what keeps that variant honest.
+        """
+        return _median(self.dollar_volume[max(0, k - LIQUIDITY_WINDOW):k]) >= floor
+
+    def flags(self, session: date, floor: float) -> tuple[bool, bool, bool] | None:
+        """The three gate answers at ``session``, or ``None`` if no variant can pass.
+
+        Computed once and shared by every variant, which is what keeps the variants
+        differing by their gate set alone. ``None`` means the candidate is out under
+        *every* variant — it is not common stock, or it has no bars yet — so no
+        variant has to represent it.
+        """
+        if not is_common_stock(self.symbol, ""):
+            return None
+        k = self.prefix_len(session)
+        if k == 0:
+            return None
+        return (
+            self.passes_trend(k),
+            self.passes_adr(k),
+            self.passes_liquidity(k, floor),
+        )
+
+    def is_member(self, session: date, gates: frozenset[str], floor: float) -> bool:
+        """Is this candidate a member on ``session`` under ``gates``?
+
+        The instrument-type test is not a variant — it is not one of the three gates
+        under investigation and no cell drops it. It is applied on the symbol with an
+        empty name, which is what :func:`backtest.chain.stateless_universe` does for
+        a name the store did not keep: the listing-name half of the test was already
+        spent at enumeration (symbols excluded ``not_common_stock`` never had bars
+        fetched), leaving the symbol half — the index mark and the preferred series —
+        which is what still has to bite here.
+        """
+        flags = self.flags(session, floor)
+        if flags is None:
+            return False
+        return passes_under(flags, gates)
+
+
+def passes_under(flags: tuple[bool, bool, bool], gates: frozenset[str]) -> bool:
+    """Do ``flags`` clear ``gates``? The only place a variant's rule is applied."""
+    trend, adr, liquidity = flags
+    return (
+        (trend or TREND not in gates)
+        and (adr or ADR not in gates)
+        and (liquidity or LIQUIDITY not in gates)
+    )
+
+
+def series_of(symbol: str, bars: Sequence[Bar]) -> CandidateSeries | None:
+    """``bars`` as gate-input lists, or ``None`` for a symbol with no bars."""
+    if not bars:
+        return None
+    return CandidateSeries(
+        symbol=symbol,
+        sessions=tuple(b.session for b in bars),
+        adj_close=tuple(b.adj_close for b in bars),
+        day_range=tuple(
+            (b.high / b.low - 1.0) if b.low > 0 else None for b in bars
+        ),
+        dollar_volume=tuple(b.close * b.volume for b in bars),
+    )
+
+
+def load_series(store: Store, market: str) -> dict[str, CandidateSeries]:
+    """Every candidate's gate inputs, loaded once for the whole isolation.
+
+    The pool is :meth:`screener.store.Store.symbols` — every name the store holds
+    bars for — and the equality in :func:`verify_reconstruction` is what proves that
+    is the right pool: references were never fetched (they carry the enumeration
+    reason ``unread_reference``), so a symbol with bars in this store is a candidate.
+    Read off the stored bars rather than off the enumeration JSON, so the pool cannot
+    drift from the bars the gates are computed on.
+    """
+    out: dict[str, CandidateSeries] = {}
+    for symbol in store.symbols(market):
+        s = series_of(symbol, store.bars(market, symbol))
+        if s is not None:
+            out[symbol] = s
+    return out
+
+
+# -- membership, for one variant and for all of them at once ------------------
+
+
+def members_at(
+    series: Mapping[str, CandidateSeries],
+    session: date,
+    gates: frozenset[str],
+    floor: float,
+) -> list[str]:
+    """The sorted members on ``session`` under ``gates`` — one variant's universe.
+
+    Sorted, like :func:`backtest.universe.classify`, so a membership is comparable to
+    the store's own rows without either side being re-ordered first.
+    """
+    return sorted(
+        symbol for symbol, s in series.items() if s.is_member(session, gates, floor)
+    )
+
+
+def gate_flags_by_session(
+    series: Mapping[str, CandidateSeries],
+    sessions: Sequence[date],
+    floor: float,
+    progress: Callable[[int, int], None] | None = None,
+) -> list[dict[str, tuple[bool, bool, bool]]]:
+    """Every candidate's three gate answers, per session, computed once.
+
+    The single expensive pass of the isolation, and the reason every variant after it
+    is cheap: the predicates do not depend on the variant, so they are evaluated here
+    and each variant is a boolean ``and`` over the same flags
+    (:func:`memberships_under`). Candidates no variant can admit are absent rather
+    than stored as three ``False`` flags.
+    """
+    out: list[dict[str, tuple[bool, bool, bool]]] = []
+    for i, session in enumerate(sessions, start=1):
+        per_session: dict[str, tuple[bool, bool, bool]] = {}
+        for symbol, s in series.items():
+            flags = s.flags(session, floor)
+            if flags is not None and any(flags):
+                per_session[symbol] = flags
+        out.append(per_session)
+        if progress is not None:
+            progress(i, len(sessions))
+    return out
+
+
+def memberships_under(
+    flags_by_session: Sequence[Mapping[str, tuple[bool, bool, bool]]],
+    gates: frozenset[str],
+) -> list[list[str]]:
+    """One variant's membership on every session, derived from the shared flags."""
+    return [
+        sorted(sym for sym, f in per_session.items() if passes_under(f, gates))
+        for per_session in flags_by_session
+    ]
+
+
+# -- checking the reconstruction against the store ----------------------------
+
+
+@dataclass(frozen=True)
+class ReconstructionCheck:
+    """How the rebuilt full-gate membership compares to the store's own rows."""
+
+    sessions: int
+    stored: int
+    rebuilt: int
+    extra: int
+    missing: int
+    worst_session: date | None
+
+    @property
+    def exact(self) -> bool:
+        return self.extra == 0 and self.missing == 0
+
+
+def verify_reconstruction(
+    store: Store,
+    market: str,
+    sessions: Sequence[date],
+    memberships: Sequence[Sequence[str]],
+) -> ReconstructionCheck:
+    """Diff the rebuilt full-gate membership against the store's own universe rows.
+
+    This is the check the whole isolation rests on. If it is not exact, no variant
+    below means anything — a gate-drop measured off a pool that does not reproduce
+    the run's own field is measuring the pool, not the gate — so
+    :func:`run_isolation` stops on it rather than reporting cells.
+    """
+    stored_total = rebuilt_total = extra = missing = 0
+    worst: date | None = None
+    worst_diff = 0
+    for session, rebuilt_syms in zip(sessions, memberships):
+        stored = set(store.universe(market, session))
+        rebuilt = set(rebuilt_syms)
+        stored_total += len(stored)
+        rebuilt_total += len(rebuilt)
+        e, m = len(rebuilt - stored), len(stored - rebuilt)
+        extra += e
+        missing += m
+        if e + m > worst_diff:
+            worst_diff, worst = e + m, session
+    return ReconstructionCheck(
+        sessions=len(sessions),
+        stored=stored_total,
+        rebuilt=rebuilt_total,
+        extra=extra,
+        missing=missing,
+        worst_session=worst,
+    )
+
+
+# -- one variant's field, and the pair measured on it -------------------------
+
+
+def variant_sweep(
+    store: Store,
+    market: str,
+    sessions: Sequence[date],
+    memberships: Sequence[Sequence[str]],
+    *,
+    lookbacks: Sequence[str],
+    progress: Callable[[int, int, date], None] | None = None,
+) -> list[SweepSession]:
+    """:func:`replay.gate_sweep.build_sweep_sessions`, with membership handed in.
+
+    The one line that differs from the original is where ``members`` comes from —
+    this variant's gates rather than ``store.universe`` — and everything downstream
+    of it (the rank table, the decile gate, the detector) is the app's own code
+    reached the same way. So a cell measured here differs from the run's own field by
+    the membership rule and by nothing else.
+    """
+    out: list[SweepSession] = []
+    for i, (session, members) in enumerate(zip(sessions, memberships), start=1):
+        members = list(members)
+        bars = {symbol: store.bars(market, symbol) for symbol in members}
+        ranks = rank_table(bars, session)
+        gated = detection_gate(ranks, lookbacks=lookbacks)
+        detections = [
+            found
+            for symbol in members
+            if symbol in gated
+            and (found := detect(symbol, bars[symbol], session)) is not None
+        ]
+        out.append(
+            SweepSession(
+                session=session,
+                members=members,
+                ranks=ranks,
+                membership=gate_membership(ranks),
+                detections=detections,
+            )
+        )
+        if progress is not None:
+            progress(i, len(sessions), session)
+    return out
+
+
+@dataclass(frozen=True)
+class DimensionContrast:
+    """One rubric dimension's hit rate among his picks and among the field.
+
+    The star share is a threshold statistic, so it says *that* the pair moved and not
+    *which* part of the rubric moved it. These rows say which: a gate that duplicates
+    a dimension raises the **field's** hit rate on it until there is no spread left to
+    discriminate on, and that shows up here as a dimension's gap collapsing while the
+    dimensions no gate touches stay put.
+    """
+
+    dimension: str
+    weight: int
+    picks: float
+    field: float
+
+    @property
+    def gap_pp(self) -> float:
+        return (self.picks - self.field) * 100
+
+
+@dataclass(frozen=True)
+class VariantResult:
+    """One variant's cell at the anchor's detector and field."""
+
+    variant: GateVariant
+    members_per_session: float
+    field_detections: int
+    in_field: int
+    placed: int
+    picks_share: float | None
+    field_share: float | None
+    gap_pp: float | None
+    dimensions: tuple[DimensionContrast, ...]
+    seconds: float
+
+    @property
+    def in_field_share(self) -> float | None:
+        return self.in_field / self.placed if self.placed else None
+
+
+def dimension_contrasts(
+    swept: Sequence[SweepSession],
+    *,
+    replayable: Sequence[ExecutedTrade],
+    calendar: Sequence[date],
+    stored_rank_sessions: set[date],
+) -> tuple[DimensionContrast, ...]:
+    """Per-dimension hit rates for his picks and for the field, on the same cell.
+
+    Reuses the sweep the cell was measured on rather than replaying, so this costs
+    scoring and nothing else. The field is restricted to the sessions he traded on —
+    the same denominator :func:`replay.placement.build_placement_report` uses for its
+    star distributions, so these rows and the cell's pair describe one population.
+
+    The breakdown is the **seven-dimension replayed score**: `Sector` is
+    cross-sectional and is not reconstructed on this path, exactly as in the replay
+    study. It is absent rather than reported as zero.
+    """
+    entries: dict[date, set[str]] = {}
+    for t in replayable:
+        entries.setdefault(t.entry_date, set()).add(t.ticker)
+    fields = _cell_fields(
+        swept,
+        DETECTORS[ANCHOR_DETECTOR],
+        next(f for f in FIELD_SOURCES if f.name == ANCHOR_FIELD),
+        entries=entries,
+        stored_rank_sessions=stored_rank_sessions,
+        blind_spot_count=0,
+    )
+    by_session = {f.session: f for f in fields}
+
+    pick_rows, pick_sessions = [], set()
+    for trade in replayable:
+        session = evaluation_session(list(calendar), trade.entry_date)
+        held = by_session.get(session) if session else None
+        if held is None:
+            continue
+        pick_sessions.add(held.session)
+        match = field_match(held, trade.ticker)
+        if match is not None:
+            pick_rows.append(match.score.breakdown)
+    field_rows = [
+        d.score.breakdown for s in pick_sessions for d in by_session[s].detections
+    ]
+    if not pick_rows or not field_rows:
+        return ()
+    return tuple(
+        DimensionContrast(
+            dimension=row.dimension,
+            weight=row.weight,
+            picks=sum(1 for b in pick_rows if b[i].hit) / len(pick_rows),
+            field=sum(1 for b in field_rows if b[i].hit) / len(field_rows),
+        )
+        for i, row in enumerate(pick_rows[0])
+    )
+
+
+def measure_variant(
+    store: Store,
+    market: str,
+    sessions: Sequence[date],
+    memberships: Sequence[Sequence[str]],
+    *,
+    variant: GateVariant,
+    replayable: Sequence[ExecutedTrade],
+    calendar: Sequence[date],
+    blind_spot_count: int = 0,
+    progress: Callable[[int, int, date], None] | None = None,
+) -> VariantResult:
+    """Build ``variant``'s field over ``sessions`` and read the anchor's cell off it."""
+    started = time.time()
+    union = tuple(
+        dict.fromkeys(lb for version in DETECTORS for lb in DETECTORS[version].lookbacks)
+    )
+    swept = variant_sweep(
+        store, market, sessions, memberships, lookbacks=union, progress=progress
+    )
+    field = next(f for f in FIELD_SOURCES if f.name == ANCHOR_FIELD)
+    stored_ranks = sessions_with_stored_ranks(store, market, sessions)
+    grid = build_grid(
+        swept,
+        replayable=replayable,
+        calendar=calendar,
+        stored_rank_sessions=stored_ranks,
+        blind_spot_count=blind_spot_count,
+        grid=[(ANCHOR_DETECTOR, field)],
+    )
+    cell = grid.cells[0]
+    picks, field_share = cell.discrimination(PUBLISHED_RUBRIC)
+    return VariantResult(
+        variant=variant,
+        members_per_session=sum(len(s.members) for s in swept) / len(swept),
+        field_detections=cell.field_detections,
+        in_field=cell.in_field,
+        placed=cell.placed,
+        picks_share=picks,
+        field_share=field_share,
+        gap_pp=cell.edge(PUBLISHED_RUBRIC),
+        dimensions=dimension_contrasts(
+            swept,
+            replayable=replayable,
+            calendar=calendar,
+            stored_rank_sessions=stored_ranks,
+        ),
+        seconds=time.time() - started,
+    )
+
+
+# -- the whole isolation ------------------------------------------------------
+
+
+class ReconstructionFailed(RuntimeError):
+    """The full-gate rebuild did not reproduce the store's universe rows."""
+
+
+@dataclass(frozen=True)
+class Isolation:
+    check: ReconstructionCheck
+    results: tuple[VariantResult, ...]
+
+    def by_name(self, name: str) -> VariantResult:
+        return next(r for r in self.results if r.variant.name == name)
+
+
+def run_isolation(
+    store: Store,
+    market: str = ISOLATION_MARKET,
+    *,
+    contract: RunContract = DEFAULT_CONTRACT,
+    trades: Sequence[ExecutedTrade] | None = None,
+    variants: Sequence[GateVariant] = VARIANTS,
+    sessions: Sequence[date] | None = None,
+    progress: Callable[[str], None] | None = None,
+) -> Isolation:
+    """Measure every variant over one shared pass of the gate predicates.
+
+    Stops on a reconstruction that is not exact, rather than reporting cells that
+    would be measuring the candidate pool instead of the gates.
+    """
+    say = progress or (lambda _m: None)
+    store = CachingStore.wrap(store)
+    floor = contract.value(UNIVERSE_LIQUIDITY_FLOOR_KEY)[market]
+    calendar = store.sessions(market)
+    measured = (
+        list(sessions)
+        if sessions is not None
+        else [s for s in calendar if WINDOW_START <= s <= WINDOW_END][WINDOW_BURN_IN:]
+    )
+    trades = list(trades) if trades is not None else load_trades(DEFAULT_REFERENCE_JSON)
+    replayable = [
+        c.trade for c in classify_trades(trades, store, market=market) if c.replayable
+    ]
+    say(f"{len(measured)} measured sessions, {measured[0]} .. {measured[-1]}; "
+        f"{len(replayable)} of {len(trades)} trades replayable; "
+        f"liquidity floor {floor:,.0f}")
+
+    say("loading candidate series ...")
+    series = load_series(store, market)
+    say(f"  {len(series)} candidates with bars")
+
+    say("evaluating every gate once per candidate and session ...")
+    started = time.time()
+    flags = gate_flags_by_session(series, measured, floor)
+    say(f"  done in {time.time() - started:.0f}s")
+
+    by_variant = {v.name: memberships_under(flags, v.gates) for v in variants}
+
+    say("checking the full-gate rebuild against the store's own universe rows ...")
+    baseline = memberships_under(flags, ALL_GATES)
+    check = verify_reconstruction(store, market, measured, baseline)
+    say(f"  stored {check.stored}, rebuilt {check.rebuilt}, "
+        f"extra {check.extra}, missing {check.missing} -> "
+        f"{'EXACT' if check.exact else 'MISMATCH'}")
+    if not check.exact:
+        raise ReconstructionFailed(
+            f"the full-gate rebuild does not reproduce the store's universe: "
+            f"{check.extra} extra and {check.missing} missing across "
+            f"{check.sessions} sessions (worst {check.worst_session}). "
+            f"No gate can be isolated against a pool that does not reproduce the run."
+        )
+
+    results = []
+    for variant in variants:
+        say(f"measuring {variant.name} ({variant.note}) ...")
+        r = measure_variant(
+            store, market, measured, by_variant[variant.name],
+            variant=variant, replayable=replayable, calendar=calendar,
+        )
+        say(f"  members/session {r.members_per_session:.1f}  "
+            f"in_field {r.in_field}/{r.placed}  gap {_pp(r.gap_pp)}  "
+            f"[{r.seconds:.0f}s]")
+        results.append(r)
+    return Isolation(check=check, results=tuple(results))
+
+
+# -- reporting ----------------------------------------------------------------
+
+
+def _pp(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:+.2f}pp"
+
+
+def _pct(value: float | None) -> str:
+    return "n/a" if value is None else f"{value * 100:.2f}%"
+
+
+def format_isolation(isolation: Isolation) -> str:
+    """The isolation as a table, baseline first, one gate dropped per row."""
+    c = isolation.check
+    lines = [
+        "The gate isolation (#211) — one store, one population, one detector,",
+        "one gate moving at a time.",
+        "",
+        f"Full-gate rebuild vs the store's own universe rows: stored {c.stored}, "
+        f"rebuilt {c.rebuilt}, extra {c.extra}, missing {c.missing}, "
+        f"over {c.sessions} sessions -> {'EXACT' if c.exact else 'MISMATCH'}",
+        "",
+        f"{'variant':<14} {'members/sess':>12} {'field det':>10} "
+        f"{'in_field':>12} {'picks':>8} {'field':>8} {'gap':>9}",
+    ]
+    for r in isolation.results:
+        lines.append(
+            f"{r.variant.name:<14} {r.members_per_session:>12.1f} "
+            f"{r.field_detections:>10} "
+            f"{f'{r.in_field}/{r.placed}':>12} "
+            f"{_pct(r.picks_share):>8} {_pct(r.field_share):>8} "
+            f"{_pp(r.gap_pp):>9}"
+        )
+    lines += ["", "notes:"]
+    for r in isolation.results:
+        lines.append(f"  {r.variant.name:<14} {r.variant.note}")
+    lines += [
+        "",
+        f"picks/field are the share reaching >= {DISCRIMINATION_STARS} stars under "
+        f"rubric v{PUBLISHED_RUBRIC}; gap is picks - field.",
+        "",
+        "Per-dimension hit rates, his picks against the field on the sessions he traded.",
+        "A gate that duplicates a dimension shows up as that dimension's gap collapsing",
+        "while the dimensions no gate touches stay put. Seven-dimension replayed score:",
+        "`Sector` is cross-sectional and is not reconstructed on this path.",
+    ]
+    for r in isolation.results:
+        if not r.dimensions:
+            continue
+        lines += ["", f"  {r.variant.name}"]
+        lines.append(
+            f"    {'dimension':<13}{'wt':>3}{'picks':>9}{'field':>9}{'gap':>10}"
+        )
+        for d in r.dimensions:
+            lines.append(
+                f"    {d.dimension:<13}{d.weight:>3}{d.picks * 100:>8.1f}%"
+                f"{d.field * 100:>8.1f}%{d.gap_pp:>+9.1f}pp"
+            )
+    return "\n".join(lines)
+
+
+def isolation_payload(isolation: Isolation) -> dict:
+    return {
+        "window": {
+            "start": WINDOW_START.isoformat(),
+            "end": WINDOW_END.isoformat(),
+            "burn_in": WINDOW_BURN_IN,
+            "market": ISOLATION_MARKET,
+        },
+        "detector_version": ANCHOR_DETECTOR,
+        "field": ANCHOR_FIELD,
+        "rubric_version": PUBLISHED_RUBRIC,
+        "stars": DISCRIMINATION_STARS,
+        "reconstruction": {
+            "sessions": isolation.check.sessions,
+            "stored": isolation.check.stored,
+            "rebuilt": isolation.check.rebuilt,
+            "extra": isolation.check.extra,
+            "missing": isolation.check.missing,
+            "exact": isolation.check.exact,
+        },
+        "variants": [
+            {
+                "name": r.variant.name,
+                "gates": sorted(r.variant.gates),
+                "dropped": sorted(r.variant.dropped),
+                "note": r.variant.note,
+                "members_per_session": r.members_per_session,
+                "field_detections": r.field_detections,
+                "in_field": r.in_field,
+                "placed": r.placed,
+                "in_field_share": r.in_field_share,
+                "picks_share": r.picks_share,
+                "field_share": r.field_share,
+                "gap_pp": r.gap_pp,
+                "dimensions": [
+                    {
+                        "dimension": d.dimension,
+                        "weight": d.weight,
+                        "picks": d.picks,
+                        "field": d.field,
+                        "gap_pp": d.gap_pp,
+                    }
+                    for d in r.dimensions
+                ],
+            }
+            for r in isolation.results
+        ],
+    }
+
+
+DEFAULT_OUT_JSON = (
+    Path(__file__).resolve().parents[2] / "references" / "backtest_gate_isolation.json"
+)
+DEFAULT_OUT_TXT = (
+    Path(__file__).resolve().parents[2] / "references" / "backtest_gate_isolation.txt"
+)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="The #211 gate isolation.")
+    parser.add_argument("--store", default="data/backtest.duckdb")
+    parser.add_argument("--market", default=ISOLATION_MARKET)
+    parser.add_argument("--out-json", default=str(DEFAULT_OUT_JSON))
+    parser.add_argument("--out-txt", default=str(DEFAULT_OUT_TXT))
+    args = parser.parse_args(argv)
+
+    def say(message: str) -> None:
+        print(message, flush=True)
+
+    isolation = run_isolation(Store.open(args.store), args.market, progress=say)
+    report = format_isolation(isolation)
+    print()
+    print(report)
+    Path(args.out_json).write_text(
+        json.dumps(isolation_payload(isolation), indent=1) + "\n"
+    )
+    Path(args.out_txt).write_text(report + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/backtest/field_gate_isolation.py
+++ b/backend/backtest/field_gate_isolation.py
@@ -39,7 +39,9 @@ attributed to "the universe".
 :func:`replay.gate_sweep.build_sweep_sessions` reads membership off the store's
 persisted ``universe`` rows, and those rows are the *intersection* of every gate.
 Adding a gate to them is a filter; **dropping** one admits names the run never
-stored, so this module recomputes membership from the candidate bars instead.
+stored, so this module recomputes membership from the candidate bars and hands it
+to that same function through its ``members_for`` hook. The sweep itself — ranks,
+decile gate, detector — is not reimplemented here.
 
 That reconstruction is the load-bearing claim here, so it is checked rather than
 trusted, in two independent ways:
@@ -89,7 +91,11 @@ from screener.detection import detect, detection_gate
 from screener.indicators import ADR_WINDOW
 from screener.ranks import rank_table
 from screener.store import Store
-from screener.universe import LIQUIDITY_WINDOW, is_common_stock
+from screener.universe import (
+    LIQUIDITY_WINDOW,
+    _median as app_median,
+    is_common_stock,
+)
 
 from replay.caching_store import CachingStore
 from replay.discrimination_grid import (
@@ -101,7 +107,7 @@ from replay.discrimination_grid import (
     build_grid,
     sessions_with_stored_ranks,
 )
-from replay.gate_sweep import SweepSession, gate_membership
+from replay.gate_sweep import SweepSession, build_sweep_sessions
 from replay.placement import field_match
 from replay.reference import (
     DEFAULT_REFERENCE_JSON,
@@ -136,13 +142,16 @@ ANCHOR_FIELD = "whole"
 # -- the gates, as a set that can have one member removed ---------------------
 
 # The three gates :mod:`backtest.universe` intersects on US, named so a variant can
-# drop exactly one.
-TREND, ADR, LIQUIDITY = "trend", "adr", "liquidity"
-ALL_GATES = frozenset({TREND, ADR, LIQUIDITY})
+# drop exactly one. The middle one is ``VOLATILITY`` rather than ``ADR`` because that
+# is what the contract calls it (``universe.volatility_gate``) and because ADR is the
+# *quantity* it is measured with — this module also imports ``ADR_FLOOR`` and
+# ``ADR_WINDOW``, and one label cannot mean both the gate and the number.
+TREND, VOLATILITY, LIQUIDITY = "trend", "volatility", "liquidity"
+ALL_GATES = frozenset({TREND, VOLATILITY, LIQUIDITY})
 
 
 @dataclass(frozen=True)
-class GateVariant:
+class UniverseGateSet:
     """One universe rule: the run's gates, minus at most one of them.
 
     ``dropped`` is the whole point — a variant that drops nothing is the run's own
@@ -163,23 +172,23 @@ class GateVariant:
 # The baseline first, then one variant per gate. Each note says what the app's
 # universe does with the same gate, because the divergence being explained is
 # against the app's field.
-VARIANTS: tuple[GateVariant, ...] = (
-    GateVariant(
+VARIANTS: tuple[UniverseGateSet, ...] = (
+    UniverseGateSet(
         "all-three",
         ALL_GATES,
         "the run's own field — reproduces the committed -5.01pp",
     ),
-    GateVariant(
+    UniverseGateSet(
         "no-adr",
-        ALL_GATES - {ADR},
+        ALL_GATES - {VOLATILITY},
         "drops the 3.5% ADR20 floor, which the app's universe does not have",
     ),
-    GateVariant(
+    UniverseGateSet(
         "no-trend",
         ALL_GATES - {TREND},
         "drops close > SMA50, which the app's universe does not have",
     ),
-    GateVariant(
+    UniverseGateSet(
         "no-liquidity",
         ALL_GATES - {LIQUIDITY},
         "drops the $10M ADTV floor, which the app sets at $20M instead",
@@ -190,7 +199,7 @@ VARIANTS: tuple[GateVariant, ...] = (
     # This is the app's shape reached from inside the run's own field — liquidity
     # alone, without the two gates the app has no counterpart for — so it separates
     # "those two jointly" from "the field is narrow at all".
-    GateVariant(
+    UniverseGateSet(
         "liquidity-only",
         frozenset({LIQUIDITY}),
         "drops both gates the app lacks, keeping only a liquidity floor",
@@ -199,22 +208,6 @@ VARIANTS: tuple[GateVariant, ...] = (
 
 
 # -- one candidate's gate inputs ----------------------------------------------
-
-
-def _median(values: Sequence[float]) -> float:
-    """:func:`screener.universe._median`, which is private and must not be forked.
-
-    Restated rather than imported because it is not part of that module's surface;
-    a seam test pins the two against each other so this copy cannot drift.
-    """
-    n = len(values)
-    if n == 0:
-        return 0.0
-    ordered = sorted(values)
-    mid = n // 2
-    if n % 2:
-        return ordered[mid]
-    return (ordered[mid - 1] + ordered[mid]) / 2
 
 
 @dataclass(frozen=True)
@@ -275,7 +268,7 @@ class CandidateSeries:
         moment the ``no-trend`` variant drops it, so copying the app's shortfall
         behaviour rather than tidying it is what keeps that variant honest.
         """
-        return _median(self.dollar_volume[max(0, k - LIQUIDITY_WINDOW):k]) >= floor
+        return app_median(self.dollar_volume[max(0, k - LIQUIDITY_WINDOW):k]) >= floor
 
     def flags(self, session: date, floor: float) -> tuple[bool, bool, bool] | None:
         """The three gate answers at ``session``, or ``None`` if no variant can pass.
@@ -315,10 +308,10 @@ class CandidateSeries:
 
 def passes_under(flags: tuple[bool, bool, bool], gates: frozenset[str]) -> bool:
     """Do ``flags`` clear ``gates``? The only place a variant's rule is applied."""
-    trend, adr, liquidity = flags
+    trend, volatility, liquidity = flags
     return (
         (trend or TREND not in gates)
-        and (adr or ADR not in gates)
+        and (volatility or VOLATILITY not in gates)
         and (liquidity or LIQUIDITY not in gates)
     )
 
@@ -480,38 +473,23 @@ def variant_sweep(
     lookbacks: Sequence[str],
     progress: Callable[[int, int, date], None] | None = None,
 ) -> list[SweepSession]:
-    """:func:`replay.gate_sweep.build_sweep_sessions`, with membership handed in.
+    """This variant's field, through the sweep the run's own field is built with.
 
-    The one line that differs from the original is where ``members`` comes from —
-    this variant's gates rather than ``store.universe`` — and everything downstream
-    of it (the rank table, the decile gate, the detector) is the app's own code
-    reached the same way. So a cell measured here differs from the run's own field by
-    the membership rule and by nothing else.
+    :func:`replay.gate_sweep.build_sweep_sessions` does the work; the only thing
+    handed in is where membership comes from. Reusing it rather than reimplementing
+    the loop is what makes "only the gate set moved" true of the *code* as well as
+    of the intent — the rank table, the decile gate and the detector are literally
+    the same statements for a variant field as for the run's own.
     """
-    out: list[SweepSession] = []
-    for i, (session, members) in enumerate(zip(sessions, memberships), start=1):
-        members = list(members)
-        bars = {symbol: store.bars(market, symbol) for symbol in members}
-        ranks = rank_table(bars, session)
-        gated = detection_gate(ranks, lookbacks=lookbacks)
-        detections = [
-            found
-            for symbol in members
-            if symbol in gated
-            and (found := detect(symbol, bars[symbol], session)) is not None
-        ]
-        out.append(
-            SweepSession(
-                session=session,
-                members=members,
-                ranks=ranks,
-                membership=gate_membership(ranks),
-                detections=detections,
-            )
-        )
-        if progress is not None:
-            progress(i, len(sessions), session)
-    return out
+    by_session = dict(zip(sessions, memberships))
+    return build_sweep_sessions(
+        store,
+        market,
+        sessions,
+        lookbacks=lookbacks,
+        members_for=lambda session: by_session[session],
+        progress=progress,
+    )
 
 
 @dataclass(frozen=True)
@@ -539,7 +517,7 @@ class DimensionContrast:
 class VariantResult:
     """One variant's cell at the anchor's detector and field."""
 
-    variant: GateVariant
+    variant: UniverseGateSet
     members_per_session: float
     field_detections: int
     in_field: int
@@ -618,10 +596,9 @@ def measure_variant(
     sessions: Sequence[date],
     memberships: Sequence[Sequence[str]],
     *,
-    variant: GateVariant,
+    variant: UniverseGateSet,
     replayable: Sequence[ExecutedTrade],
     calendar: Sequence[date],
-    blind_spot_count: int = 0,
     progress: Callable[[int, int, date], None] | None = None,
 ) -> VariantResult:
     """Build ``variant``'s field over ``sessions`` and read the anchor's cell off it."""
@@ -639,7 +616,7 @@ def measure_variant(
         replayable=replayable,
         calendar=calendar,
         stored_rank_sessions=stored_ranks,
-        blind_spot_count=blind_spot_count,
+        blind_spot_count=0,
         grid=[(ANCHOR_DETECTOR, field)],
     )
     cell = grid.cells[0]
@@ -685,7 +662,7 @@ def run_isolation(
     *,
     contract: RunContract = DEFAULT_CONTRACT,
     trades: Sequence[ExecutedTrade] | None = None,
-    variants: Sequence[GateVariant] = VARIANTS,
+    variants: Sequence[UniverseGateSet] = VARIANTS,
     sessions: Sequence[date] | None = None,
     progress: Callable[[str], None] | None = None,
 ) -> Isolation:

--- a/backend/replay/gate_sweep.py
+++ b/backend/replay/gate_sweep.py
@@ -485,6 +485,7 @@ def build_sweep_sessions(
     sessions: Sequence[date],
     *,
     lookbacks: Sequence[str],
+    members_for: Callable[[date], Sequence[str]] | None = None,
     progress: Callable[[int, int, date], None] | None = None,
 ) -> list[SweepSession]:
     """Reconstruct each session's universe, ranks and widest-gate detections.
@@ -495,6 +496,14 @@ def build_sweep_sessions(
     reconstruction is the chain's own reuse path with nothing written back. The
     detector then runs over the union gate ``lookbacks`` describes.
 
+    ``members_for`` overrides where membership comes from, and exists for the one
+    caller that cannot read it back: :mod:`backtest.field_gate_isolation` measures
+    universes with a gate *removed*, which admits names the store never held, so its
+    membership is recomputed rather than stored (#211). Defaulting to ``None`` keeps
+    the store's own rows for every other caller — and keeps the two callers on one
+    detection pass, so a variant field and the run's own field cannot differ by an
+    accident of reimplementation.
+
     ``progress`` is called as ``progress(i, total, session)`` after each session, so
     a long pass reports rather than hanging silently.
     """
@@ -502,7 +511,11 @@ def build_sweep_sessions(
     total = len(sessions)
     out: list[SweepSession] = []
     for i, session in enumerate(sessions, start=1):
-        members = store.universe(market, session)
+        members = list(
+            store.universe(market, session)
+            if members_for is None
+            else members_for(session)
+        )
         bars = {symbol: store.bars(market, symbol) for symbol in members}
         ranks = rank_table(bars, session)
         membership = gate_membership(ranks)

--- a/backend/tests/test_field_gate_isolation.py
+++ b/backend/tests/test_field_gate_isolation.py
@@ -8,9 +8,9 @@ to hold, and both are pinned here rather than assumed:
 
 - **Its gates are :mod:`backtest.universe`'s gates.** The module holds each
   candidate's bars as parallel lists and indexes them per session instead of
-  re-slicing the symbol's history, and it carries its own copy of the app's private
-  ``_median``. These tests put both against the originals on the same bars and
-  require the same answer, so neither can drift from what it stands in for.
+  re-slicing the symbol's history. These tests put the two orders side by side on the
+  same bars and require the same answer, so the indexed path cannot drift from the
+  classifier it stands in for.
 - **Every variant reads one shared evaluation of the gates.** The predicates do not
   depend on the variant, so they are computed once and each variant is a boolean
   ``and`` over the same flags. That batch path must agree with the direct one, or
@@ -45,14 +45,13 @@ from backtest.universe import (
     passes_trend_gate,
 )
 from backtest.field_gate_isolation import (
-    ADR,
     ALL_GATES,
     LIQUIDITY,
     TREND,
     VARIANTS,
-    GateVariant,
+    VOLATILITY,
     ReconstructionFailed,
-    _median,
+    UniverseGateSet,
     gate_flags_by_session,
     members_at,
     memberships_under,
@@ -141,7 +140,7 @@ def test_the_liquidity_gate_medians_a_short_window_exactly_as_the_app_does():
 
     Unreachable while the trend gate is in force — it needs 50 bars — and reachable
     the moment the ``no-trend`` variant drops it, which is why the shortfall
-    behaviour is copied rather than tidied.
+    behaviour is reused rather than tidied.
     """
     bars = _bars(sessions=SESSIONS[:6])
     series = series_of("AAA", bars)
@@ -204,23 +203,6 @@ def test_a_non_positive_low_fails_the_adr_gate_rather_than_raising():
     bars[30] = Bar(bars[30].session, 50.0, 50.0, 0.0, 50.0, 50.0, 1_000_000)
     series = series_of("AAA", bars)
     assert series.passes_adr(series.prefix_len(bars[40].session)) is False
-
-
-@pytest.mark.parametrize(
-    "values",
-    [[], [1.0], [1.0, 3.0], [3.0, 1.0, 2.0], [4.0, 1.0, 3.0, 2.0], [5.0] * 20],
-)
-def test_the_median_copy_is_the_app_s_median(values):
-    """The app's ``_median`` is private, so this module copies it — and is pinned.
-
-    Compared through :func:`screener.universe.median_dollar_volume`, which is the
-    public function that median exists to serve, so the pin does not depend on a
-    private name staying importable.
-    """
-    bars = [
-        Bar(SESSIONS[i], 1.0, 1.0, 1.0, 1.0, 1.0, int(v)) for i, v in enumerate(values)
-    ]
-    assert _median([b.close * b.volume for b in bars]) == median_dollar_volume(bars)
 
 
 # -- every variant reads one shared evaluation of the gates -------------------
@@ -289,7 +271,7 @@ def test_each_dropped_gate_admits_the_name_that_gate_alone_rejects():
     """The isolation only means something if each drop moves its own name and no other."""
     series = _four_names()
     assert members_at(series, SIGNAL, ALL_GATES, US_FLOOR) == ["PASS"]
-    assert members_at(series, SIGNAL, ALL_GATES - {ADR}, US_FLOOR) == ["DULL", "PASS"]
+    assert members_at(series, SIGNAL, ALL_GATES - {VOLATILITY}, US_FLOOR) == ["DULL", "PASS"]
     assert members_at(series, SIGNAL, ALL_GATES - {TREND}, US_FLOOR) == [
         "FALLING",
         "PASS",
@@ -388,6 +370,6 @@ def test_the_isolation_stops_when_the_rebuild_misses_the_store_s_own_rows():
             "US",
             trades=[],
             sessions=[SIGNAL],
-            variants=[GateVariant("all-three", ALL_GATES, "")],
+            variants=[UniverseGateSet("all-three", ALL_GATES, "")],
         )
     assert "does not reproduce" in str(excinfo.value)

--- a/backend/tests/test_field_gate_isolation.py
+++ b/backend/tests/test_field_gate_isolation.py
@@ -1,0 +1,393 @@
+"""#211's gate isolation: the fast path must be the classifier, and a dropped gate
+must only ever admit.
+
+:mod:`backtest.field_gate_isolation` exists to answer one question — *which* of the
+stateless universe's three gates reverses the rubric's edge — and it can only answer
+it if its rebuilt membership is the run's own membership. Two things therefore have
+to hold, and both are pinned here rather than assumed:
+
+- **Its gates are :mod:`backtest.universe`'s gates.** The module holds each
+  candidate's bars as parallel lists and indexes them per session instead of
+  re-slicing the symbol's history, and it carries its own copy of the app's private
+  ``_median``. These tests put both against the originals on the same bars and
+  require the same answer, so neither can drift from what it stands in for.
+- **Every variant reads one shared evaluation of the gates.** The predicates do not
+  depend on the variant, so they are computed once and each variant is a boolean
+  ``and`` over the same flags. That batch path must agree with the direct one, or
+  "only the gate set moved" stops being true.
+- **Dropping a gate widens the field and never moves a constant.** A variant is
+  the run's gates *minus one*, so its membership must be a superset of the
+  baseline's. A variant that narrowed the field, or that passed a name the
+  remaining gates reject, would not be isolating a gate at all.
+
+The store-backed half of the claim — that the full-gate rebuild reproduces
+``backtest.duckdb``'s own universe rows exactly — is checked against the real store
+by :func:`~backtest.field_gate_isolation.verify_reconstruction` on every run, and
+recorded in ``references/backtest_gate_isolation.txt``. What is tested here is the
+arithmetic that check relies on.
+"""
+
+from datetime import date, timedelta
+
+import pytest
+
+from screener.bars import Bar
+from screener.store import Store
+from screener.universe import median_dollar_volume
+
+from backtest.contract import DEFAULT_CONTRACT, UNIVERSE_LIQUIDITY_FLOOR_KEY
+from backtest.universe import (
+    ADR_FLOOR,
+    Candidate,
+    is_member as classifier_is_member,
+    passes_adr_gate,
+    passes_liquidity_gate,
+    passes_trend_gate,
+)
+from backtest.field_gate_isolation import (
+    ADR,
+    ALL_GATES,
+    LIQUIDITY,
+    TREND,
+    VARIANTS,
+    GateVariant,
+    ReconstructionFailed,
+    _median,
+    gate_flags_by_session,
+    members_at,
+    memberships_under,
+    run_isolation,
+    series_of,
+)
+
+US_FLOOR = DEFAULT_CONTRACT.value(UNIVERSE_LIQUIDITY_FLOOR_KEY)["US"]
+
+# 60 bars through t−1 plus the signal session itself, so every case can be asked
+# both "what was knowable the night before" and "does day t's own bar leak".
+SESSIONS = [date(2020, 1, 1) + timedelta(days=i) for i in range(61)]
+SIGNAL = SESSIONS[-1]
+
+
+def _bars(
+    *,
+    price: float = 50.0,
+    drift: float = 0.002,
+    adr_pct: float = 0.05,
+    dollar_volume: float = 50_000_000.0,
+    sessions: list[date] | None = None,
+) -> list[Bar]:
+    """Bars that clear every gate by default, one knob per gate."""
+    out = []
+    for i, s in enumerate(sessions or SESSIONS):
+        p = price * (1 + drift) ** i
+        out.append(
+            Bar(
+                session=s,
+                open=p,
+                high=p * (1 + adr_pct),
+                low=p,
+                close=p,
+                adj_close=p,
+                volume=max(1, round(dollar_volume / p)),
+            )
+        )
+    return out
+
+
+def _series(symbol="AAA", **kwargs):
+    return series_of(symbol, _bars(**kwargs))
+
+
+def _k(series, session=SIGNAL):
+    return series.prefix_len(session)
+
+
+def _sliced(bars, session=SIGNAL):
+    """The bars the classifier sees — strictly before ``session``."""
+    return [b for b in bars if b.session < session]
+
+
+# -- the fast path is the classifier ------------------------------------------
+
+
+@pytest.mark.parametrize("drift", [0.01, 0.002, 0.0, -0.002, -0.01])
+def test_the_trend_gate_agrees_with_the_classifier_on_every_drift(drift):
+    bars = _bars(drift=drift)
+    series = series_of("AAA", bars)
+    assert series.passes_trend(_k(series)) is passes_trend_gate(_sliced(bars))
+
+
+@pytest.mark.parametrize("adr_pct", [0.10, 0.05, 0.036, 0.035, 0.034, 0.02])
+def test_the_adr_gate_agrees_with_the_classifier_across_the_floor(adr_pct):
+    """Including exactly at the floor, which is inclusive on both sides."""
+    bars = _bars(adr_pct=adr_pct)
+    series = series_of("AAA", bars)
+    assert series.passes_adr(_k(series)) is passes_adr_gate(_sliced(bars))
+
+
+@pytest.mark.parametrize(
+    "dollar_volume", [50_000_000.0, 10_000_001.0, 10_000_000.0, 9_999_999.0, 1_000.0]
+)
+def test_the_liquidity_gate_agrees_with_the_classifier_across_the_floor(dollar_volume):
+    bars = _bars(dollar_volume=dollar_volume)
+    series = series_of("AAA", bars)
+    assert series.passes_liquidity(_k(series), US_FLOOR) is passes_liquidity_gate(
+        _sliced(bars), "US", DEFAULT_CONTRACT
+    )
+
+
+def test_the_liquidity_gate_medians_a_short_window_exactly_as_the_app_does():
+    """The app medians whatever the trailing 20 bars hold rather than requiring 20.
+
+    Unreachable while the trend gate is in force — it needs 50 bars — and reachable
+    the moment the ``no-trend`` variant drops it, which is why the shortfall
+    behaviour is copied rather than tidied.
+    """
+    bars = _bars(sessions=SESSIONS[:6])
+    series = series_of("AAA", bars)
+    k = series.prefix_len(SESSIONS[5])
+    assert k == 5
+    expected = median_dollar_volume(_sliced(bars, SESSIONS[5])) >= US_FLOOR
+    assert series.passes_liquidity(k, US_FLOOR) is expected
+
+
+@pytest.mark.parametrize("bar_count", [0, 1, 19, 20, 49, 50])
+def test_the_windows_open_where_the_classifier_opens_them(bar_count):
+    """ADR needs 20 bars and the trend gate 50, and neither answers before that."""
+    bars = _bars(sessions=SESSIONS[:bar_count]) if bar_count else []
+    series = series_of("AAA", bars)
+    if series is None:
+        assert bar_count == 0
+        return
+    k = series.prefix_len(SESSIONS[bar_count])
+    assert series.passes_adr(k) is passes_adr_gate(_sliced(bars, SESSIONS[bar_count]))
+    assert series.passes_trend(k) is passes_trend_gate(
+        _sliced(bars, SESSIONS[bar_count])
+    )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"drift": -0.01},
+        {"adr_pct": 0.02},
+        {"dollar_volume": 1_000.0},
+        {"drift": -0.01, "adr_pct": 0.02},
+        {"adr_pct": 0.02, "dollar_volume": 1_000.0},
+    ],
+)
+def test_full_gate_membership_agrees_with_the_classifier(kwargs):
+    """The whole gate, not just its parts — this is the equality the run rests on."""
+    bars = _bars(**kwargs)
+    series = series_of("AAA", bars)
+    expected = classifier_is_member(
+        Candidate(symbol="AAA", name="", bars=bars), "US", SIGNAL, DEFAULT_CONTRACT
+    )
+    assert series.is_member(SIGNAL, ALL_GATES, US_FLOOR) is expected
+
+
+def test_no_gate_reads_the_signal_session_s_own_bar():
+    """A monstrous bar *on* the signal session cannot change that session's answer."""
+    bars = _bars(adr_pct=0.02)
+    loud = bars[:-1] + [
+        Bar(SIGNAL, 50.0, 5_000.0, 1.0, 50.0, 50.0, 10_000_000_000),
+    ]
+    assert series_of("AAA", loud).is_member(
+        SIGNAL, ALL_GATES, US_FLOOR
+    ) is series_of("AAA", bars).is_member(SIGNAL, ALL_GATES, US_FLOOR)
+
+
+def test_a_non_positive_low_fails_the_adr_gate_rather_than_raising():
+    """One corrupt row must not take down a 5,495-symbol pass, and must not pass."""
+    bars = _bars()
+    bars[30] = Bar(bars[30].session, 50.0, 50.0, 0.0, 50.0, 50.0, 1_000_000)
+    series = series_of("AAA", bars)
+    assert series.passes_adr(series.prefix_len(bars[40].session)) is False
+
+
+@pytest.mark.parametrize(
+    "values",
+    [[], [1.0], [1.0, 3.0], [3.0, 1.0, 2.0], [4.0, 1.0, 3.0, 2.0], [5.0] * 20],
+)
+def test_the_median_copy_is_the_app_s_median(values):
+    """The app's ``_median`` is private, so this module copies it — and is pinned.
+
+    Compared through :func:`screener.universe.median_dollar_volume`, which is the
+    public function that median exists to serve, so the pin does not depend on a
+    private name staying importable.
+    """
+    bars = [
+        Bar(SESSIONS[i], 1.0, 1.0, 1.0, 1.0, 1.0, int(v)) for i, v in enumerate(values)
+    ]
+    assert _median([b.close * b.volume for b in bars]) == median_dollar_volume(bars)
+
+
+# -- every variant reads one shared evaluation of the gates -------------------
+
+
+def _four_names():
+    return {
+        "PASS": _series("PASS"),
+        "DULL": _series("DULL", adr_pct=0.02),
+        "FALLING": _series("FALLING", drift=-0.01),
+        "THIN": _series("THIN", dollar_volume=1_000.0),
+    }
+
+
+@pytest.mark.parametrize("variant", VARIANTS, ids=lambda v: v.name)
+def test_the_batch_path_agrees_with_the_direct_one(variant):
+    """One shared pass of the predicates must place every name where the direct
+    per-variant evaluation does, or the variants are not sharing a baseline."""
+    series = _four_names()
+    flags = gate_flags_by_session(series, [SIGNAL], US_FLOOR)
+    assert memberships_under(flags, variant.gates) == [
+        members_at(series, SIGNAL, variant.gates, US_FLOOR)
+    ]
+
+
+def test_a_candidate_no_variant_can_admit_is_left_out_of_the_flags():
+    """Carrying every rejected name at every session would cost more than it says."""
+    series = {"NOPE": _series("NOPE", adr_pct=0.02, drift=-0.01, dollar_volume=1.0)}
+    assert gate_flags_by_session(series, [SIGNAL], US_FLOOR) == [{}]
+    for variant in VARIANTS:
+        assert memberships_under(
+            gate_flags_by_session(series, [SIGNAL], US_FLOOR), variant.gates
+        ) == [[]]
+
+
+# -- a variant drops a gate, and does nothing else ----------------------------
+
+
+def test_the_variants_are_the_baseline_then_one_drop_per_gate():
+    """Baseline first, then every gate dropped alone — that is the attribution.
+
+    The two-gate cell is deliberately last and deliberately the only one: it exists
+    because no single drop restores the sign, so it is a follow-up question rather
+    than part of the one-variable-at-a-time table above it.
+    """
+    baseline, *rest = VARIANTS
+    assert baseline.gates == ALL_GATES and baseline.dropped == frozenset()
+    singles = [v for v in rest if len(v.dropped) == 1]
+    assert {next(iter(v.dropped)) for v in singles} == ALL_GATES
+    pairs = [v for v in rest if len(v.dropped) == 2]
+    assert [v.name for v in pairs] == ["liquidity-only"]
+    assert pairs[0].gates == frozenset({LIQUIDITY})
+    assert len(singles) + len(pairs) == len(rest)
+
+
+@pytest.mark.parametrize("gate", sorted(ALL_GATES))
+def test_dropping_a_gate_only_ever_admits(gate):
+    """A variant's membership is a superset of the baseline's, name for name."""
+    series = _four_names()
+    baseline = set(members_at(series, SIGNAL, ALL_GATES, US_FLOOR))
+    widened = set(members_at(series, SIGNAL, ALL_GATES - {gate}, US_FLOOR))
+    assert baseline <= widened
+
+
+def test_each_dropped_gate_admits_the_name_that_gate_alone_rejects():
+    """The isolation only means something if each drop moves its own name and no other."""
+    series = _four_names()
+    assert members_at(series, SIGNAL, ALL_GATES, US_FLOOR) == ["PASS"]
+    assert members_at(series, SIGNAL, ALL_GATES - {ADR}, US_FLOOR) == ["DULL", "PASS"]
+    assert members_at(series, SIGNAL, ALL_GATES - {TREND}, US_FLOOR) == [
+        "FALLING",
+        "PASS",
+    ]
+    assert members_at(series, SIGNAL, ALL_GATES - {LIQUIDITY}, US_FLOOR) == [
+        "PASS",
+        "THIN",
+    ]
+
+
+def test_the_instrument_type_test_is_not_a_variant():
+    """No cell drops it, so an index cannot enter a field by having a gate removed."""
+    series = {"^IXIC": _series("^IXIC")}
+    for variant in VARIANTS:
+        assert members_at(series, SIGNAL, variant.gates, US_FLOOR) == []
+
+
+def test_membership_is_sorted_like_the_classifier_s():
+    series = {s: _series(s) for s in ("ZZZ", "AAA", "MMM")}
+    assert members_at(series, SIGNAL, ALL_GATES, US_FLOOR) == ["AAA", "MMM", "ZZZ"]
+
+
+# -- the isolation refuses to report against a pool it cannot reproduce -------
+
+
+def test_the_isolation_measures_every_variant_end_to_end():
+    """A whole run over a tiny store, so the grid is actually reached and read.
+
+    The reconstruction check passes here by construction — the store's universe rows
+    were written from the same bars — which leaves this test doing the job the
+    failure case cannot: exercising every step *after* the check, down to the cell
+    the anchor is quoted at.
+    """
+    store = Store.memory()
+    for symbol, kwargs in (
+        ("AAA", {}),
+        ("DULL", {"adr_pct": 0.02}),
+        ("FALLING", {"drift": -0.01}),
+        ("THIN", {"dollar_volume": 1_000.0}),
+    ):
+        store.append_bars("US", symbol, _bars(**kwargs))
+    store.append_universe("US", SIGNAL, ["AAA"])
+
+    isolation = run_isolation(store, "US", trades=[], sessions=[SIGNAL])
+
+    assert isolation.check.exact
+    assert {r.variant.name for r in isolation.results} == {v.name for v in VARIANTS}
+    # Each drop admits its own name, so the field widens by exactly one per variant.
+    assert isolation.by_name("all-three").members_per_session == 1.0
+    for name in ("no-adr", "no-trend", "no-liquidity"):
+        assert isolation.by_name(name).members_per_session == 2.0
+    # Dropping two admits both their names: everything but the illiquid one.
+    assert isolation.by_name("liquidity-only").members_per_session == 3.0
+    # No trades, so there is nothing to place and no gap to read — and that must be
+    # reported as absent rather than as a zero edge.
+    assert isolation.by_name("all-three").placed == 0
+    assert isolation.by_name("all-three").gap_pp is None
+
+
+def test_the_dimension_rows_are_the_seven_dimension_replayed_score():
+    """`Sector` is cross-sectional and is not reconstructed on the replay path.
+
+    Reported as absent rather than as a zero hit rate, because a dimension nobody
+    computed and a dimension nobody hit are different claims — and #194's acceptance
+    criteria turn on the seven-dimension score never being mistaken for the app's
+    nine-point one.
+    """
+    store = Store.memory()
+    store.append_bars("US", "AAA", _bars())
+    store.append_universe("US", SIGNAL, ["AAA"])
+    isolation = run_isolation(store, "US", trades=[], sessions=[SIGNAL])
+    # No trades here, so there is nothing to place and no contrast to draw.
+    assert isolation.by_name("all-three").dimensions == ()
+
+
+def test_a_dimension_gap_is_picks_minus_field_in_points():
+    from backtest.field_gate_isolation import DimensionContrast
+
+    row = DimensionContrast(dimension="ADR", weight=2, picks=0.77, field=0.613)
+    assert row.gap_pp == pytest.approx(15.7)
+
+
+def test_the_isolation_stops_when_the_rebuild_misses_the_store_s_own_rows():
+    """A gate measured off a pool that is not the run's field measures the pool.
+
+    The store here holds a universe row for a name it holds no bars for, so the
+    rebuild cannot reproduce it. The run must stop rather than report cells.
+    """
+    store = Store.memory()
+    bars = _bars()
+    store.append_bars("US", "AAA", bars)
+    store.append_universe("US", SIGNAL, ["AAA", "GHOST"])
+    with pytest.raises(ReconstructionFailed) as excinfo:
+        run_isolation(
+            store,
+            "US",
+            trades=[],
+            sessions=[SIGNAL],
+            variants=[GateVariant("all-three", ALL_GATES, "")],
+        )
+    assert "does not reproduce" in str(excinfo.value)

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -190,6 +190,16 @@ Two consequences to carry:
 | **Kill criterion** | Arm B's after-cost expectancy ≤ 0 in **both** markets, on the **full window and with 2020–21 excluded**, measured on the **survivor-biased store** | Below |
 | **Ship criterion** | Arm B's after-cost expectancy > 0 in a market across both windows, **and** the pessimistic bound from Phase 2 keeps it above 0 | A positive run that survives its own bias is the only kind that licenses a change |
 
+**Neither criterion reads the rubric, and #211 is the reason that is worth saying.**
+The gate isolation ([`backtest_gate_isolation.md`](../references/backtest_gate_isolation.md))
+found that the rubric's edge over the field reverses inside this run's own universe, and
+that this is a property of the contracted gates rather than a defect. That changes
+nothing here — ship and kill are both expectancy on arm B, plus Phase 2's bound — and the
+three-outcome table above already contemplates the rubric ranking rather than deciding.
+What it does change is how findings §4b's gap may be cited: **never without naming the
+field it was measured over**, since it is +1.95pp under the app's universe and −5.01pp
+under the contract's.
+
 **Why the kill line is drawn on the survivor-biased number.** Survivorship inflates results in
 a known direction: the missing names are disproportionately the ones that died. So a failure
 there is decisive — the honest figure can only be worse. A *pass* proves much less, which is

--- a/references/backtest_anchor_divergence.md
+++ b/references/backtest_anchor_divergence.md
@@ -22,6 +22,15 @@ which is the one outcome the table refuses to let a written cause waive. So:
 
 That refusal is the table working, not the table failing.
 
+**Since this page was written, #211 has established why `in_field` reverses**, and the
+answer is recorded beside it in [the gate isolation](backtest_gate_isolation.md). It is
+the contract's **ADR20 floor and trend gate acting together** — neither on its own moves
+the sign — and it is a property of the method under the gates this run is contracted to
+use, not a defect in how the field is built. That does not lift the refusal above: a sign
+flip is not waivable by a written cause, and this one is not being waived. It does mean
+the sentence "cannot be settled here" below has been answered elsewhere, and that the
+`in_field` discussion further down should be read together with that page.
+
 ## The divergence
 
 The three geometry anchors are medians measured from his bars at his entries. They hold
@@ -136,17 +145,24 @@ committed figure came from, and the gap stays positive at +1.86 — within a hai
 the same sign. The flip appears only when the field is rebuilt from the contract's stateless
 universe, which also more than halves `in_field`, 64.4% → 32.8%.
 
-That narrowing is not itself surprising: the stateless universe adds an ADR20 floor of 3.5%
-and a $10M ADTV floor and drops the app's membership hysteresis, so it is a much tighter field
-and fewer of his names reach it. What the sign says is different and is not explained by
-tightness: **inside that narrower field, the published rubric ranks his trades below the field
-average rather than above it.** The rubric's edge does not survive the gate the backtest runs
-under.
+That narrowing is not itself surprising: the stateless universe adds an ADR20 floor of 3.5%,
+adds a trend gate (`close > SMA50`), sets its ADTV floor at $10M rather than the app's $20M,
+and drops the app's membership hysteresis, so it is a much tighter field and fewer of his
+names reach it. What the sign says is different and is not explained by tightness: **inside
+that narrower field, the published rubric ranks his trades below the field average rather
+than above it.** The rubric's edge does not survive the gate the backtest runs under.
+
+*(The trend gate was omitted when this paragraph was first written — the app's universe has
+no counterpart for it at all. It turns out to be half the cause; see below.)*
 
 Whether that is a defect in the field construction or a real result about the rubric out of
-sample is exactly the open question, and it is not one this issue can settle — it is the
-question #194 asks. What is settled is where it is *not*: not the bars (bit-identical), not
-the detector (recall reproduces to four decimals), and not the population (isolated above).
+sample was the open question, and this issue could not settle it. **#211 has**:
+[the gate isolation](backtest_gate_isolation.md) attributes it to the **ADR20 floor and the
+trend gate acting together** — every single-gate drop leaves the gap negative, dropping both
+turns it positive — and returns the verdict **property, not defect**. What was already
+settled is where it is *not*: not the bars (bit-identical), not the detector (recall
+reproduces to four decimals), and not the population (isolated above); #211 adds that it is
+not the liquidity floor and not the membership reconstruction either.
 
 **This anchor is a first measurement**, flagged as such in the table precisely so a mismatch is
 investigated in both directions rather than charged straight to the new pipeline. The committed
@@ -171,7 +187,12 @@ onto the pin.
   population 23% smaller.
 - `in_field` is **not settled and cannot be settled here.** The rubric's edge reverses inside
   the contract's stateless field, and no figure from this run may be read until that is
-  understood. It is not the bars, not the detector and not the population.
+  understood. It is not the bars, not the detector and not the population. **#211 has since
+  settled *why*** — see [the gate isolation](backtest_gate_isolation.md). The short version:
+  it is the **ADR20 floor and the trend gate together**, neither alone, and it is a property
+  of the method under the contracted gates rather than a defect in the field. The anchor
+  still fails, because a sign flip is still not waivable; what changed is that the run is
+  blocked on a result rather than on a mystery.
 
 Every divergence is recorded through the mechanism rather than only here, so a reader who
 never opens this file still cannot mistake one for a match:

--- a/references/backtest_gate_isolation.json
+++ b/references/backtest_gate_isolation.json
@@ -1,0 +1,371 @@
+{
+ "window": {
+  "start": "2019-04-01",
+  "end": "2022-12-30",
+  "burn_in": 126,
+  "market": "US"
+ },
+ "detector_version": 3,
+ "field": "whole",
+ "rubric_version": 1,
+ "stars": 3.5,
+ "reconstruction": {
+  "sessions": 821,
+  "stored": 297709,
+  "rebuilt": 297709,
+  "extra": 0,
+  "missing": 0,
+  "exact": true
+ },
+ "variants": [
+  {
+   "name": "all-three",
+   "gates": [
+    "adr",
+    "liquidity",
+    "trend"
+   ],
+   "dropped": [],
+   "note": "the run's own field \u2014 reproduces the committed -5.01pp",
+   "members_per_session": 362.6175395858709,
+   "field_detections": 35971,
+   "in_field": 165,
+   "placed": 503,
+   "in_field_share": 0.32803180914512925,
+   "picks_share": 0.14545454545454545,
+   "field_share": 0.19552004370689066,
+   "gap_pp": -5.006549825234521,
+   "dimensions": [
+    {
+     "dimension": "Tightness",
+     "weight": 2,
+     "picks": 0.4303030303030303,
+     "field": 0.25035853308748207,
+     "gap_pp": 17.994449721554822
+    },
+    {
+     "dimension": "Orderliness",
+     "weight": 1,
+     "picks": 0.40606060606060607,
+     "field": 0.436454278494844,
+     "gap_pp": -3.039367243423791
+    },
+    {
+     "dimension": "Prior move",
+     "weight": 1,
+     "picks": 1.0,
+     "field": 1.0,
+     "gap_pp": 0.0
+    },
+    {
+     "dimension": "Base length",
+     "weight": 0,
+     "picks": 0.5212121212121212,
+     "field": 0.678139725466093,
+     "gap_pp": -15.692760425397179
+    },
+    {
+     "dimension": "MA support",
+     "weight": 1,
+     "picks": 0.8606060606060606,
+     "field": 0.8583623574404152,
+     "gap_pp": 0.2243703165645372
+    },
+    {
+     "dimension": "Volume",
+     "weight": 1,
+     "picks": 0.2606060606060606,
+     "field": 0.322679778733866,
+     "gap_pp": -6.207371812780538
+    },
+    {
+     "dimension": "ADR",
+     "weight": 2,
+     "picks": 0.896969696969697,
+     "field": 0.9071228573379772,
+     "gap_pp": -1.0153160368280179
+    }
+   ]
+  },
+  {
+   "name": "no-adr",
+   "gates": [
+    "liquidity",
+    "trend"
+   ],
+   "dropped": [
+    "adr"
+   ],
+   "note": "drops the 3.5% ADR20 floor, which the app's universe does not have",
+   "members_per_session": 906.1534713763702,
+   "field_detections": 84329,
+   "in_field": 247,
+   "placed": 503,
+   "in_field_share": 0.49105367793240556,
+   "picks_share": 0.14979757085020243,
+   "field_share": 0.16435974809761217,
+   "gap_pp": -1.456217724740974,
+   "dimensions": [
+    {
+     "dimension": "Tightness",
+     "weight": 2,
+     "picks": 0.3967611336032389,
+     "field": 0.21641301495670429,
+     "gap_pp": 18.03481186465346
+    },
+    {
+     "dimension": "Orderliness",
+     "weight": 1,
+     "picks": 0.4008097165991903,
+     "field": 0.46428102860141696,
+     "gap_pp": -6.347131200222666
+    },
+    {
+     "dimension": "Prior move",
+     "weight": 1,
+     "picks": 1.0,
+     "field": 1.0,
+     "gap_pp": 0.0
+    },
+    {
+     "dimension": "Base length",
+     "weight": 0,
+     "picks": 0.5141700404858299,
+     "field": 0.6920755707163474,
+     "gap_pp": -17.790553023051746
+    },
+    {
+     "dimension": "MA support",
+     "weight": 1,
+     "picks": 0.8461538461538461,
+     "field": 0.8524009446339543,
+     "gap_pp": -0.6247098480108182
+    },
+    {
+     "dimension": "Volume",
+     "weight": 1,
+     "picks": 0.3360323886639676,
+     "field": 0.3745736027289425,
+     "gap_pp": -3.8541214064974905
+    },
+    {
+     "dimension": "ADR",
+     "weight": 2,
+     "picks": 0.7813765182186235,
+     "field": 0.6632773550249278,
+     "gap_pp": 11.809916319369574
+    }
+   ]
+  },
+  {
+   "name": "no-trend",
+   "gates": [
+    "adr",
+    "liquidity"
+   ],
+   "dropped": [
+    "trend"
+   ],
+   "note": "drops close > SMA50, which the app's universe does not have",
+   "members_per_session": 771.2350791717417,
+   "field_detections": 82650,
+   "in_field": 231,
+   "placed": 503,
+   "in_field_share": 0.4592445328031809,
+   "picks_share": 0.14285714285714285,
+   "field_share": 0.1572876126363031,
+   "gap_pp": -1.4430469779160238,
+   "dimensions": [
+    {
+     "dimension": "Tightness",
+     "weight": 2,
+     "picks": 0.42857142857142855,
+     "field": 0.24259317695732968,
+     "gap_pp": 18.597825161409887
+    },
+    {
+     "dimension": "Orderliness",
+     "weight": 1,
+     "picks": 0.36363636363636365,
+     "field": 0.36005048911328497,
+     "gap_pp": 0.35858745230786804
+    },
+    {
+     "dimension": "Prior move",
+     "weight": 1,
+     "picks": 1.0,
+     "field": 1.0,
+     "gap_pp": 0.0
+    },
+    {
+     "dimension": "Base length",
+     "weight": 0,
+     "picks": 0.47619047619047616,
+     "field": 0.5647067073384524,
+     "gap_pp": -8.851623114797624
+    },
+    {
+     "dimension": "MA support",
+     "weight": 1,
+     "picks": 0.8051948051948052,
+     "field": 0.6860558886434557,
+     "gap_pp": 11.913891655134956
+    },
+    {
+     "dimension": "Volume",
+     "weight": 1,
+     "picks": 0.2987012987012987,
+     "field": 0.35314329792083027,
+     "gap_pp": -5.444199921953158
+    },
+    {
+     "dimension": "ADR",
+     "weight": 2,
+     "picks": 0.8831168831168831,
+     "field": 0.8442551102696259,
+     "gap_pp": 3.8861772847257225
+    }
+   ]
+  },
+  {
+   "name": "no-liquidity",
+   "gates": [
+    "adr",
+    "trend"
+   ],
+   "dropped": [
+    "liquidity"
+   ],
+   "note": "drops the $10M ADTV floor, which the app sets at $20M instead",
+   "members_per_session": 985.0669914738124,
+   "field_detections": 103411,
+   "in_field": 193,
+   "placed": 503,
+   "in_field_share": 0.3836978131212724,
+   "picks_share": 0.16580310880829016,
+   "field_share": 0.18443597108051896,
+   "gap_pp": -1.8632862272228796,
+   "dimensions": [
+    {
+     "dimension": "Tightness",
+     "weight": 2,
+     "picks": 0.43523316062176165,
+     "field": 0.3104882638407448,
+     "gap_pp": 12.474489678101685
+    },
+    {
+     "dimension": "Orderliness",
+     "weight": 1,
+     "picks": 0.38860103626943004,
+     "field": 0.42562147172427456,
+     "gap_pp": -3.702043545484451
+    },
+    {
+     "dimension": "Prior move",
+     "weight": 1,
+     "picks": 1.0,
+     "field": 1.0,
+     "gap_pp": 0.0
+    },
+    {
+     "dimension": "Base length",
+     "weight": 0,
+     "picks": 0.5129533678756477,
+     "field": 0.6387293255422403,
+     "gap_pp": -12.577595766659256
+    },
+    {
+     "dimension": "MA support",
+     "weight": 1,
+     "picks": 0.8652849740932642,
+     "field": 0.8524066554422105,
+     "gap_pp": 1.287831865105371
+    },
+    {
+     "dimension": "Volume",
+     "weight": 1,
+     "picks": 0.29533678756476683,
+     "field": 0.2773843715955234,
+     "gap_pp": 1.7952415969243407
+    },
+    {
+     "dimension": "ADR",
+     "weight": 2,
+     "picks": 0.8860103626943006,
+     "field": 0.929384965831435,
+     "gap_pp": -4.337460313713448
+    }
+   ]
+  },
+  {
+   "name": "liquidity-only",
+   "gates": [
+    "liquidity"
+   ],
+   "dropped": [
+    "adr",
+    "trend"
+   ],
+   "note": "drops both gates the app lacks, keeping only a liquidity floor",
+   "members_per_session": 1687.8197320341048,
+   "field_detections": 176643,
+   "in_field": 322,
+   "placed": 503,
+   "in_field_share": 0.6401590457256461,
+   "picks_share": 0.13354037267080746,
+   "field_share": 0.12636165577342048,
+   "gap_pp": 0.7178716897386972,
+   "dimensions": [
+    {
+     "dimension": "Tightness",
+     "weight": 2,
+     "picks": 0.40372670807453415,
+     "field": 0.20671960244152757,
+     "gap_pp": 19.700710563300657
+    },
+    {
+     "dimension": "Orderliness",
+     "weight": 1,
+     "picks": 0.3447204968944099,
+     "field": 0.37501575469489906,
+     "gap_pp": -3.029525780048914
+    },
+    {
+     "dimension": "Prior move",
+     "weight": 1,
+     "picks": 1.0,
+     "field": 1.0,
+     "gap_pp": 0.0
+    },
+    {
+     "dimension": "Base length",
+     "weight": 0,
+     "picks": 0.4658385093167702,
+     "field": 0.5778642035326528,
+     "gap_pp": -11.20256942158826
+    },
+    {
+     "dimension": "MA support",
+     "weight": 1,
+     "picks": 0.7857142857142857,
+     "field": 0.687894992707827,
+     "gap_pp": 9.781929300645874
+    },
+    {
+     "dimension": "Volume",
+     "weight": 1,
+     "picks": 0.35714285714285715,
+     "field": 0.39687426853202257,
+     "gap_pp": -3.9731411389165414
+    },
+    {
+     "dimension": "ADR",
+     "weight": 2,
+     "picks": 0.7701863354037267,
+     "field": 0.6128126181602117,
+     "gap_pp": 15.737371724351501
+    }
+   ]
+  }
+ ]
+}

--- a/references/backtest_gate_isolation.json
+++ b/references/backtest_gate_isolation.json
@@ -21,9 +21,9 @@
   {
    "name": "all-three",
    "gates": [
-    "adr",
     "liquidity",
-    "trend"
+    "trend",
+    "volatility"
    ],
    "dropped": [],
    "note": "the run's own field \u2014 reproduces the committed -5.01pp",
@@ -94,7 +94,7 @@
     "trend"
    ],
    "dropped": [
-    "adr"
+    "volatility"
    ],
    "note": "drops the 3.5% ADR20 floor, which the app's universe does not have",
    "members_per_session": 906.1534713763702,
@@ -160,8 +160,8 @@
   {
    "name": "no-trend",
    "gates": [
-    "adr",
-    "liquidity"
+    "liquidity",
+    "volatility"
    ],
    "dropped": [
     "trend"
@@ -230,8 +230,8 @@
   {
    "name": "no-liquidity",
    "gates": [
-    "adr",
-    "trend"
+    "trend",
+    "volatility"
    ],
    "dropped": [
     "liquidity"
@@ -303,8 +303,8 @@
     "liquidity"
    ],
    "dropped": [
-    "adr",
-    "trend"
+    "trend",
+    "volatility"
    ],
    "note": "drops both gates the app lacks, keeping only a liquidity floor",
    "members_per_session": 1687.8197320341048,

--- a/references/backtest_gate_isolation.md
+++ b/references/backtest_gate_isolation.md
@@ -101,8 +101,17 @@ that matters, and the `liquidity only` row keeps it and still lands positive.
 **The two-gate row is the app's shape, and it lands where the app lands.** `liquidity
 only` gives `in_field` 322 of 503 — 64.0% — against the app's own 324 of 503, 64.4%. Two
 trades apart, from a different store by a different route. So this row is the app-shaped
-field reached from inside the run's own store, and the two gates are the whole of the
-difference that matters.
+field reached from inside the run's own store.
+
+**Hysteresis is not isolated here, and its exoneration is inferential.** The third
+difference the divergence page names is that the contract drops the app's membership
+hysteresis band, and no variant above restores it — the contract's classifier is
+stateless by construction (`backtest.universe.classify` takes no `prior_members`), so
+adding the band back is not a gate that can be switched off. What bounds it is the row
+above: `liquidity only` reaches the app's own `in_field` to within two trades **without**
+hysteresis, which leaves little room for the band to be carrying the sign. That is a
+bound, not a measurement, and it is the one difference of the four this page has not
+varied directly.
 
 **The movement is entirely in the field, not in his picks.** Across every row his picks
 sit between 13.35% and 16.58% — a narrow band with no trend. The field swings from
@@ -227,6 +236,10 @@ here.** Against `data/replay.duckdb` under the app's universe:
 | --- | ---: | ---: |
 | all 656 replayable trades | 397/656 (60.5%) | **+1.95pp** |
 | the same 503 the backtest store can rank | 324/503 (64.4%) | **+1.86pp** |
+
+Both come from `replay.discrimination_grid.run_grid` rather than from this page's own
+module, so they are **not** in `backtest_gate_isolation.json` — the command that
+reproduces them is under "Reproducing this page" below.
 
 The first reproduces the committed figure exactly. The second holds the population fixed
 at the backtest store's 503 names and returns the same sign within a hair — so the pin is

--- a/references/backtest_gate_isolation.md
+++ b/references/backtest_gate_isolation.md
@@ -1,0 +1,258 @@
+# Why the rubric's edge reverses inside the stateless field
+
+Issue #211, PRD #182. The companion to
+[the anchor divergence](backtest_anchor_divergence.md), which ends by saying `in_field`
+"is **not settled and cannot be settled here**". This page settles it.
+
+Read that page first. In one line: #198 ran both markets end to end, checked the six
+anchors against the run's own field, and five settled. `in_field` did not — it flipped
+the sign of findings §4b's gap, from the committed **+1.95pp** to **−5.01pp**, and a
+sign flip is the one outcome the anchor table refuses to let a written cause waive.
+
+## The verdict
+
+**It is a property of the method under the gates this run is contracted to use, not a
+defect in how the field is built.**
+
+The reversal is attributable to the **conjunction of two gates** — the ADR20 floor of
+3.5% and the trend gate, `close > SMA50`. Neither one alone accounts for it: dropping
+either leaves the gap negative. Dropping **both** restores the sign. The liquidity floor
+is not the cause and is exonerated below.
+
+Both of those gates are doing exactly what the contract says they should. Nothing is
+miscomputed: the rebuilt membership reproduces the run's own universe rows exactly, and
+every gate reproduces `backtest.universe`'s own predicate. There is no bug to fix, so
+`in_field` is **not** re-measured over a repaired field — there is no repair to make.
+
+What the run has actually measured is this: **the published rubric's edge over the app's
+field is an edge over names the app's universe lets in and the contract's does not.**
+Screen those names out first and the edge does not survive. That is a finding about the
+method, it is #194's question arriving from a different direction, and it is reported
+here as the result rather than adjusted away.
+
+**No constant was moved to get this answer, and none is proposed.** Restoring the sign
+requires removing two gates outright, not loosening either — and a gate removal goes
+through ADR 0002 and its evidence rule, not through this ticket.
+
+## The isolation
+
+The trouble with #198's third measurement is that it moves *towards* the app: a
+different store, a different universe. This one moves the other way and stays inside the
+run's own field. One store (`data/backtest.duckdb`), one population (the same 503
+replayable trades), one detector (v3), one window (US, 2019-04-01 .. 2022-12-30, 126
+burn-in, 821 measured sessions). The only thing that moves between rows is **which gates
+build the universe**.
+
+| variant | members/sess | field detections | `in_field` | picks ≥3.5★ | field ≥3.5★ | gap |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| **all three** — the run's own field | 362.6 | 35,971 | 165/503 (32.8%) | 14.55% | 19.55% | **−5.01pp** |
+| no ADR floor | 906.2 | 84,329 | 247/503 (49.1%) | 14.98% | 16.44% | −1.46pp |
+| no trend gate | 771.2 | 82,650 | 231/503 (45.9%) | 14.29% | 15.73% | −1.44pp |
+| no liquidity floor | 985.1 | 103,411 | 193/503 (38.4%) | 16.58% | 18.44% | −1.86pp |
+| **liquidity only** — both dropped | 1,687.8 | 176,643 | 322/503 (64.0%) | 13.35% | 12.64% | **+0.72pp** |
+
+Reproduce with:
+
+```
+python -m backtest.field_gate_isolation --store data/backtest.duckdb
+```
+
+which writes [`backtest_gate_isolation.txt`](backtest_gate_isolation.txt) and
+[`backtest_gate_isolation.json`](backtest_gate_isolation.json), both carrying the
+per-dimension rows below as well as this table. About 40 minutes.
+
+### Why this table can be trusted
+
+The store's persisted `universe` rows are the *intersection* of every gate, so a row
+that **drops** a gate needs names the run never stored. Membership is therefore rebuilt
+from the candidate bars rather than read back — and that rebuild is the load-bearing
+claim here, so it is checked rather than assumed, two ways:
+
+- Under the full gate set it reproduces the store's own universe rows **exactly**:
+  297,709 stored, 297,709 rebuilt, **0 extra and 0 missing** across all 821 sessions.
+  `run_isolation` raises rather than reporting a single cell if this is not exact,
+  because a gate measured off a pool that is not the run's field is measuring the pool.
+- Each gate predicate is pinned against `backtest.universe`'s own `passes_*` function on
+  the same bars, in `tests/test_field_gate_isolation.py`, along with the shared-evaluation
+  path every variant reads from.
+
+The 362.6 members per session in the baseline row is 297,709 ÷ 821 — the stored figure,
+not a recomputed one — and that row reproduces the committed −5.01pp to the digit.
+
+## Reading the table
+
+**No single gate is the cause.** Every single-gate drop moves the gap by a similar
+amount — +3.55, +3.57, +3.15 — and every one of them leaves it negative. A ticket that
+demanded "attribute it to a specific gate, not the universe as a whole" gets a two-gate
+answer, and the two are named: the ADR floor and the trend gate.
+
+**Those two are exactly the gates the app's universe has no counterpart for.** The app's
+universe is liquidity, instrument type, listing age and density; it has neither a
+volatility gate nor a trend gate (`backtest.universe`'s own module docstring says so).
+The divergence page lists three differences from the app — the ADR floor, the ADTV floor
+and the dropped hysteresis — and **omits the trend gate**. That omission matters, because
+the trend gate turns out to be half the answer.
+
+**The liquidity floor is exonerated.** It is the one gate both universes have; they
+differ only in level, and the contract's $10M is *looser* than the app's $20M, so it
+admits names rather than excluding them. Dropping it moves the gap least in the direction
+that matters, and the `liquidity only` row keeps it and still lands positive.
+
+**The two-gate row is the app's shape, and it lands where the app lands.** `liquidity
+only` gives `in_field` 322 of 503 — 64.0% — against the app's own 324 of 503, 64.4%. Two
+trades apart, from a different store by a different route. So this row is the app-shaped
+field reached from inside the run's own store, and the two gates are the whole of the
+difference that matters.
+
+**The movement is entirely in the field, not in his picks.** Across every row his picks
+sit between 13.35% and 16.58% — a narrow band with no trend. The field swings from
+12.64% to 19.55%. The gates do not make his trades look worse; they make **the field look
+better**, by removing the names that were dragging the field's average down.
+
+## The mechanism
+
+The two gates that cause the reversal each **duplicate a rubric dimension**. Applying
+one raises the *field's* hit rate on the dimension it duplicates until there is no
+spread left to discriminate on, and the dimension's contribution to the gap collapses.
+
+Per-dimension hit rates, his picks against the field on the sessions he traded, under
+the run's own field and under the app-shaped one:
+
+| dimension | wt | run's field: picks / field / gap | app-shaped: picks / field / gap |
+| --- | ---: | ---: | ---: |
+| **ADR** | 2 | 89.7% / 90.7% / **−1.0pp** | 77.0% / 61.3% / **+15.7pp** |
+| **MA support** | 1 | 86.1% / 85.8% / **+0.2pp** | 78.6% / 68.8% / **+9.8pp** |
+| Tightness | 2 | 43.0% / 25.0% / +18.0pp | 40.4% / 20.7% / +19.7pp |
+| Base length | 0 | 52.1% / 67.8% / −15.7pp | 46.6% / 57.8% / −11.2pp |
+| Volume | 1 | 26.1% / 32.3% / −6.2pp | 35.7% / 39.7% / −4.0pp |
+| Orderliness | 1 | 40.6% / 43.6% / −3.0pp | 34.5% / 37.5% / −3.0pp |
+| Prior move | 1 | 100% / 100% / 0.0pp | 100% / 100% / 0.0pp |
+
+The correspondence is one-to-one, and it is the whole explanation:
+
+- **The ADR floor kills the ADR dimension.** The rubric's heaviest dimension — 2 points
+  of 9 — scores `adr >= 5%` (`screener.score.ADR_MIN`). The universe gate is
+  `ADR20 >= 3.5%` (`backtest.universe.ADR_FLOOR`). Same variable, two thresholds. Under
+  the gate the field clears the 5% dimension **90.7%** of the time against his picks'
+  89.7%: a dimension worth +15.7pp of edge on the app-shaped field is worth −1.0pp here.
+- **The trend gate kills MA support.** `close > SMA50` is a trend qualification, and
+  `MA support` scores `sma20_rising`. Requiring the whole field to sit above its 50-day
+  average lifts the field's hit rate from 68.8% to 85.8%, and the dimension's +9.8pp
+  goes to +0.2pp.
+- **Every dimension with no corresponding gate barely moves.** Tightness (+18.0 vs
+  +19.7), Orderliness (−3.0 vs −3.0), Volume (−6.2 vs −4.0), Prior move (0.0 vs 0.0).
+  `Base length` carries weight 0 and cannot move any star total at all.
+
+The single-gate rows confirm it by moving one dimension each. Drop the ADR floor and
+the ADR dimension comes back to **+11.8pp** while MA support stays flattened at −0.6pp.
+Drop the trend gate and MA support comes back to **+11.9pp** while ADR only partly
+recovers, to +3.9pp. Each gate suppresses its own dimension and leaves the other's
+suppressed, which is the prediction this explanation makes and the measurement it could
+have failed.
+
+That is why no *single* drop restores the sign. Dropping the ADR floor gives back one
+dimension and leaves MA support flattened; dropping the trend gate does the reverse.
+Only removing both returns two dimensions' worth of discrimination, and +0.72pp is what
+that buys.
+
+It also says where his edge lives: **Tightness**, at +18 to +20pp on either field and
+weighted 2. That dimension survives both gates untouched. What the gates
+remove is not his edge but the rubric's other two sources of separation.
+
+**On the deliberate 3.5% / 5% gap.** `backtest/universe.py` sets the floor below the
+rubric's threshold on purpose, and says why: findings §6 measured the 5% floor silently
+withholding a score point from 31% of his real entries, so "a universe cut at 5% would
+leave the ADR dimension with no spread left to test." The reasoning is sound and is not
+disturbed here. What this measurement adds is that **1.5 percentage points was not enough
+clearance to achieve it**: at a 3.5% floor the field already clears the 5% dimension
+90.7% of the time, and the spread the gap was meant to preserve is gone anyway.
+
+That is a finding about a constant, and per this ticket it is **reported, not acted on**.
+Nothing here proposes moving `ADR_FLOOR`; a change to it would need to go through ADR
+0002's evidence rule, would re-open the §6 trade-off the current value was chosen to
+respect, and would invalidate this run's persisted denominator. It is recorded so that whoever
+revisits the floor knows the 1.5pp clearance does not buy the spread the docstring claims
+for it.
+
+The seven-dimension replayed score is what these rows report: `Sector` is cross-sectional
+and is not reconstructed on this path, so it is absent rather than shown as zero.
+
+## What this does and does not license
+
+- **The anchor stays failed.** `in_field` diverges, its cause is now understood, and a
+  sign flip is still not waivable by a written cause — that rule exists precisely so a
+  finding like this one cannot be argued past. `backtest.full_run` continues to emit no
+  figure, plot or payload. What has changed is that the run is no longer blocked on an
+  *unexplained* divergence; it is blocked on a *result*.
+- **This is not the only thing blocking the run.** #196's survivorship bound is
+  independently larger than the effect the run is looking for — its pessimistic twin goes
+  negative for any headline below **+0.605R**. Settling `in_field` does not touch that.
+- **The plan's ship criterion is not what this refutes** — see below.
+- **#194 now has its input.** `backtest.ranking` has been ready since #206 and has never
+  had a denominator. This finding is a *selection* contrast, not an outcome one; #194
+  asks whether a higher star score predicts a better **result**, which is a different and
+  stronger question. Nothing here answers it, and this page is not a substitute for it.
+
+### On the ship criterion
+
+The ticket says "the plan's ship criterion assumes the opposite", i.e. that the rubric
+ranks. Read against the plan, that is not accurate, and the point is worth being exact about:
+the ship criterion is what the whole run is for.
+
+The ship criterion is: *arm B's after-cost expectancy > 0 in a market across both windows,
+**and** the pessimistic bound from Phase 2 keeps it above 0.* It is an expectancy
+criterion over the **detector's** trades and exits. It does not read the rubric, and
+nothing in it requires his picks to out-score the field.
+
+The plan is explicit that the rubric might not decide. Its three-outcome table
+includes "They are flat, but his selection beat them → his edge is discretionary, and the
+rubric's job is to *rank*, not to *decide*." A rubric that does not separate his picks
+from a screened field is a result the plan already contemplates publishing.
+
+So no ship-criterion revision follows from this page. What does follow is narrower and
+should be said plainly: **findings §4b's gap should not be quoted as evidence that the
+rubric ranks, without naming the field it was measured over.** Under the app's universe
+it is +1.95pp; under the contract's stateless universe it is −5.01pp; the number is a
+property of the pair, not of the rubric. The ranking claim's real test is #194's, on
+outcomes.
+
+## What was checked, and what it rules out
+
+Both directions, as the ticket requires — the pin was re-measured, not assumed.
+
+**The committed pin now has a second measurement agreeing with it, and both were re-run
+here.** Against `data/replay.duckdb` under the app's universe:
+
+| population | `in_field` | gap |
+| --- | ---: | ---: |
+| all 656 replayable trades | 397/656 (60.5%) | **+1.95pp** |
+| the same 503 the backtest store can rank | 324/503 (64.4%) | **+1.86pp** |
+
+The first reproduces the committed figure exactly. The second holds the population fixed
+at the backtest store's 503 names and returns the same sign within a hair — so the pin is
+corroborated by a measurement over a different population, and the suspicion moves onto
+the field rather than onto the pin. Both rows were re-run for this page rather than
+quoted from #198.
+
+Taken with what #198 already ruled out, the causes now excluded are:
+
+- **not the bars** — of the 496 trades both stores can measure, all 496 carry
+  bit-identical geometry;
+- **not the detector** — recall reproduces at 421/503 = 83.70% against 83.69%;
+- **not the population** — held fixed above, the sign holds;
+- **not the candidate pool or the membership code** — the rebuild reproduces the store's
+  universe rows exactly, 0 extra and 0 missing over 821 sessions;
+- **not the liquidity floor** — measured, and it is not the gate that moves the sign;
+- **not any single gate at all** — every one-gate drop leaves the gap negative.
+
+What is left is the pair, and the pair is the contract working as written.
+
+## Reproducing this page
+
+- the variant table, from `python -m backtest.field_gate_isolation --store data/backtest.duckdb`;
+- the two replay rows, from `replay.discrimination_grid.run_grid` against
+  `data/replay.duckdb` over the same window, once with all 828 trades and once with the
+  trade list restricted to the names `data/backtest.duckdb.coverage.US.json` lists as
+  `stored`;
+- the rubric weights and thresholds, from `screener.score.DIMENSIONS` and `ADR_MIN`;
+- the gates, from `backtest.universe` and the contract cells it reads.

--- a/references/backtest_gate_isolation.txt
+++ b/references/backtest_gate_isolation.txt
@@ -1,0 +1,75 @@
+The gate isolation (#211) — one store, one population, one detector,
+one gate moving at a time.
+
+Full-gate rebuild vs the store's own universe rows: stored 297709, rebuilt 297709, extra 0, missing 0, over 821 sessions -> EXACT
+
+variant        members/sess  field det     in_field    picks    field       gap
+all-three             362.6      35971      165/503   14.55%   19.55%   -5.01pp
+no-adr                906.2      84329      247/503   14.98%   16.44%   -1.46pp
+no-trend              771.2      82650      231/503   14.29%   15.73%   -1.44pp
+no-liquidity          985.1     103411      193/503   16.58%   18.44%   -1.86pp
+liquidity-only       1687.8     176643      322/503   13.35%   12.64%   +0.72pp
+
+notes:
+  all-three      the run's own field — reproduces the committed -5.01pp
+  no-adr         drops the 3.5% ADR20 floor, which the app's universe does not have
+  no-trend       drops close > SMA50, which the app's universe does not have
+  no-liquidity   drops the $10M ADTV floor, which the app sets at $20M instead
+  liquidity-only drops both gates the app lacks, keeping only a liquidity floor
+
+picks/field are the share reaching >= 3.5 stars under rubric v1; gap is picks - field.
+
+Per-dimension hit rates, his picks against the field on the sessions he traded.
+A gate that duplicates a dimension shows up as that dimension's gap collapsing
+while the dimensions no gate touches stay put. Seven-dimension replayed score:
+`Sector` is cross-sectional and is not reconstructed on this path.
+
+  all-three
+    dimension     wt    picks    field       gap
+    Tightness      2    43.0%    25.0%    +18.0pp
+    Orderliness    1    40.6%    43.6%     -3.0pp
+    Prior move     1   100.0%   100.0%     +0.0pp
+    Base length    0    52.1%    67.8%    -15.7pp
+    MA support     1    86.1%    85.8%     +0.2pp
+    Volume         1    26.1%    32.3%     -6.2pp
+    ADR            2    89.7%    90.7%     -1.0pp
+
+  no-adr
+    dimension     wt    picks    field       gap
+    Tightness      2    39.7%    21.6%    +18.0pp
+    Orderliness    1    40.1%    46.4%     -6.3pp
+    Prior move     1   100.0%   100.0%     +0.0pp
+    Base length    0    51.4%    69.2%    -17.8pp
+    MA support     1    84.6%    85.2%     -0.6pp
+    Volume         1    33.6%    37.5%     -3.9pp
+    ADR            2    78.1%    66.3%    +11.8pp
+
+  no-trend
+    dimension     wt    picks    field       gap
+    Tightness      2    42.9%    24.3%    +18.6pp
+    Orderliness    1    36.4%    36.0%     +0.4pp
+    Prior move     1   100.0%   100.0%     +0.0pp
+    Base length    0    47.6%    56.5%     -8.9pp
+    MA support     1    80.5%    68.6%    +11.9pp
+    Volume         1    29.9%    35.3%     -5.4pp
+    ADR            2    88.3%    84.4%     +3.9pp
+
+  no-liquidity
+    dimension     wt    picks    field       gap
+    Tightness      2    43.5%    31.0%    +12.5pp
+    Orderliness    1    38.9%    42.6%     -3.7pp
+    Prior move     1   100.0%   100.0%     +0.0pp
+    Base length    0    51.3%    63.9%    -12.6pp
+    MA support     1    86.5%    85.2%     +1.3pp
+    Volume         1    29.5%    27.7%     +1.8pp
+    ADR            2    88.6%    92.9%     -4.3pp
+
+  liquidity-only
+    dimension     wt    picks    field       gap
+    Tightness      2    40.4%    20.7%    +19.7pp
+    Orderliness    1    34.5%    37.5%     -3.0pp
+    Prior move     1   100.0%   100.0%     +0.0pp
+    Base length    0    46.6%    57.8%    -11.2pp
+    MA support     1    78.6%    68.8%     +9.8pp
+    Volume         1    35.7%    39.7%     -4.0pp
+    ADR            2    77.0%    61.3%    +15.7pp


### PR DESCRIPTION
Closes #211.

`in_field` was the one anchor #198 could not settle: findings §4b's gap flipped from the
committed **+1.95pp** to **−5.01pp** inside the run's own field, and a sign flip is the one
outcome the anchor table refuses to let a written cause waive.

## The verdict

**A property of the method under the gates this run is contracted to use, not a defect in
how the field is built.**

The reversal is attributable to the **conjunction of two gates** — the ADR20 floor of 3.5%
and the trend gate, `close > SMA50`. Neither alone restores the sign; dropping both gives
**+0.72pp**. The liquidity floor is measured and exonerated. There is no bug, so `in_field`
is not re-measured over a repaired field — there is no repair to make.

| variant | `in_field` | gap |
| --- | ---: | ---: |
| all three — the run's own field | 165/503 (32.8%) | **−5.01pp** |
| no ADR floor | 247/503 (49.1%) | −1.46pp |
| no trend gate | 231/503 (45.9%) | −1.44pp |
| no liquidity floor | 193/503 (38.4%) | −1.86pp |
| liquidity only — both dropped | 322/503 (64.0%) | **+0.72pp** |

The mechanism is measured per rubric dimension rather than asserted: each of the two gates
**duplicates a rubric dimension** and lifts the *field's* hit rate on it until no spread is
left. The ADR floor kills the ADR dimension (+15.7pp → −1.0pp); the trend gate kills MA
support (+9.8pp → +0.2pp). Dimensions with no corresponding gate barely move. The single-gate
rows confirm it by recovering one dimension each and leaving the other flattened — the
prediction this explanation makes, and the measurement it could have failed.

The movement is entirely in the field, not in his picks: across every variant his picks sit
in a narrow 13.35–16.58% band while the field swings 12.64–19.55%. The gates do not make his
trades look worse; they make the field look better.

## What is in this branch

| What | Where |
| --- | --- |
| The verdict, in full | `references/backtest_gate_isolation.md` |
| Generated artefacts | `references/backtest_gate_isolation.{json,txt}` |
| The module | `backend/backtest/field_gate_isolation.py` |
| Its seam tests | `backend/tests/test_field_gate_isolation.py` |
| Pointers added | `references/backtest_anchor_divergence.md`, `docs/out-of-sample-backtest-plan.md` |

Reproduce in ≈40 min: `python -m backtest.field_gate_isolation --store data/backtest.duckdb`

Membership has to be **rebuilt** rather than read back — the store's persisted `universe`
rows are the intersection of every gate, so a variant that drops one needs names the run
never stored. That rebuild is the load-bearing claim, so it is checked two ways: under the
full gate set it reproduces the store's own rows exactly (297,709 / 297,709, 0 extra,
0 missing, 821 sessions, and `run_isolation` raises rather than reporting a cell if not), and
every gate predicate is pinned against `backtest.universe`'s own `passes_*` function on the
same bars.

## Acceptance criteria

- [x] Attributed to a specific gate, not the stateless universe as a whole — two named gates, all four single-gate drops measured
- [x] Runs in both directions; the committed pin now has a second measurement agreeing with it — 397/656 (+1.95pp) reproduced exactly, and 324/503 (+1.86pp) over the population held fixed
- [x] The verdict names which it is — a property, stated plainly
- [x] If a defect, fixed and re-measured — n/a, it is not a defect
- [ ] **If a property, the plan's ship criterion is re-examined** — see below
- [x] No constant moved to restore the sign; a constant that would have to move is reported as the finding — `ADR_FLOOR` is reported, not touched
- [x] The verdict is recorded where a reader of the run finds it — `references/backtest_gate_isolation.md`, linked from the divergence page

### The one criterion answered by pushing back

AC5 rests on the premise that the ship criterion assumes the rubric ranks. **That premise is
false.** The ship criterion is arm B's after-cost expectancy plus Phase 2's pessimistic bound
(`docs/out-of-sample-backtest-plan.md`, "Costs, metric, and the kill line"). It reads no
rubric term, and the plan's own three-outcome table already contemplates publishing a result
where the rubric ranks rather than decides.

So no ship-criterion revision follows. The narrower true consequence is recorded in both the
plan and the write-up: **findings §4b's gap must never be cited without naming the field it
was measured over.** +1.95pp under the app's universe, −5.01pp under the contract's — the
number is a property of the pair, not of the rubric.

This is the only place the delivered work departs from the ticket's framing, and it is the
issue author's call to accept or overrule.

## What this does not unblock

- **The anchor stays failed.** A sign flip is not waivable by a written cause, and this does
  not waive it. `backtest.full_run` still emits no figure, plot or payload. What changed is
  that the run is blocked on a *result* rather than on a mystery.
- **#196's survivorship bound blocks independently** and is larger than the effect the run is
  looking for — its pessimistic twin goes negative for any headline below +0.605R.
- **#194 is not answered.** This is a *selection* contrast; #194 asks whether a higher star
  score predicts a better *outcome*. Different and stronger question.

## Testing

969 backend tests pass, including 48 new seam tests.
