### PR TITLE
Measure what membership hysteresis is worth to the in_field anchor (#213)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,7 +56,10 @@ yesterday's membership for both stickiness and its hysteresis band. Dropping tha
 reintroduces the boundary churn it exists to damp — a name oscillating around a floor enters
 and leaves day by day — which is **nearly free at signal level**, since each signal is
 evaluated on its own session, and real at portfolio level. Recorded as a known difference,
-not fixed. Its 3.5% sits **deliberately below** the rubric's `score.ADR_MIN` of 5%, because
+not fixed. "Nearly free" is measured rather than asserted since #213: putting the band
+back inside the backtest's own field is worth **+0.40pp of `in_field` and 0.05pp of the
+rubric's gap**, against 3.5pp for any one gate (`references/backtest_gate_isolation.md`).
+Its 3.5% sits **deliberately below** the rubric's `score.ADR_MIN` of 5%, because
 findings §6 Finding 2 measured that 5% floor withholding a score point from 31% of his real
 entries, so a universe cut at 5% would leave the ADR dimension no spread to test.
 _Avoid_: backtest universe filter; reading the Rp 100 trim as a penny-stock filter — it is

--- a/backend/backtest/field_gate_isolation.py
+++ b/backend/backtest/field_gate_isolation.py
@@ -22,9 +22,10 @@ takes the compound apart.
 app — a different store, a different universe. This module moves the other way and
 stays inside the run's own field: one store (``backtest.duckdb``), one population
 (the same 503 replayable trades), one detector, one window. The only thing that
-moves between cells is **which gates build the universe**, one gate at a time. A
-cell read against the baseline therefore differs from it by exactly one gate, which
-is what "attribute it to a gate rather than to the universe" requires.
+moves between cells is **one difference from the app's universe** — a gate, or (since
+#213) the membership band. A cell read against the one beside it therefore differs
+from it by exactly that one thing, which is what "attribute it to a gate rather than
+to the universe" requires.
 
 **Four gates, not three.** The divergence page names three differences from the
 app's universe — the ADR20 floor, the ADTV floor and the dropped hysteresis. There
@@ -34,6 +35,26 @@ universe is liquidity, instrument type, listing age and density; it has neither 
 trend gate nor a volatility gate. So the trend gate is a variant here like the
 others, because a difference nobody listed is exactly the kind that ends up
 attributed to "the universe".
+
+**The fourth difference is not a gate, so it is walked rather than dropped (#213).**
+The app's universe is *hysteretic*: a name enters on the liquidity floor at ≥ 1.0× and
+leaves only below 0.8× (:data:`screener.universe.HYSTERESIS_EXIT`), which the contract
+drops. That cannot be switched off here, because the contract's classifier never had
+it — :func:`backtest.universe.classify` takes no prior membership and is stateless by
+construction (``universe.statelessness``). So the band is added instead, by a **stateful
+variant classifier** that lives only in this module
+(:func:`hysteretic_memberships`): it walks sessions forward carrying the previous
+session's membership, applies the app's band on the liquidity gate, and is otherwise the
+contract's own gates. Two cells use it — the run's own field plus the band, and the
+app-shaped field plus the band — and each is read against the same gate set without it,
+so what moves between them is the band and nothing else. Nothing about
+:mod:`backtest.universe` changes: its statelessness is a recorded property with its own
+test, and #213 measures what it costs rather than reversing it.
+
+Because the band is stateful, its cells are **walked into**: the window's own 126-session
+burn-in is replayed first so a member is something the walk has made rather than
+something its first session had to invent. No warm-up session is reported, and no bar
+outside the reference study's window is read to settle it.
 
 **Dropping a gate needs a superset, so membership is rebuilt rather than read.**
 :func:`replay.gate_sweep.build_sweep_sessions` reads membership off the store's
@@ -84,7 +105,15 @@ import time
 from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
-from typing import Callable, Mapping, Sequence
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    Iterable,
+    Mapping,
+    NamedTuple,
+    Sequence,
+)
 
 from screener.bars import Bar
 from screener.detection import detect, detection_gate
@@ -92,6 +121,7 @@ from screener.indicators import ADR_WINDOW
 from screener.ranks import rank_table
 from screener.store import Store
 from screener.universe import (
+    HYSTERESIS_EXIT,
     LIQUIDITY_WINDOW,
     _median as app_median,
     is_common_stock,
@@ -119,6 +149,12 @@ from replay.reference import (
 
 from .contract import DEFAULT_CONTRACT, UNIVERSE_LIQUIDITY_FLOOR_KEY, RunContract
 from .universe import ADR_FLOOR, TREND_WINDOW
+
+# The recorded figures, as JSON holds them: one payload, or one variant's row inside
+# it. Heterogeneous by construction — this is what is written to
+# ``backtest_gate_isolation.json`` and read back to re-render or merge a table without
+# re-measuring a cell.
+Cell = Mapping[str, Any]
 
 # The window the gate-dependent anchors were measured over, and the burn-in they
 # were measured with — the reference study's own window, restated here so a re-run
@@ -150,19 +186,55 @@ TREND, VOLATILITY, LIQUIDITY = "trend", "volatility", "liquidity"
 ALL_GATES = frozenset({TREND, VOLATILITY, LIQUIDITY})
 
 
+def band_threshold(floor: float, *, held: bool) -> float:
+    """The floor a name has to clear: 1.0× to enter, ``HYSTERESIS_EXIT`` to stay.
+
+    The app's asymmetry, in one expression and one place — "more evidence to leave
+    than to enter" (:mod:`screener.universe`, spec §4.1, §3.4 rules 3/6). The
+    multiple is imported from the app rather than restated here, so the band this
+    module measures is the band the app applies and cannot drift from it.
+    """
+    return floor * (HYSTERESIS_EXIT if held else 1.0)
+
+
+class GateFlags(NamedTuple):
+    """One candidate's gate answers on one session, computed once for every variant.
+
+    Four answers for three gates, because the liquidity floor is asked twice: at
+    1.0× (:attr:`liquidity`, which is what a non-member has to clear) and at 0.8×
+    (:attr:`liquidity_held`, which is what a member has to fall below to leave).
+    A stateless variant reads the first and never the second; a hysteretic one
+    picks between them by whether the name was a member on the session before.
+    """
+
+    trend: bool
+    volatility: bool
+    liquidity: bool
+    liquidity_held: bool
+
+
 @dataclass(frozen=True)
 class UniverseGateSet:
-    """One universe rule: the run's gates, minus at most one of them.
+    """One universe rule: the run's gates, minus at most one — and its band, or not.
 
-    ``dropped`` is the whole point — a variant that drops nothing is the run's own
-    field and is the baseline every other cell is read against. Because exactly one
-    gate separates any variant from that baseline, a difference between them
-    attributes to that gate and to nothing else.
+    ``dropped`` is the whole point — a variant that drops nothing and holds no band
+    is the run's own field and is the baseline every other cell is read against.
+    Because exactly one thing separates any variant from a variant beside it, a
+    difference between them attributes to that thing and to nothing else.
+
+    ``hysteresis`` is the fourth difference from the app's universe (#213) and the
+    one that is not a gate: it cannot be switched off, because the contract's
+    classifier never had it. A variant that sets it walks sessions forward carrying
+    the previous session's membership and applies the app's 0.8–1.0× band on the
+    liquidity floor, and is otherwise these same gates. It is a **measurement
+    variant and lives only here** — :func:`backtest.universe.classify` stays
+    stateless (``universe.statelessness``).
     """
 
     name: str
     gates: frozenset[str]
     note: str
+    hysteresis: bool = False
 
     @property
     def dropped(self) -> frozenset[str]:
@@ -203,6 +275,22 @@ VARIANTS: tuple[UniverseGateSet, ...] = (
         "liquidity-only",
         frozenset({LIQUIDITY}),
         "drops both gates the app lacks, keeping only a liquidity floor",
+    ),
+    # The two band cells (#213). Each one is a row above it plus the app's
+    # hysteresis and nothing else, so each is read against that row and the
+    # difference is what the band is worth. Both keep the liquidity gate, because
+    # the band is on that floor and a band on a dropped floor measures nothing.
+    UniverseGateSet(
+        "all-three+band",
+        ALL_GATES,
+        "the run's own field, plus the app's 0.8-1.0x hysteresis band",
+        hysteresis=True,
+    ),
+    UniverseGateSet(
+        "liquidity-only+band",
+        frozenset({LIQUIDITY}),
+        "the app's full shape — its gate set and its band — from the run's store",
+        hysteresis=True,
     ),
 )
 
@@ -258,8 +346,8 @@ class CandidateSeries:
             return False
         return sum(window) / ADR_WINDOW >= ADR_FLOOR
 
-    def passes_liquidity(self, k: int, floor: float) -> bool:
-        """Median dollar volume at or above ``floor`` — the app's own measure.
+    def adtv(self, k: int) -> float:
+        """Median dollar volume over the trailing window — the app's own measure.
 
         Deliberately **not** gated on a full window, because
         :func:`screener.universe.median_dollar_volume` is not: it medians whatever
@@ -268,28 +356,53 @@ class CandidateSeries:
         moment the ``no-trend`` variant drops it, so copying the app's shortfall
         behaviour rather than tidying it is what keeps that variant honest.
         """
-        return app_median(self.dollar_volume[max(0, k - LIQUIDITY_WINDOW):k]) >= floor
+        return app_median(self.dollar_volume[max(0, k - LIQUIDITY_WINDOW):k])
 
-    def flags(self, session: date, floor: float) -> tuple[bool, bool, bool] | None:
-        """The three gate answers at ``session``, or ``None`` if no variant can pass.
+    def passes_liquidity_band(self, k: int, floor: float, *, held: bool) -> bool:
+        """The app's hysteretic floor: 1.0× to enter, below 0.8× to leave (#213).
+
+        ``held`` is whether this name was a member on the session before, which is
+        the only state anywhere in this module — and the reason a hysteretic variant
+        has to be *walked* rather than evaluated session by session.
+        """
+        return self.adtv(k) >= band_threshold(floor, held=held)
+
+    def passes_liquidity(self, k: int, floor: float) -> bool:
+        """ADTV at or above ``floor`` — :func:`backtest.universe.passes_liquidity_gate`.
+
+        The entry side of the band, which is what a name with no prior membership
+        faces, and which is the whole liquidity gate for every stateless variant.
+        """
+        return self.passes_liquidity_band(k, floor, held=False)
+
+    def flags(self, session: date, floor: float) -> GateFlags | None:
+        """The gate answers at ``session``, or ``None`` if no variant can pass.
 
         Computed once and shared by every variant, which is what keeps the variants
         differing by their gate set alone. ``None`` means the candidate is out under
         *every* variant — it is not common stock, or it has no bars yet — so no
         variant has to represent it.
+
+        Both ends of the band are asked through :meth:`passes_liquidity_band` rather
+        than compared here, so the predicate the seam tests pin against
+        :mod:`screener.universe` is the predicate this pass actually runs. The extra
+        median is worth it: the whole pass is 19 seconds against the sweeps' minutes.
         """
         if not is_common_stock(self.symbol, ""):
             return None
         k = self.prefix_len(session)
         if k == 0:
             return None
-        return (
+        return GateFlags(
             self.passes_trend(k),
             self.passes_adr(k),
             self.passes_liquidity(k, floor),
+            self.passes_liquidity_band(k, floor, held=True),
         )
 
-    def is_member(self, session: date, gates: frozenset[str], floor: float) -> bool:
+    def is_member(
+        self, session: date, gates: frozenset[str], floor: float, *, held: bool = False
+    ) -> bool:
         """Is this candidate a member on ``session`` under ``gates``?
 
         The instrument-type test is not a variant — it is not one of the three gates
@@ -303,15 +416,21 @@ class CandidateSeries:
         flags = self.flags(session, floor)
         if flags is None:
             return False
-        return passes_under(flags, gates)
+        return passes_under(flags, gates, held=held)
 
 
-def passes_under(flags: tuple[bool, bool, bool], gates: frozenset[str]) -> bool:
-    """Do ``flags`` clear ``gates``? The only place a variant's rule is applied."""
-    trend, volatility, liquidity = flags
+def passes_under(flags: GateFlags, gates: frozenset[str], *, held: bool = False) -> bool:
+    """Do ``flags`` clear ``gates``? The only place a variant's rule is applied.
+
+    ``held`` is the band, and it relaxes the liquidity floor and nothing else — the
+    app's band is on that floor alone (``screener.universe._is_member``), so a held
+    name still has to clear every other gate the variant applies. It is ``False``
+    for every stateless variant, which is what makes those variants stateless.
+    """
+    liquidity = flags.liquidity_held if held else flags.liquidity
     return (
-        (trend or TREND not in gates)
-        and (volatility or VOLATILITY not in gates)
+        (flags.trend or TREND not in gates)
+        and (flags.volatility or VOLATILITY not in gates)
         and (liquidity or LIQUIDITY not in gates)
     )
 
@@ -357,14 +476,20 @@ def members_at(
     session: date,
     gates: frozenset[str],
     floor: float,
+    *,
+    prior: Collection[str] = (),
 ) -> list[str]:
     """The sorted members on ``session`` under ``gates`` — one variant's universe.
 
     Sorted, like :func:`backtest.universe.classify`, so a membership is comparable to
-    the store's own rows without either side being re-ordered first.
+    the store's own rows without either side being re-ordered first. ``prior`` is
+    the previous session's membership, and passing a non-empty one is what asks for
+    the band; a stateless variant's caller leaves it empty.
     """
     return sorted(
-        symbol for symbol, s in series.items() if s.is_member(session, gates, floor)
+        symbol
+        for symbol, s in series.items()
+        if s.is_member(session, gates, floor, held=symbol in prior)
     )
 
 
@@ -373,18 +498,20 @@ def gate_flags_by_session(
     sessions: Sequence[date],
     floor: float,
     progress: Callable[[int, int], None] | None = None,
-) -> list[dict[str, tuple[bool, bool, bool]]]:
-    """Every candidate's three gate answers, per session, computed once.
+) -> list[dict[str, GateFlags]]:
+    """Every candidate's gate answers, per session, computed once.
 
     The single expensive pass of the isolation, and the reason every variant after it
     is cheap: the predicates do not depend on the variant, so they are evaluated here
     and each variant is a boolean ``and`` over the same flags
-    (:func:`memberships_under`). Candidates no variant can admit are absent rather
-    than stored as three ``False`` flags.
+    (:func:`memberships_for`). Candidates no variant can admit are absent rather
+    than stored as four ``False`` flags — and a name that cannot even clear 0.8× the
+    floor is out under the band too, so dropping it stays safe now that a hysteretic
+    variant reads the same flags.
     """
-    out: list[dict[str, tuple[bool, bool, bool]]] = []
+    out: list[dict[str, GateFlags]] = []
     for i, session in enumerate(sessions, start=1):
-        per_session: dict[str, tuple[bool, bool, bool]] = {}
+        per_session: dict[str, GateFlags] = {}
         for symbol, s in series.items():
             flags = s.flags(session, floor)
             if flags is not None and any(flags):
@@ -396,14 +523,76 @@ def gate_flags_by_session(
 
 
 def memberships_under(
-    flags_by_session: Sequence[Mapping[str, tuple[bool, bool, bool]]],
+    flags_by_session: Sequence[Mapping[str, GateFlags]],
     gates: frozenset[str],
 ) -> list[list[str]]:
-    """One variant's membership on every session, derived from the shared flags."""
+    """One stateless variant's membership on every session, from the shared flags.
+
+    Each session's answer depends on that session's flags and nothing else, exactly
+    as :func:`backtest.universe.classify` does.
+    """
     return [
         sorted(sym for sym, f in per_session.items() if passes_under(f, gates))
         for per_session in flags_by_session
     ]
+
+
+def hysteretic_memberships(
+    flags_by_session: Sequence[Mapping[str, GateFlags]],
+    gates: frozenset[str],
+    prior: Collection[str] = (),
+) -> list[list[str]]:
+    """The **stateful variant classifier** (#213): the same gates, walked forward.
+
+    The one thing in this module that is not a function of a single session. It
+    carries the previous session's membership and lets a member clear the liquidity
+    floor at 0.8× where a non-member needs 1.0×, which is the app's band and the
+    app's asymmetry — "more evidence to leave than to enter".
+
+    It is a **measurement variant and nothing else**. It is used by this harness and
+    never by the run: :func:`backtest.universe.classify` takes no prior membership
+    and returns the same answer however often it is asked
+    (``universe.statelessness``), and #213 measures what that costs rather than
+    changing it.
+
+    ``prior`` seeds the walk, which is what a warm-up hands in. Started cold it
+    admits nobody on the band on its first session — a member is something the walk
+    has to have made — so the sessions a cell reports are walked *into* rather than
+    started at (:func:`memberships_for`).
+
+    A name absent from a session's flags is out under every rule including the band,
+    so it leaves membership here as it does anywhere else.
+    """
+    members: set[str] = set(prior)
+    out: list[list[str]] = []
+    for per_session in flags_by_session:
+        members = {
+            sym
+            for sym, f in per_session.items()
+            if passes_under(f, gates, held=sym in members)
+        }
+        out.append(sorted(members))
+    return out
+
+
+def memberships_for(
+    flags_by_session: Sequence[Mapping[str, GateFlags]],
+    variant: UniverseGateSet,
+    *,
+    warm_up: int = 0,
+    prior: Collection[str] = (),
+) -> list[list[str]]:
+    """One variant's membership on the **measured** sessions, however it is built.
+
+    ``warm_up`` is how many leading sessions are there to settle the band rather
+    than to be reported: the walk reads them and the result drops them, so a
+    hysteretic cell is measured over the same sessions as every other cell. A
+    stateless variant ignores them, which is what "the warm-up changes nothing
+    except the band" means here.
+    """
+    if not variant.hysteresis:
+        return memberships_under(flags_by_session[warm_up:], variant.gates)
+    return hysteretic_memberships(flags_by_session, variant.gates, prior)[warm_up:]
 
 
 # -- checking the reconstruction against the store ----------------------------
@@ -651,9 +840,25 @@ class ReconstructionFailed(RuntimeError):
 class Isolation:
     check: ReconstructionCheck
     results: tuple[VariantResult, ...]
+    warm_up: int = 0
 
     def by_name(self, name: str) -> VariantResult:
         return next(r for r in self.results if r.variant.name == name)
+
+
+def window_sessions(calendar: Sequence[date]) -> tuple[list[date], list[date]]:
+    """The anchor's window, split into the burn-in and the sessions it measures.
+
+    The burn-in is what the reference study discards, and it is what a hysteretic
+    variant needs for the very reason that study discards it: a walk started cold
+    has no members to hold, so its first sessions would read as stateless ones. The
+    replay study warms over the same 126 sessions and says why — "so the hysteresis
+    band settles before any measured session" (findings §4, user stories 13/14) — so
+    the band cells here settle over exactly the sessions the app-side figure they are
+    compared against settled over, and no bar outside the window is read to do it.
+    """
+    windowed = [s for s in calendar if WINDOW_START <= s <= WINDOW_END]
+    return windowed[:WINDOW_BURN_IN], windowed[WINDOW_BURN_IN:]
 
 
 def run_isolation(
@@ -664,27 +869,39 @@ def run_isolation(
     trades: Sequence[ExecutedTrade] | None = None,
     variants: Sequence[UniverseGateSet] = VARIANTS,
     sessions: Sequence[date] | None = None,
+    warm_up: Sequence[date] | None = None,
     progress: Callable[[str], None] | None = None,
 ) -> Isolation:
     """Measure every variant over one shared pass of the gate predicates.
 
     Stops on a reconstruction that is not exact, rather than reporting cells that
     would be measuring the candidate pool instead of the gates.
+
+    ``warm_up`` is the sessions a hysteretic variant walks through before the ones
+    it reports, and it defaults to the window's own burn-in. It is skipped entirely
+    when no variant is hysteretic, so the stateless table costs exactly what it did.
+    Nothing measured is read off a warm-up session: the reconstruction check and
+    every cell are over ``sessions`` alone.
     """
     say = progress or (lambda _m: None)
     store = CachingStore.wrap(store)
     floor = contract.value(UNIVERSE_LIQUIDITY_FLOOR_KEY)[market]
     calendar = store.sessions(market)
-    measured = (
-        list(sessions)
-        if sessions is not None
-        else [s for s in calendar if WINDOW_START <= s <= WINDOW_END][WINDOW_BURN_IN:]
+    burn_in, windowed = window_sessions(calendar)
+    measured = list(sessions) if sessions is not None else windowed
+    warming = (
+        list(warm_up)
+        if warm_up is not None
+        else (burn_in if sessions is None else [])
     )
+    if not any(v.hysteresis for v in variants):
+        warming = []
     trades = list(trades) if trades is not None else load_trades(DEFAULT_REFERENCE_JSON)
     replayable = [
         c.trade for c in classify_trades(trades, store, market=market) if c.replayable
     ]
     say(f"{len(measured)} measured sessions, {measured[0]} .. {measured[-1]}; "
+        f"{len(warming)} warm-up sessions for the band; "
         f"{len(replayable)} of {len(trades)} trades replayable; "
         f"liquidity floor {floor:,.0f}")
 
@@ -694,13 +911,15 @@ def run_isolation(
 
     say("evaluating every gate once per candidate and session ...")
     started = time.time()
-    flags = gate_flags_by_session(series, measured, floor)
+    flags = gate_flags_by_session(series, list(warming) + measured, floor)
     say(f"  done in {time.time() - started:.0f}s")
 
-    by_variant = {v.name: memberships_under(flags, v.gates) for v in variants}
+    by_variant = {
+        v.name: memberships_for(flags, v, warm_up=len(warming)) for v in variants
+    }
 
     say("checking the full-gate rebuild against the store's own universe rows ...")
-    baseline = memberships_under(flags, ALL_GATES)
+    baseline = memberships_under(flags[len(warming):], ALL_GATES)
     check = verify_reconstruction(store, market, measured, baseline)
     say(f"  stored {check.stored}, rebuilt {check.rebuilt}, "
         f"extra {check.extra}, missing {check.missing} -> "
@@ -724,7 +943,7 @@ def run_isolation(
             f"in_field {r.in_field}/{r.placed}  gap {_pp(r.gap_pp)}  "
             f"[{r.seconds:.0f}s]")
         results.append(r)
-    return Isolation(check=check, results=tuple(results))
+    return Isolation(check=check, results=tuple(results), warm_up=len(warming))
 
 
 # -- reporting ----------------------------------------------------------------
@@ -738,62 +957,202 @@ def _pct(value: float | None) -> str:
     return "n/a" if value is None else f"{value * 100:.2f}%"
 
 
-def format_isolation(isolation: Isolation) -> str:
-    """The isolation as a table, baseline first, one gate dropped per row."""
-    c = isolation.check
+def band_effects(variants: Sequence[Cell]) -> list[dict[str, Any]]:
+    """What the band is worth, per hysteretic cell: its stateless twin, subtracted.
+
+    The twin is the row with the same gate set and no band, so the difference is
+    the band and nothing else — the same one-variable-at-a-time rule the gate rows
+    are built on. A pair with a cell nobody measured (no ``gap_pp``, no placed
+    trades) yields **no effect at all** rather than a zero one: "the band is worth
+    nothing" and "nobody measured it" are different claims, and only the first is a
+    finding.
+    """
+    by_gates = {
+        frozenset(v["gates"]): v for v in variants if not v.get("hysteresis")
+    }
+    out = []
+    for variant in variants:
+        if not variant.get("hysteresis"):
+            continue
+        twin = by_gates.get(frozenset(variant["gates"]))
+        if twin is None or variant["gap_pp"] is None or twin["gap_pp"] is None:
+            continue
+        placed = variant["placed"]
+        out.append(
+            {
+                "variant": variant["name"],
+                "baseline": twin["name"],
+                "gates": sorted(variant["gates"]),
+                "members_delta": variant["members_per_session"]
+                - twin["members_per_session"],
+                "in_field": variant["in_field"],
+                "baseline_in_field": twin["in_field"],
+                "placed": placed,
+                "in_field_delta": variant["in_field"] - twin["in_field"],
+                "in_field_delta_pp": (
+                    (variant["in_field"] - twin["in_field"]) / placed * 100
+                    if placed
+                    else None
+                ),
+                "gap_pp": variant["gap_pp"],
+                "baseline_gap_pp": twin["gap_pp"],
+                "gap_delta_pp": variant["gap_pp"] - twin["gap_pp"],
+            }
+        )
+    return out
+
+
+def format_payload(payload: Cell) -> str:
+    """The isolation as a table, rendered from the figures that were recorded.
+
+    Reading the payload rather than the objects is what lets a table be re-rendered
+    — or a subset of rows merged into it (:func:`merge_payloads`) — without
+    re-measuring cells that have already been run.
+    """
+    c = payload["reconstruction"]
+    variants = payload["variants"]
+    width = max(len("variant"), *(len(v["name"]) for v in variants))
     lines = [
-        "The gate isolation (#211) — one store, one population, one detector,",
-        "one gate moving at a time.",
+        "The gate isolation (#211, #213) — one store, one population, one detector,",
+        "one difference from the app's universe moving at a time.",
         "",
-        f"Full-gate rebuild vs the store's own universe rows: stored {c.stored}, "
-        f"rebuilt {c.rebuilt}, extra {c.extra}, missing {c.missing}, "
-        f"over {c.sessions} sessions -> {'EXACT' if c.exact else 'MISMATCH'}",
+        f"Full-gate rebuild vs the store's own universe rows: stored {c['stored']}, "
+        f"rebuilt {c['rebuilt']}, extra {c['extra']}, missing {c['missing']}, "
+        f"over {c['sessions']} sessions -> {'EXACT' if c['exact'] else 'MISMATCH'}",
         "",
-        f"{'variant':<14} {'members/sess':>12} {'field det':>10} "
+        f"{'variant':<{width}} {'members/sess':>12} {'field det':>10} "
         f"{'in_field':>12} {'picks':>8} {'field':>8} {'gap':>9}",
     ]
-    for r in isolation.results:
+    for v in variants:
+        placed = "{}/{}".format(v["in_field"], v["placed"])
         lines.append(
-            f"{r.variant.name:<14} {r.members_per_session:>12.1f} "
-            f"{r.field_detections:>10} "
-            f"{f'{r.in_field}/{r.placed}':>12} "
-            f"{_pct(r.picks_share):>8} {_pct(r.field_share):>8} "
-            f"{_pp(r.gap_pp):>9}"
+            f"{v['name']:<{width}} {v['members_per_session']:>12.1f} "
+            f"{v['field_detections']:>10} {placed:>12} "
+            f"{_pct(v['picks_share']):>8} {_pct(v['field_share']):>8} "
+            f"{_pp(v['gap_pp']):>9}"
         )
     lines += ["", "notes:"]
-    for r in isolation.results:
-        lines.append(f"  {r.variant.name:<14} {r.variant.note}")
+    for v in variants:
+        lines.append(f"  {v['name']:<{width}} {v['note']}")
     lines += [
         "",
-        f"picks/field are the share reaching >= {DISCRIMINATION_STARS} stars under "
-        f"rubric v{PUBLISHED_RUBRIC}; gap is picks - field.",
+        f"picks/field are the share reaching >= {payload['stars']} stars under "
+        f"rubric v{payload['rubric_version']}; gap is picks - field.",
+    ]
+    effects = payload.get("band_effects") or []
+    if effects:
+        warm = payload["window"].get("band_warm_up", 0)
+        lines += [
+            "",
+            "What the app's hysteresis band is worth: each band row against the same",
+            f"gates without it. The band relaxes the liquidity floor to "
+            f"{HYSTERESIS_EXIT:g}x for a",
+            "name that was a member on the session before, and touches no other gate.",
+            f"It is walked into over {warm} warm-up sessions, none of which is reported.",
+            "",
+            f"  {'band row':<{width}} {'vs':<{width}} {'members':>9} "
+            f"{'in_field':>12} {'gap':>9} {'gap delta':>10}",
+        ]
+        for e in effects:
+            moved = "{:+d}/{}".format(e["in_field_delta"], e["placed"])
+            lines.append(
+                f"  {e['variant']:<{width}} {e['baseline']:<{width}} "
+                f"{e['members_delta']:>+9.1f} {moved:>12} "
+                f"{_pp(e['gap_pp']):>9} {_pp(e['gap_delta_pp']):>10}"
+            )
+    lines += [
         "",
         "Per-dimension hit rates, his picks against the field on the sessions he traded.",
         "A gate that duplicates a dimension shows up as that dimension's gap collapsing",
         "while the dimensions no gate touches stay put. Seven-dimension replayed score:",
         "`Sector` is cross-sectional and is not reconstructed on this path.",
     ]
-    for r in isolation.results:
-        if not r.dimensions:
+    for v in variants:
+        if not v["dimensions"]:
             continue
-        lines += ["", f"  {r.variant.name}"]
+        lines += ["", f"  {v['name']}"]
         lines.append(
             f"    {'dimension':<13}{'wt':>3}{'picks':>9}{'field':>9}{'gap':>10}"
         )
-        for d in r.dimensions:
+        for d in v["dimensions"]:
             lines.append(
-                f"    {d.dimension:<13}{d.weight:>3}{d.picks * 100:>8.1f}%"
-                f"{d.field * 100:>8.1f}%{d.gap_pp:>+9.1f}pp"
+                f"    {d['dimension']:<13}{d['weight']:>3}{d['picks'] * 100:>8.1f}%"
+                f"{d['field'] * 100:>8.1f}%{d['gap_pp']:>+9.1f}pp"
             )
     return "\n".join(lines)
 
 
+def format_isolation(isolation: Isolation) -> str:
+    """The isolation as a table, baseline first, one difference per row."""
+    return format_payload(isolation_payload(isolation))
+
+
+def _comparable(payload: Cell, key: str) -> Any:
+    """The part of ``key`` two payloads have to agree on to sit in one table.
+
+    The window's warm-up is excluded: it settles the band for the rows that have
+    one and changes nothing about the sessions any row is measured over, so a
+    recorded table from before there were band rows still merges.
+    """
+    value = payload.get(key)
+    if key == "window":
+        return {k: v for k, v in value.items() if k != "band_warm_up"}
+    return value
+
+
+def merge_payloads(recorded: Cell, fresh: Cell) -> dict[str, Any]:
+    """``fresh``'s cells on top of ``recorded``'s, in :data:`VARIANTS` order.
+
+    #213 adds two rows to a table whose other five were run three times across two
+    implementations and reproduced identically, so it measures the two and merges
+    rather than re-measuring what is already recorded.
+
+    Rows from two different measurements would read as one, so the things that
+    would make them incomparable — the window, the detector, the field, the rubric —
+    have to match, and a mismatch raises rather than merging. The reconstruction
+    check reported is the fresh run's: it is the pass that actually verified the
+    pool these cells were measured off.
+    """
+    for key in ("window", "detector_version", "field", "rubric_version", "stars"):
+        if _comparable(recorded, key) != _comparable(fresh, key):
+            raise ValueError(
+                f"refusing to merge: {key} differs between the recorded isolation "
+                f"({_comparable(recorded, key)!r}) and the fresh one "
+                f"({_comparable(fresh, key)!r}). Cells from two measurements would "
+                f"read as one table."
+            )
+    cells = {v["name"]: v for v in recorded["variants"]}
+    cells.update({v["name"]: v for v in fresh["variants"]})
+    # A table recorded before there were band rows has no ``hysteresis`` on its
+    # cells. Fill it from the variant of that name rather than leaving the merged
+    # artifact half-labelled, which would read as "unknown" rather than "stateless".
+    known = {v.name: v.hysteresis for v in VARIANTS}
+    cells = {
+        name: (
+            cell
+            if "hysteresis" in cell
+            else {**cell, "hysteresis": known.get(name, False)}
+        )
+        for name, cell in cells.items()
+    }
+    order = [v.name for v in VARIANTS]
+    merged = dict(recorded)
+    merged["window"] = fresh["window"]
+    merged["reconstruction"] = fresh["reconstruction"]
+    merged["variants"] = [cells.pop(name) for name in order if name in cells] + list(
+        cells.values()
+    )
+    merged["band_effects"] = band_effects(merged["variants"])
+    return merged
+
+
 def isolation_payload(isolation: Isolation) -> dict:
-    return {
+    payload = {
         "window": {
             "start": WINDOW_START.isoformat(),
             "end": WINDOW_END.isoformat(),
             "burn_in": WINDOW_BURN_IN,
+            "band_warm_up": isolation.warm_up,
             "market": ISOLATION_MARKET,
         },
         "detector_version": ANCHOR_DETECTOR,
@@ -814,6 +1173,7 @@ def isolation_payload(isolation: Isolation) -> dict:
                 "gates": sorted(r.variant.gates),
                 "dropped": sorted(r.variant.dropped),
                 "note": r.variant.note,
+                "hysteresis": r.variant.hysteresis,
                 "members_per_session": r.members_per_session,
                 "field_detections": r.field_detections,
                 "in_field": r.in_field,
@@ -836,6 +1196,8 @@ def isolation_payload(isolation: Isolation) -> dict:
             for r in isolation.results
         ],
     }
+    payload["band_effects"] = band_effects(payload["variants"])
+    return payload
 
 
 DEFAULT_OUT_JSON = (
@@ -846,24 +1208,54 @@ DEFAULT_OUT_TXT = (
 )
 
 
+def selected_variants(names: Iterable[str]) -> tuple[UniverseGateSet, ...]:
+    """The named variants, in :data:`VARIANTS` order, or a refusal naming the rest."""
+    wanted = list(names)
+    known = {v.name: v for v in VARIANTS}
+    unknown = [n for n in wanted if n not in known]
+    if unknown:
+        raise SystemExit(
+            f"unknown variant(s) {', '.join(unknown)}; "
+            f"known: {', '.join(known)}"
+        )
+    return tuple(v for v in VARIANTS if v.name in set(wanted))
+
+
 def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="The #211 gate isolation.")
+    parser = argparse.ArgumentParser(description="The #211/#213 gate isolation.")
     parser.add_argument("--store", default="data/backtest.duckdb")
     parser.add_argument("--market", default=ISOLATION_MARKET)
     parser.add_argument("--out-json", default=str(DEFAULT_OUT_JSON))
     parser.add_argument("--out-txt", default=str(DEFAULT_OUT_TXT))
+    parser.add_argument(
+        "--only",
+        default="",
+        help=(
+            "comma-separated variant names to measure, merged into the cells "
+            "--out-json already records rather than replacing them. The five "
+            "stateless rows were run three times across two implementations and "
+            "reproduced identically; #213's two band rows are what this adds."
+        ),
+    )
     args = parser.parse_args(argv)
 
     def say(message: str) -> None:
         print(message, flush=True)
 
-    isolation = run_isolation(Store.open(args.store), args.market, progress=say)
-    report = format_isolation(isolation)
+    only = [n.strip() for n in args.only.split(",") if n.strip()]
+    variants = selected_variants(only) if only else VARIANTS
+    isolation = run_isolation(
+        Store.open(args.store), args.market, variants=variants, progress=say
+    )
+    payload = isolation_payload(isolation)
+    if only:
+        recorded = json.loads(Path(args.out_json).read_text())
+        payload = merge_payloads(recorded, payload)
+        say(f"merged {len(only)} measured cell(s) into {args.out_json}")
+    report = format_payload(payload)
     print()
     print(report)
-    Path(args.out_json).write_text(
-        json.dumps(isolation_payload(isolation), indent=1) + "\n"
-    )
+    Path(args.out_json).write_text(json.dumps(payload, indent=1) + "\n")
     Path(args.out_txt).write_text(report + "\n")
     return 0
 

--- a/backend/tests/test_field_gate_isolation.py
+++ b/backend/tests/test_field_gate_isolation.py
@@ -27,14 +27,18 @@ recorded in ``references/backtest_gate_isolation.txt``. What is tested here is t
 arithmetic that check relies on.
 """
 
+import inspect
 from datetime import date, timedelta
+from typing import Callable
 
 import pytest
 
+from screener import universe as app_universe
 from screener.bars import Bar
 from screener.store import Store
 from screener.universe import median_dollar_volume
 
+from backtest import universe as backtest_universe
 from backtest.contract import DEFAULT_CONTRACT, UNIVERSE_LIQUIDITY_FLOOR_KEY
 from backtest.universe import (
     ADR_FLOOR,
@@ -46,17 +50,31 @@ from backtest.universe import (
 )
 from backtest.field_gate_isolation import (
     ALL_GATES,
+    HYSTERESIS_EXIT,
     LIQUIDITY,
     TREND,
     VARIANTS,
     VOLATILITY,
+    WINDOW_BURN_IN,
+    WINDOW_END,
+    WINDOW_START,
+    GateFlags,
     ReconstructionFailed,
     UniverseGateSet,
+    band_effects,
+    band_threshold,
+    format_isolation,
+    format_payload,
     gate_flags_by_session,
+    hysteretic_memberships,
+    isolation_payload,
     members_at,
+    memberships_for,
     memberships_under,
+    merge_payloads,
     run_isolation,
     series_of,
+    window_sessions,
 )
 
 US_FLOOR = DEFAULT_CONTRACT.value(UNIVERSE_LIQUIDITY_FLOOR_KEY)["US"]
@@ -72,13 +90,19 @@ def _bars(
     price: float = 50.0,
     drift: float = 0.002,
     adr_pct: float = 0.05,
-    dollar_volume: float = 50_000_000.0,
+    dollar_volume: float | Callable[[int], float] = 50_000_000.0,
     sessions: list[date] | None = None,
 ) -> list[Bar]:
-    """Bars that clear every gate by default, one knob per gate."""
+    """Bars that clear every gate by default, one knob per gate.
+
+    ``dollar_volume`` takes a function of the bar's index as well as a level, for
+    the one case a level cannot express: a name whose turnover *changes*, which is
+    what the hysteresis band exists to respond to.
+    """
     out = []
     for i, s in enumerate(sessions or SESSIONS):
         p = price * (1 + drift) ** i
+        dv = dollar_volume(i) if callable(dollar_volume) else dollar_volume
         out.append(
             Bar(
                 session=s,
@@ -87,7 +111,7 @@ def _bars(
                 low=p,
                 close=p,
                 adj_close=p,
-                volume=max(1, round(dollar_volume / p)),
+                volume=max(1, round(dv / p)),
             )
         )
     return out
@@ -217,45 +241,23 @@ def _four_names():
     }
 
 
-@pytest.mark.parametrize("variant", VARIANTS, ids=lambda v: v.name)
-def test_the_batch_path_agrees_with_the_direct_one(variant):
-    """One shared pass of the predicates must place every name where the direct
-    per-variant evaluation does, or the variants are not sharing a baseline."""
-    series = _four_names()
-    flags = gate_flags_by_session(series, [SIGNAL], US_FLOOR)
-    assert memberships_under(flags, variant.gates) == [
-        members_at(series, SIGNAL, variant.gates, US_FLOOR)
-    ]
-
-
 def test_a_candidate_no_variant_can_admit_is_left_out_of_the_flags():
-    """Carrying every rejected name at every session would cost more than it says."""
+    """Carrying every rejected name at every session would cost more than it says.
+
+    A name below 0.8× the floor is out under the band too, so the pruning stays
+    safe once a hysteretic variant reads the same flags.
+    """
     series = {"NOPE": _series("NOPE", adr_pct=0.02, drift=-0.01, dollar_volume=1.0)}
     assert gate_flags_by_session(series, [SIGNAL], US_FLOOR) == [{}]
     for variant in VARIANTS:
-        assert memberships_under(
-            gate_flags_by_session(series, [SIGNAL], US_FLOOR), variant.gates
+        assert memberships_for(
+            gate_flags_by_session(series, [SIGNAL], US_FLOOR),
+            variant,
+            prior={"NOPE"},
         ) == [[]]
 
 
 # -- a variant drops a gate, and does nothing else ----------------------------
-
-
-def test_the_variants_are_the_baseline_then_one_drop_per_gate():
-    """Baseline first, then every gate dropped alone — that is the attribution.
-
-    The two-gate cell is deliberately last and deliberately the only one: it exists
-    because no single drop restores the sign, so it is a follow-up question rather
-    than part of the one-variable-at-a-time table above it.
-    """
-    baseline, *rest = VARIANTS
-    assert baseline.gates == ALL_GATES and baseline.dropped == frozenset()
-    singles = [v for v in rest if len(v.dropped) == 1]
-    assert {next(iter(v.dropped)) for v in singles} == ALL_GATES
-    pairs = [v for v in rest if len(v.dropped) == 2]
-    assert [v.name for v in pairs] == ["liquidity-only"]
-    assert pairs[0].gates == frozenset({LIQUIDITY})
-    assert len(singles) + len(pairs) == len(rest)
 
 
 @pytest.mark.parametrize("gate", sorted(ALL_GATES))
@@ -325,6 +327,11 @@ def test_the_isolation_measures_every_variant_end_to_end():
         assert isolation.by_name(name).members_per_session == 2.0
     # Dropping two admits both their names: everything but the illiquid one.
     assert isolation.by_name("liquidity-only").members_per_session == 3.0
+    # On one session from a cold start the band has no prior to hold anything by,
+    # so each hysteretic row lands on its stateless twin. What the band is worth
+    # needs a walk, and the walk is measured in its own tests below.
+    assert isolation.by_name("all-three+band").members_per_session == 1.0
+    assert isolation.by_name("liquidity-only+band").members_per_session == 3.0
     # No trades, so there is nothing to place and no gap to read — and that must be
     # reported as absent rather than as a zero edge.
     assert isolation.by_name("all-three").placed == 0
@@ -373,3 +380,421 @@ def test_the_isolation_stops_when_the_rebuild_misses_the_store_s_own_rows():
             variants=[UniverseGateSet("all-three", ALL_GATES, "")],
         )
     assert "does not reproduce" in str(excinfo.value)
+
+
+# -- the band: what the app's hysteresis is worth, measured beside the contract
+
+
+APP_FLOOR = app_universe.LIQUIDITY_FLOOR["US"]
+
+
+# The four flag positions, as the walk reads them: the three gates, then the
+# fourth answer the band needs — "does this name still clear 0.8× the floor?".
+def _flags(trend=True, volatility=True, liquidity=True, held=True):
+    return GateFlags(trend, volatility, liquidity, held)
+
+
+# A name at 1.0× or better enters; one between 0.8× and 1.0× is held but cannot
+# enter; one below 0.8× is out under every rule.
+ENTERS = _flags(liquidity=True, held=True)
+IN_BAND = _flags(liquidity=False, held=True)
+BELOW_BAND = _flags(liquidity=False, held=False)
+
+
+def test_the_band_is_the_apps_own_constant_and_never_a_copy_of_it():
+    """0.8 is the app's number (spec §4.1, ticket 05 D11), imported not restated.
+
+    And it stays out of :mod:`backtest.universe`, whose statelessness is a
+    recorded contract property with its own test — this is a measurement variant
+    that lives beside that classifier, never an edit to it.
+    """
+    assert HYSTERESIS_EXIT is app_universe.HYSTERESIS_EXIT
+    assert not hasattr(backtest_universe, "HYSTERESIS_EXIT")
+
+
+def test_the_contracts_classifier_is_still_stateless():
+    """#213 measures the band; it does not give the contract one."""
+    assert "prior_members" not in inspect.signature(
+        backtest_universe.classify
+    ).parameters
+    bars = _bars()
+    once = backtest_universe.classify(
+        "US",
+        [Candidate(symbol="AAA", name="", bars=bars)],
+        SIGNAL,
+        DEFAULT_CONTRACT,
+    )
+    assert once == backtest_universe.classify(
+        "US", [Candidate(symbol="AAA", name="", bars=bars)], SIGNAL, DEFAULT_CONTRACT
+    )
+
+
+def test_the_threshold_is_asymmetric_the_way_the_app_is():
+    """More evidence to leave than to enter: 1.0× in, 0.8× out."""
+    assert band_threshold(APP_FLOOR, held=False) == APP_FLOOR
+    assert band_threshold(APP_FLOOR, held=True) == APP_FLOOR * 0.8
+
+
+@pytest.mark.parametrize("held", [True, False])
+@pytest.mark.parametrize("multiple", [1.5, 1.01, 1.0, 0.99, 0.9, 0.81, 0.8, 0.79, 0.5])
+def test_the_band_agrees_with_the_app_on_the_same_bars(multiple, held):
+    """The variant's band predicate is :mod:`screener.universe`'s own behaviour.
+
+    Asked at the app's own floor, over the bars the app would see — everything
+    through t−1 — so the two sides differ in nothing but which code answers. The
+    app's classifier is run whole rather than its private gate called, because
+    what is being pinned is the band as the app applies it.
+    """
+    bars = _bars(dollar_volume=APP_FLOOR * multiple)
+    knowable = _sliced(bars)
+    series = series_of("AAA", bars)
+    app_members = app_universe.classify(
+        "US",
+        [app_universe.Candidate(symbol="AAA", name="", resolved=True, bars=knowable)],
+        [b.session for b in knowable],
+        {"AAA"} if held else set(),
+    )
+    assert series.passes_liquidity_band(_k(series), APP_FLOOR, held=held) is (
+        app_members == ["AAA"]
+    )
+
+
+def test_the_entry_side_of_the_band_is_the_plain_liquidity_gate():
+    """A non-member enters at 1.0×, which is the gate the other variants apply."""
+    for multiple in (1.5, 1.0, 0.99, 0.5):
+        series = _series(dollar_volume=US_FLOOR * multiple)
+        k = _k(series)
+        assert series.passes_liquidity_band(k, US_FLOOR, held=False) is (
+            series.passes_liquidity(k, US_FLOOR)
+        )
+
+
+# -- the walk -----------------------------------------------------------------
+
+
+def test_a_member_is_held_in_the_band_and_a_non_member_is_not_admitted_by_it():
+    """The whole asymmetry, on one name: it cannot enter on a band reading, it is
+    held on one, and once it drops below the band it needs 1.0× to come back."""
+    walk = [
+        {"A": IN_BAND},
+        {"A": ENTERS},
+        {"A": IN_BAND},
+        {"A": BELOW_BAND},
+        {"A": IN_BAND},
+    ]
+    assert hysteretic_memberships(walk, ALL_GATES) == [[], ["A"], ["A"], [], []]
+    # Without the band the same name is a member only where it clears 1.0×.
+    assert memberships_under(walk, ALL_GATES) == [[], ["A"], [], [], []]
+
+
+def test_the_band_relaxes_the_liquidity_floor_and_nothing_else():
+    """A held name still has to clear the gates the variant applies — the app's
+    band is on the liquidity floor alone (``screener.universe._is_member``)."""
+    walk = [
+        {"A": ENTERS},
+        {"A": _flags(volatility=False, liquidity=False)},
+        {"A": _flags(trend=False, liquidity=False)},
+    ]
+    assert hysteretic_memberships(walk, ALL_GATES) == [["A"], [], []]
+    assert hysteretic_memberships(walk, frozenset({LIQUIDITY})) == [["A"], ["A"], ["A"]]
+
+
+def test_a_walk_starts_from_the_prior_it_is_given():
+    """Which is what a warm-up is: state carried in, not assumed empty."""
+    walk = [{"A": IN_BAND}]
+    assert hysteretic_memberships(walk, ALL_GATES) == [[]]
+    assert hysteretic_memberships(walk, ALL_GATES, prior={"A"}) == [["A"]]
+
+
+def test_the_band_only_ever_admits():
+    """Session for session, a hysteretic membership is a superset of the same
+    gates without the band — so a cell that moves cannot have moved by exclusion."""
+    walk = [
+        {"A": ENTERS, "B": IN_BAND},
+        {"A": IN_BAND, "B": ENTERS},
+        {"A": BELOW_BAND, "B": IN_BAND},
+    ]
+    for gates in (ALL_GATES, frozenset({LIQUIDITY})):
+        for plain, banded in zip(
+            memberships_under(walk, gates), hysteretic_memberships(walk, gates)
+        ):
+            assert set(plain) <= set(banded)
+
+
+def test_the_band_is_a_no_op_where_the_liquidity_gate_is_dropped():
+    """Nothing else in the universe is hysteretic, so a variant without the
+    liquidity floor has no band to apply."""
+    walk = [{"A": ENTERS}, {"A": BELOW_BAND}]
+    gates = ALL_GATES - {LIQUIDITY}
+    assert hysteretic_memberships(walk, gates) == memberships_under(walk, gates)
+
+
+def test_the_walk_is_sorted_like_the_classifier_s():
+    """So a band membership is comparable to the store's rows and to the stateless
+    variants' without either side being re-ordered first."""
+    walk = [{"ZZZ": ENTERS, "AAA": ENTERS, "MMM": ENTERS}]
+    assert hysteretic_memberships(walk, ALL_GATES) == [["AAA", "MMM", "ZZZ"]]
+
+
+@pytest.mark.parametrize("variant", VARIANTS, ids=lambda v: v.name)
+def test_the_batch_path_agrees_with_the_direct_one_under_every_variant(variant):
+    """Including the hysteretic ones, whose direct path takes the prior in hand."""
+    series = _four_names()
+    prior = {"THIN"}
+    flags = gate_flags_by_session(series, [SIGNAL], US_FLOOR)
+    assert memberships_for(flags, variant, prior=prior) == [
+        members_at(
+            series,
+            SIGNAL,
+            variant.gates,
+            US_FLOOR,
+            prior=prior if variant.hysteresis else (),
+        )
+    ]
+
+
+def test_memberships_for_drops_the_warm_up_sessions_it_walked_through():
+    """The warm-up exists to settle the band, not to be reported."""
+    walk = [{"A": ENTERS}, {"A": IN_BAND}, {"A": IN_BAND}]
+    banded = next(v for v in VARIANTS if v.hysteresis and LIQUIDITY in v.gates)
+    plain = next(v for v in VARIANTS if not v.hysteresis and v.gates == banded.gates)
+    assert memberships_for(walk, banded, warm_up=1) == [["A"], ["A"]]
+    assert memberships_for(walk, plain, warm_up=1) == [[], []]
+
+
+# -- the variants the band makes possible -------------------------------------
+
+
+def test_the_stateless_variants_are_the_baseline_then_one_drop_per_gate():
+    """Baseline first, then every gate dropped alone — that is the attribution.
+
+    The two-gate cell is deliberately last of the stateless rows and deliberately
+    the only one: it exists because no single drop restores the sign, so it is a
+    follow-up question rather than part of the one-variable-at-a-time table.
+    """
+    stateless = [v for v in VARIANTS if not v.hysteresis]
+    baseline, *rest = stateless
+    assert baseline.gates == ALL_GATES and baseline.dropped == frozenset()
+    singles = [v for v in rest if len(v.dropped) == 1]
+    assert {next(iter(v.dropped)) for v in singles} == ALL_GATES
+    pairs = [v for v in rest if len(v.dropped) == 2]
+    assert [v.name for v in pairs] == ["liquidity-only"]
+    assert pairs[0].gates == frozenset({LIQUIDITY})
+    assert len(singles) + len(pairs) == len(rest)
+
+
+def test_every_hysteretic_variant_has_a_stateless_twin_to_be_read_against():
+    """A band cell means nothing on its own — what it is worth is the difference
+    from the same gates without it, so each one must have that row to subtract."""
+    banded = [v for v in VARIANTS if v.hysteresis]
+    assert {v.name for v in banded} == {"all-three+band", "liquidity-only+band"}
+    for v in banded:
+        assert LIQUIDITY in v.gates, "a band on a dropped floor measures nothing"
+        twin = [w for w in VARIANTS if not w.hysteresis and w.gates == v.gates]
+        assert len(twin) == 1
+
+
+def test_a_band_effect_is_the_twin_row_subtracted():
+    """What the band is worth is a difference, and the page quotes it in points —
+    so the arithmetic behind "+0.40pp of `in_field`, +0.05pp of gap" is pinned here
+    rather than done by hand on the way into the write-up."""
+    effects = band_effects(
+        [
+            {
+                "name": "liquidity-only",
+                "gates": ["liquidity"],
+                "hysteresis": False,
+                "members_per_session": 1687.8,
+                "in_field": 322,
+                "placed": 503,
+                "gap_pp": 0.72,
+            },
+            {
+                "name": "liquidity-only+band",
+                "gates": ["liquidity"],
+                "hysteresis": True,
+                "members_per_session": 1700.0,
+                "in_field": 324,
+                "placed": 503,
+                "gap_pp": 0.60,
+            },
+        ]
+    )
+    assert len(effects) == 1
+    effect = effects[0]
+    assert effect["variant"] == "liquidity-only+band"
+    assert effect["baseline"] == "liquidity-only"
+    assert effect["gap_delta_pp"] == pytest.approx(-0.12)
+    assert effect["in_field_delta"] == 2
+    assert effect["in_field_delta_pp"] == pytest.approx(0.3976, abs=1e-3)
+    assert effect["members_delta"] == pytest.approx(12.2)
+
+
+def test_a_band_effect_is_absent_rather_than_zero_when_a_row_is_unmeasured():
+    """A cell nobody measured and a band worth nothing are different claims."""
+    effects = band_effects(
+        [
+            {
+                "name": "all-three+band",
+                "gates": ["liquidity", "trend", "volatility"],
+                "hysteresis": True,
+                "members_per_session": 1.0,
+                "in_field": 0,
+                "placed": 0,
+                "gap_pp": None,
+            },
+        ]
+    )
+    assert effects == []
+
+
+# -- the whole isolation, with a band that had somewhere to come from ---------
+
+
+def _fading(i):
+    """1.5× the floor while a name is liquid, 0.9× — inside the band — after."""
+    return US_FLOOR * (1.5 if i <= 42 else 0.9)
+
+
+def _band_store():
+    """A store where one name enters on the warm-up and then fades into the band.
+
+    ``FADER``'s trailing median clears 1.0× on ``SESSIONS[52]`` (11 of its 20
+    window bars are still the high level) and sits at 0.9× on both measured
+    sessions. So the band's answer is not the plain gate's, and whether it is a
+    member on the measured sessions depends on a session nobody reports.
+    """
+    store = Store.memory()
+    store.append_bars("US", "AAA", _bars())
+    store.append_bars("US", "FADER", _bars(dollar_volume=_fading))
+    for session in (SESSIONS[55], SESSIONS[56]):
+        store.append_universe("US", session, ["AAA"])
+    return store
+
+
+def test_the_band_variants_hold_a_name_the_stateless_gates_drop():
+    """The whole isolation with a band that had somewhere to come from: the walk
+    reaches the store, the warm-up carries state into the measured sessions, and the
+    two band cells differ from their twins by the name the band holds."""
+    isolation = run_isolation(
+        _band_store(),
+        "US",
+        trades=[],
+        sessions=[SESSIONS[55], SESSIONS[56]],
+        warm_up=[SESSIONS[52], SESSIONS[53], SESSIONS[54]],
+    )
+    assert isolation.check.exact
+    assert {r.variant.name for r in isolation.results} == {v.name for v in VARIANTS}
+    assert isolation.by_name("all-three").members_per_session == 1.0
+    assert isolation.by_name("all-three+band").members_per_session == 2.0
+    assert isolation.by_name("liquidity-only").members_per_session == 1.0
+    assert isolation.by_name("liquidity-only+band").members_per_session == 2.0
+
+
+def test_without_a_warm_up_the_band_has_no_prior_to_hold_a_name_by():
+    """Which is why the run warms it: a walk started cold cannot hold anything on
+    its first session, and a name already inside the band never enters at all."""
+    isolation = run_isolation(
+        _band_store(), "US", trades=[], sessions=[SESSIONS[55], SESSIONS[56]]
+    )
+    assert isolation.by_name("all-three+band").members_per_session == 1.0
+    assert isolation.by_name("all-three").members_per_session == 1.0
+
+
+def test_the_warm_up_is_the_windows_own_burn_in():
+    """The band settles over the sessions the anchor's window already discards,
+    so no bar outside the reference study's window is read to settle it."""
+    outside = [WINDOW_START - timedelta(days=1), WINDOW_END + timedelta(days=1)]
+    inside = [WINDOW_START + timedelta(days=i) for i in range(WINDOW_BURN_IN + 5)]
+    warm, measured = window_sessions(sorted(inside + outside))
+    assert list(warm) + list(measured) == inside
+    assert len(warm) == WINDOW_BURN_IN
+    assert measured[0] == inside[WINDOW_BURN_IN]
+
+
+# -- the report is the payload, and a subset can be merged into it -------------
+
+
+def test_the_report_is_rendered_from_the_payload_it_records():
+    """One formatter, reading the recorded figures — so a table can be re-rendered
+    from ``backtest_gate_isolation.json`` without re-measuring anything."""
+    store = Store.memory()
+    store.append_bars("US", "AAA", _bars())
+    store.append_universe("US", SIGNAL, ["AAA"])
+    isolation = run_isolation(store, "US", trades=[], sessions=[SIGNAL])
+    assert format_isolation(isolation) == format_payload(isolation_payload(isolation))
+
+
+def _payload(variants, **overrides):
+    payload = {
+        "window": {
+            "start": WINDOW_START.isoformat(),
+            "end": WINDOW_END.isoformat(),
+            "burn_in": WINDOW_BURN_IN,
+            "market": "US",
+        },
+        "detector_version": 3,
+        "field": "whole",
+        "rubric_version": 2,
+        "stars": 3.5,
+        "reconstruction": {"sessions": 821, "stored": 1, "rebuilt": 1,
+                           "extra": 0, "missing": 0, "exact": True},
+        "variants": variants,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _cell(name, gates, hysteresis=False, gap=1.0):
+    return {
+        "name": name,
+        "gates": sorted(gates),
+        "dropped": sorted(ALL_GATES - set(gates)),
+        "note": "",
+        "hysteresis": hysteresis,
+        "members_per_session": 100.0,
+        "field_detections": 10,
+        "in_field": 300,
+        "placed": 503,
+        "in_field_share": 300 / 503,
+        "picks_share": 0.14,
+        "field_share": 0.13,
+        "gap_pp": gap,
+        "dimensions": [],
+    }
+
+
+def test_merging_keeps_the_recorded_cells_and_adds_the_measured_ones():
+    """The five stateless rows were run three times across two implementations;
+    #213 adds two rows to them rather than re-measuring what they already say."""
+    recorded = _payload([_cell(v.name, v.gates, v.hysteresis)
+                         for v in VARIANTS if not v.hysteresis])
+    fresh = _payload([_cell(v.name, v.gates, v.hysteresis, gap=-2.0)
+                      for v in VARIANTS if v.hysteresis])
+    merged = merge_payloads(recorded, fresh)
+    assert [c["name"] for c in merged["variants"]] == [v.name for v in VARIANTS]
+    assert merged["variants"][0]["gap_pp"] == 1.0
+    assert [c["gap_pp"] for c in merged["variants"] if c["hysteresis"]] == [-2.0, -2.0]
+    assert len(merged["band_effects"]) == 2
+
+
+def test_merging_replaces_a_cell_that_was_measured_again():
+    """A re-measured cell wins. Merging is for adding rows to a table, never for
+    keeping a stale figure alive beside the run that superseded it."""
+    recorded = _payload([_cell("all-three", ALL_GATES, gap=1.0)])
+    fresh = _payload([_cell("all-three", ALL_GATES, gap=9.0)])
+    merged = merge_payloads(recorded, fresh)
+    assert [c["gap_pp"] for c in merged["variants"]] == [9.0]
+
+
+def test_merging_refuses_cells_measured_over_a_different_window():
+    """Rows from two windows in one table would read as one measurement."""
+    recorded = _payload([_cell("all-three", ALL_GATES)])
+    fresh = _payload(
+        [_cell("all-three+band", ALL_GATES, hysteresis=True)],
+        window={"start": "2015-01-01", "end": "2018-12-31", "burn_in": 126,
+                "market": "US"},
+    )
+    with pytest.raises(ValueError) as excinfo:
+        merge_payloads(recorded, fresh)
+    assert "window" in str(excinfo.value)

--- a/references/backtest_anchor_divergence.md
+++ b/references/backtest_anchor_divergence.md
@@ -162,7 +162,10 @@ trend gate acting together** — every single-gate drop leaves the gap negative,
 turns it positive — and returns the verdict **property, not defect**. What was already
 settled is where it is *not*: not the bars (bit-identical), not the detector (recall
 reproduces to four decimals), and not the population (isolated above); #211 adds that it is
-not the liquidity floor and not the membership reconstruction either.
+not the liquidity floor and not the membership reconstruction either, and #213 that it is
+not the dropped hysteresis band — worth 0.05pp of the gap and two trades of `in_field`
+against a gate's 3.5pp. All four differences this paragraph names have now been varied
+directly.
 
 **This anchor is a first measurement**, flagged as such in the table precisely so a mismatch is
 investigated in both directions rather than charged straight to the new pipeline. The committed

--- a/references/backtest_gate_isolation.json
+++ b/references/backtest_gate_isolation.json
@@ -3,6 +3,7 @@
   "start": "2019-04-01",
   "end": "2022-12-30",
   "burn_in": 126,
+  "band_warm_up": 126,
   "market": "US"
  },
  "detector_version": 3,
@@ -85,7 +86,8 @@
      "field": 0.9071228573379772,
      "gap_pp": -1.0153160368280179
     }
-   ]
+   ],
+   "hysteresis": false
   },
   {
    "name": "no-adr",
@@ -155,7 +157,8 @@
      "field": 0.6632773550249278,
      "gap_pp": 11.809916319369574
     }
-   ]
+   ],
+   "hysteresis": false
   },
   {
    "name": "no-trend",
@@ -225,7 +228,8 @@
      "field": 0.8442551102696259,
      "gap_pp": 3.8861772847257225
     }
-   ]
+   ],
+   "hysteresis": false
   },
   {
    "name": "no-liquidity",
@@ -295,7 +299,8 @@
      "field": 0.929384965831435,
      "gap_pp": -4.337460313713448
     }
-   ]
+   ],
+   "hysteresis": false
   },
   {
    "name": "liquidity-only",
@@ -365,7 +370,185 @@
      "field": 0.6128126181602117,
      "gap_pp": 15.737371724351501
     }
+   ],
+   "hysteresis": false
+  },
+  {
+   "name": "all-three+band",
+   "gates": [
+    "liquidity",
+    "trend",
+    "volatility"
+   ],
+   "dropped": [],
+   "note": "the run's own field, plus the app's 0.8-1.0x hysteresis band",
+   "hysteresis": true,
+   "members_per_session": 369.884287454324,
+   "field_detections": 36858,
+   "in_field": 167,
+   "placed": 503,
+   "in_field_share": 0.3320079522862823,
+   "picks_share": 0.1437125748502994,
+   "field_share": 0.19422922789206518,
+   "gap_pp": -5.051665304176578,
+   "dimensions": [
+    {
+     "dimension": "Tightness",
+     "weight": 2,
+     "picks": 0.4251497005988024,
+     "field": 0.2518033662837296,
+     "gap_pp": 17.334633431507278
+    },
+    {
+     "dimension": "Orderliness",
+     "weight": 1,
+     "picks": 0.40718562874251496,
+     "field": 0.4337429869088966,
+     "gap_pp": -2.655735816638166
+    },
+    {
+     "dimension": "Prior move",
+     "weight": 1,
+     "picks": 1.0,
+     "field": 1.0,
+     "gap_pp": 0.0
+    },
+    {
+     "dimension": "Base length",
+     "weight": 0,
+     "picks": 0.5209580838323353,
+     "field": 0.673657493988779,
+     "gap_pp": -15.269941015644372
+    },
+    {
+     "dimension": "MA support",
+     "weight": 1,
+     "picks": 0.8562874251497006,
+     "field": 0.8539941223617419,
+     "gap_pp": 0.22933027879586954
+    },
+    {
+     "dimension": "Volume",
+     "weight": 1,
+     "picks": 0.25748502994011974,
+     "field": 0.322201442693027,
+     "gap_pp": -6.4716412752907235
+    },
+    {
+     "dimension": "ADR",
+     "weight": 2,
+     "picks": 0.8982035928143712,
+     "field": 0.9080951108736308,
+     "gap_pp": -0.9891518059259585
+    }
    ]
+  },
+  {
+   "name": "liquidity-only+band",
+   "gates": [
+    "liquidity"
+   ],
+   "dropped": [
+    "trend",
+    "volatility"
+   ],
+   "note": "the app's full shape \u2014 its gate set and its band \u2014 from the run's store",
+   "hysteresis": true,
+   "members_per_session": 1752.0109622411694,
+   "field_detections": 184494,
+   "in_field": 324,
+   "placed": 503,
+   "in_field_share": 0.6441351888667992,
+   "picks_share": 0.13271604938271606,
+   "field_share": 0.1250021629665519,
+   "gap_pp": 0.7713886416164162,
+   "dimensions": [
+    {
+     "dimension": "Tightness",
+     "weight": 2,
+     "picks": 0.4012345679012346,
+     "field": 0.2079216486996245,
+     "gap_pp": 19.331291920161007
+    },
+    {
+     "dimension": "Orderliness",
+     "weight": 1,
+     "picks": 0.345679012345679,
+     "field": 0.3702652662179232,
+     "gap_pp": -2.4586253872244224
+    },
+    {
+     "dimension": "Prior move",
+     "weight": 1,
+     "picks": 1.0,
+     "field": 1.0,
+     "gap_pp": 0.0
+    },
+    {
+     "dimension": "Base length",
+     "weight": 0,
+     "picks": 0.4660493827160494,
+     "field": 0.5695696561748369,
+     "gap_pp": -10.352027345878751
+    },
+    {
+     "dimension": "MA support",
+     "weight": 1,
+     "picks": 0.7839506172839507,
+     "field": 0.682372687788756,
+     "gap_pp": 10.157792949519461
+    },
+    {
+     "dimension": "Volume",
+     "weight": 1,
+     "picks": 0.3549382716049383,
+     "field": 0.4012216435085048,
+     "gap_pp": -4.6283371903566515
+    },
+    {
+     "dimension": "ADR",
+     "weight": 2,
+     "picks": 0.7685185185185185,
+     "field": 0.6132442767905038,
+     "gap_pp": 15.527424172801474
+    }
+   ]
+  }
+ ],
+ "band_effects": [
+  {
+   "variant": "all-three+band",
+   "baseline": "all-three",
+   "gates": [
+    "liquidity",
+    "trend",
+    "volatility"
+   ],
+   "members_delta": 7.2667478684531375,
+   "in_field": 167,
+   "baseline_in_field": 165,
+   "placed": 503,
+   "in_field_delta": 2,
+   "in_field_delta_pp": 0.3976143141153081,
+   "gap_pp": -5.051665304176578,
+   "baseline_gap_pp": -5.006549825234521,
+   "gap_delta_pp": -0.0451154789420567
+  },
+  {
+   "variant": "liquidity-only+band",
+   "baseline": "liquidity-only",
+   "gates": [
+    "liquidity"
+   ],
+   "members_delta": 64.19123020706456,
+   "in_field": 324,
+   "baseline_in_field": 322,
+   "placed": 503,
+   "in_field_delta": 2,
+   "in_field_delta_pp": 0.3976143141153081,
+   "gap_pp": 0.7713886416164162,
+   "baseline_gap_pp": 0.7178716897386972,
+   "gap_delta_pp": 0.05351695187771899
   }
  ]
 }

--- a/references/backtest_gate_isolation.md
+++ b/references/backtest_gate_isolation.md
@@ -17,7 +17,10 @@ defect in how the field is built.**
 The reversal is attributable to the **conjunction of two gates** — the ADR20 floor of
 3.5% and the trend gate, `close > SMA50`. Neither one alone accounts for it: dropping
 either leaves the gap negative. Dropping **both** restores the sign. The liquidity floor
-is not the cause and is exonerated below.
+is not the cause and is exonerated below, and so — since #213 — is the app's membership
+hysteresis, which is worth 0.05pp of the gap against a gate's 3.5pp. All four differences
+between the two universes have now been varied directly; none of the four is bounded by
+inference.
 
 Both of those gates are doing exactly what the contract says they should. Nothing is
 miscomputed: the rebuilt membership reproduces the run's own universe rows exactly, and
@@ -40,8 +43,8 @@ The trouble with #198's third measurement is that it moves *towards* the app: a
 different store, a different universe. This one moves the other way and stays inside the
 run's own field. One store (`data/backtest.duckdb`), one population (the same 503
 replayable trades), one detector (v3), one window (US, 2019-04-01 .. 2022-12-30, 126
-burn-in, 821 measured sessions). The only thing that moves between rows is **which gates
-build the universe**.
+burn-in, 821 measured sessions). The only thing that moves between rows is **one
+difference from the app's universe** — a gate, or the membership band.
 
 | variant | members/sess | field detections | `in_field` | picks ≥3.5★ | field ≥3.5★ | gap |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
@@ -50,11 +53,24 @@ build the universe**.
 | no trend gate | 771.2 | 82,650 | 231/503 (45.9%) | 14.29% | 15.73% | −1.44pp |
 | no liquidity floor | 985.1 | 103,411 | 193/503 (38.4%) | 16.58% | 18.44% | −1.86pp |
 | **liquidity only** — both dropped | 1,687.8 | 176,643 | 322/503 (64.0%) | 13.35% | 12.64% | **+0.72pp** |
+| all three **+ hysteresis** | 369.9 | 36,858 | 167/503 (33.2%) | 14.37% | 19.42% | −5.05pp |
+| **liquidity only + hysteresis** — the app's whole shape | 1,752.0 | 184,494 | 324/503 (64.4%) | 13.27% | 12.50% | **+0.77pp** |
+
+The last two rows are #213's, and they are the app's membership band added back — a name
+enters on the liquidity floor at ≥ 1.0× and leaves only below 0.8×, walked forward session
+by session. What they are worth is [below](#what-the-hysteresis-band-is-worth).
 
 Reproduce with:
 
 ```
 python -m backtest.field_gate_isolation --store data/backtest.duckdb
+```
+
+or, to re-measure only the two band rows and merge them into the recorded five:
+
+```
+python -m backtest.field_gate_isolation --store data/backtest.duckdb \
+  --only all-three+band,liquidity-only+band
 ```
 
 which writes [`backtest_gate_isolation.txt`](backtest_gate_isolation.txt) and
@@ -82,7 +98,7 @@ not a recomputed one — and that row reproduces the committed −5.01pp to the 
 ## Reading the table
 
 **No single gate is the cause.** Every single-gate drop moves the gap by a similar
-amount — +3.55, +3.57, +3.15 — and every one of them leaves it negative. A ticket that
+amount — +3.55, +3.56, +3.14 — and every one of them leaves it negative. A ticket that
 demanded "attribute it to a specific gate, not the universe as a whole" gets a two-gate
 answer, and the two are named: the ADR floor and the trend gate.
 
@@ -100,23 +116,97 @@ that matters, and the `liquidity only` row keeps it and still lands positive.
 
 **The two-gate row is the app's shape, and it lands where the app lands.** `liquidity
 only` gives `in_field` 322 of 503 — 64.0% — against the app's own 324 of 503, 64.4%. Two
-trades apart, from a different store by a different route. So this row is the app-shaped
-field reached from inside the run's own store.
-
-**Hysteresis is not isolated here, and its exoneration is inferential.** The third
-difference the divergence page names is that the contract drops the app's membership
-hysteresis band, and no variant above restores it — the contract's classifier is
-stateless by construction (`backtest.universe.classify` takes no `prior_members`), so
-adding the band back is not a gate that can be switched off. What bounds it is the row
-above: `liquidity only` reaches the app's own `in_field` to within two trades **without**
-hysteresis, which leaves little room for the band to be carrying the sign. That is a
-bound, not a measurement, and it is the one difference of the four this page has not
-varied directly.
+trades apart, from a different store by a different route. Add the band and it is not two
+trades apart: `liquidity only + hysteresis` gives **324 of 503**, the app's own count
+exactly. So this row is the app-shaped field reached from inside the run's own store, and
+the last two trades were the band.
 
 **The movement is entirely in the field, not in his picks.** Across every row his picks
 sit between 13.35% and 16.58% — a narrow band with no trend. The field swings from
 12.64% to 19.55%. The gates do not make his trades look worse; they make **the field look
 better**, by removing the names that were dragging the field's average down.
+
+## What the hysteresis band is worth
+
+Issue #213. The fourth difference between the two universes is the one that is not a gate:
+the app's universe is **hysteretic** — a name enters on the liquidity floor at ≥ 1.0× and
+leaves only below 0.8× (`screener.universe.HYSTERESIS_EXIT`), asymmetric on purpose, "more
+evidence to leave than to enter" — and the contract's drops the band entirely. It cannot
+be switched off the way a gate can, because `backtest.universe.classify` never had it and
+takes no `prior_members`. So it was added back instead, and the two rows above are the
+result.
+
+| | members/sess | `in_field` | gap | what the band moved |
+| --- | ---: | ---: | ---: | ---: |
+| all three | 362.6 | 165/503 (32.80%) | −5.007pp | |
+| all three **+ hysteresis** | 369.9 | 167/503 (33.20%) | −5.052pp | **+0.40pp** `in_field`, **−0.045pp** gap |
+| liquidity only | 1,687.8 | 322/503 (64.02%) | +0.718pp | |
+| liquidity only **+ hysteresis** | 1,752.0 | 324/503 (64.41%) | +0.771pp | **+0.40pp** `in_field`, **+0.054pp** gap |
+
+**The band does not move the sign, and now that is measured rather than inferred.** It is
+worth **two trades** of `in_field` on either field — +0.40 percentage points — and it moves
+the rubric's gap by **0.045pp** on the run's own field and **0.054pp** on the app-shaped
+one. A single gate moves that gap by 3.14 to 3.56pp — roughly sixty to eighty times as
+far. The two
+rows also move it in *opposite* directions — the tight field a little more negative, the
+loose field a little more positive — so there is not even a consistent sign to attribute.
+Nothing here changes what the section above concludes; it removes the last inference from
+it.
+
+**The band widens the field, and the widening does not reach his trades.** It admits 7.3
+more names per session under the full gate set and 64.2 more under the app's — nine times
+as many, because a band can only hold a name the *other* gates still admit, and the ADR
+floor and the trend gate throw out most of what it would otherwise carry. Both widenings
+move the same two trades into the field. The field's own ≥3.5★ share barely notices:
+19.55% → 19.42% and 12.64% → 12.50%. Neither do the per-dimension rows below: every
+dimension sits within 0.9pp of its band-less twin, and the widest of those is `Base
+length`, which carries weight 0 and can move no star total. ADR holds at −1.0pp on the
+run's field and 15.5 against 15.7pp on the app-shaped one. The band duplicates no rubric
+dimension — which is the mechanism the next section attributes the reversal to, and a
+second reason the band was never a candidate for carrying the sign.
+
+**It also closes the two-trade gap that was the old bound's slack.** `liquidity only`
+reached the app's `in_field` to within two trades; `liquidity only + hysteresis` reaches
+it exactly, 324 of 503 against the app's 324 of 503, from a different store by a different
+route. The app's whole shape — its gate set *and* its band — reproducing the app's own
+count to the trade is a direct check that what this page rebuilds is the app's field
+rather than something near it.
+
+**No constant was moved to measure it, and none is proposed.** `HYSTERESIS_EXIT` is read
+from the app rather than restated; the contract's gates keep their committed values in
+every row.
+
+### How it was measured, and why the contract is still stateless
+
+`backtest.universe.classify` is **unchanged**. Its statelessness is a recorded contract
+property (`universe.statelessness`) with its own test, and the churn it reintroduces is a
+known difference rather than a defect. What #213 adds is a **stateful variant classifier
+that lives only in the isolation harness**
+(`backtest.field_gate_isolation.hysteretic_memberships`): it walks sessions forward
+carrying the previous session's membership, applies the band on the liquidity gate, and is
+otherwise the contract's own gates. Nothing in the run can reach it.
+
+Three things make the rows trustworthy:
+
+- **The band's predicate is the app's, pinned to it.** `tests/test_field_gate_isolation.py`
+  runs `screener.universe.classify` over the same bars at the app's own floor, at nine
+  multiples of it from 1.5× down to 0.5× and in both membership states, and requires the
+  same answer. It also holds the band to the liquidity floor alone: a held name still has
+  to clear every other gate its variant applies, exactly as `screener.universe._is_member`
+  does.
+- **The band is walked into, not started cold.** Membership is path-dependent, so a walk
+  begun on the first measured session would have no members to hold and would read as a
+  stateless one. The band settles over the window's own **126-session burn-in** — the same
+  burn-in the replay study warms over, and for the same stated reason (findings §4, "so the
+  hysteresis band settles before any measured session"). No warm-up session is reported and
+  no bar outside the window is read.
+- **The rebuild check still holds with the walk in place.** 297,709 stored, 297,709 rebuilt,
+  0 extra and 0 missing across all 821 sessions. `run_isolation` still raises rather than
+  reporting a cell if that is not exact.
+
+The five stateless rows were **not** re-measured. They were run three times across two
+implementations and reproduced identically; #213 measured its two rows and merged them into
+the recorded table (`--only`, above).
 
 ## The mechanism
 
@@ -264,13 +354,17 @@ Taken with what #198 already ruled out, the causes now excluded are:
 - **not the candidate pool or the membership code** — the rebuild reproduces the store's
   universe rows exactly, 0 extra and 0 missing over 821 sessions;
 - **not the liquidity floor** — measured, and it is not the gate that moves the sign;
+- **not the dropped hysteresis band** — measured too, since #213: adding it back moves the
+  gap by 0.05pp and `in_field` by two trades, on either field;
 - **not any single gate at all** — every one-gate drop leaves the gap negative.
 
 What is left is the pair, and the pair is the contract working as written.
 
 ## Reproducing this page
 
-- the variant table, from `python -m backtest.field_gate_isolation --store data/backtest.duckdb`;
+- the variant table, from `python -m backtest.field_gate_isolation --store data/backtest.duckdb`
+  — or its two band rows alone, with `--only all-three+band,liquidity-only+band`, which
+  merges them into the five already recorded rather than re-measuring those;
 - the two replay rows, from `replay.discrimination_grid.run_grid` against
   `data/replay.duckdb` over the same window, once with all 828 trades and once with the
   trade list restricted to the names `data/backtest.duckdb.coverage.US.json` lists as

--- a/references/backtest_gate_isolation.txt
+++ b/references/backtest_gate_isolation.txt
@@ -1,23 +1,36 @@
-The gate isolation (#211) — one store, one population, one detector,
-one gate moving at a time.
+The gate isolation (#211, #213) — one store, one population, one detector,
+one difference from the app's universe moving at a time.
 
 Full-gate rebuild vs the store's own universe rows: stored 297709, rebuilt 297709, extra 0, missing 0, over 821 sessions -> EXACT
 
-variant        members/sess  field det     in_field    picks    field       gap
-all-three             362.6      35971      165/503   14.55%   19.55%   -5.01pp
-no-adr                906.2      84329      247/503   14.98%   16.44%   -1.46pp
-no-trend              771.2      82650      231/503   14.29%   15.73%   -1.44pp
-no-liquidity          985.1     103411      193/503   16.58%   18.44%   -1.86pp
-liquidity-only       1687.8     176643      322/503   13.35%   12.64%   +0.72pp
+variant             members/sess  field det     in_field    picks    field       gap
+all-three                  362.6      35971      165/503   14.55%   19.55%   -5.01pp
+no-adr                     906.2      84329      247/503   14.98%   16.44%   -1.46pp
+no-trend                   771.2      82650      231/503   14.29%   15.73%   -1.44pp
+no-liquidity               985.1     103411      193/503   16.58%   18.44%   -1.86pp
+liquidity-only            1687.8     176643      322/503   13.35%   12.64%   +0.72pp
+all-three+band             369.9      36858      167/503   14.37%   19.42%   -5.05pp
+liquidity-only+band       1752.0     184494      324/503   13.27%   12.50%   +0.77pp
 
 notes:
-  all-three      the run's own field — reproduces the committed -5.01pp
-  no-adr         drops the 3.5% ADR20 floor, which the app's universe does not have
-  no-trend       drops close > SMA50, which the app's universe does not have
-  no-liquidity   drops the $10M ADTV floor, which the app sets at $20M instead
-  liquidity-only drops both gates the app lacks, keeping only a liquidity floor
+  all-three           the run's own field — reproduces the committed -5.01pp
+  no-adr              drops the 3.5% ADR20 floor, which the app's universe does not have
+  no-trend            drops close > SMA50, which the app's universe does not have
+  no-liquidity        drops the $10M ADTV floor, which the app sets at $20M instead
+  liquidity-only      drops both gates the app lacks, keeping only a liquidity floor
+  all-three+band      the run's own field, plus the app's 0.8-1.0x hysteresis band
+  liquidity-only+band the app's full shape — its gate set and its band — from the run's store
 
 picks/field are the share reaching >= 3.5 stars under rubric v1; gap is picks - field.
+
+What the app's hysteresis band is worth: each band row against the same
+gates without it. The band relaxes the liquidity floor to 0.8x for a
+name that was a member on the session before, and touches no other gate.
+It is walked into over 126 warm-up sessions, none of which is reported.
+
+  band row            vs                    members     in_field       gap  gap delta
+  all-three+band      all-three                +7.3       +2/503   -5.05pp    -0.05pp
+  liquidity-only+band liquidity-only          +64.2       +2/503   +0.77pp    +0.05pp
 
 Per-dimension hit rates, his picks against the field on the sessions he traded.
 A gate that duplicates a dimension shows up as that dimension's gap collapsing
@@ -73,3 +86,23 @@ while the dimensions no gate touches stay put. Seven-dimension replayed score:
     MA support     1    78.6%    68.8%     +9.8pp
     Volume         1    35.7%    39.7%     -4.0pp
     ADR            2    77.0%    61.3%    +15.7pp
+
+  all-three+band
+    dimension     wt    picks    field       gap
+    Tightness      2    42.5%    25.2%    +17.3pp
+    Orderliness    1    40.7%    43.4%     -2.7pp
+    Prior move     1   100.0%   100.0%     +0.0pp
+    Base length    0    52.1%    67.4%    -15.3pp
+    MA support     1    85.6%    85.4%     +0.2pp
+    Volume         1    25.7%    32.2%     -6.5pp
+    ADR            2    89.8%    90.8%     -1.0pp
+
+  liquidity-only+band
+    dimension     wt    picks    field       gap
+    Tightness      2    40.1%    20.8%    +19.3pp
+    Orderliness    1    34.6%    37.0%     -2.5pp
+    Prior move     1   100.0%   100.0%     +0.0pp
+    Base length    0    46.6%    57.0%    -10.4pp
+    MA support     1    78.4%    68.2%    +10.2pp
+    Volume         1    35.5%    40.1%     -4.6pp
+    ADR            2    76.9%    61.3%    +15.5pp


### PR DESCRIPTION
## Summary

- Adds a **stateful variant classifier** (`hysteretic_memberships`) to the isolation harness only — walks sessions forward carrying prior membership and applies the app's 0.8-1.0x hysteresis band on the liquidity gate. `backtest.universe.classify` is untouched and still stateless.
- Measures two new cells, `all-three+band` and `liquidity-only+band`, each read against the same gate set without the band, and merges them into the recorded table via `--only` rather than re-measuring the five existing rows.
- **Finding**: the band is worth +0.40pp of `in_field` (two trades) and 0.045-0.054pp of the rubric's gap, against 3.14-3.56pp for any single gate — and in opposite directions on the two rows. It does not carry the `in_field` sign flip. `liquidity only + hysteresis` reproduces the app's own `in_field` count exactly (324/503).
- `references/backtest_gate_isolation.md` replaces its inferential bound on hysteresis with this measurement; `references/backtest_anchor_divergence.md` and `CONTEXT.md` updated to match.

Closes #213.

## Test plan

- [x] `pytest tests/test_field_gate_isolation.py` — 89 passed, including the band predicate pinned against `screener.universe.classify` on the same bars
- [x] Full backend suite — 1010 passed
- [x] Full-gate rebuild still reproduces the store's universe rows exactly (297,709/297,709, 0 extra/missing) with the warm-up walk in place
- [x] All seven variants' recomputed membership (including the five #211 rows) matches the recorded artifact to four decimals

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BUaZrLjtrHS8NmwV848iaU