### PR TITLE
Write it up — the out-of-sample backtest, and the change it licenses (#200)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -567,6 +567,18 @@ licensing nothing. Reaching for a **swept variant** to break the tie is the fail
 the whole run contract exists to prevent.
 _Avoid_: no result, flat, mixed.
 
+**Licensed change**:
+The change a **ship** verdict permits, named in the **write-up** before any constant moves
+(PRD #182 Phase 7, `references/backtest_findings.md`). It is a permission and not an
+action: naming it is the verdict's own condition, and spending it is separate work under
+whatever evidence rule governs the thing being changed — the calibration rule (findings §7)
+for a score dimension, ADR 0005's admission instrument for a **candidate dimension**. It is
+licensed **only in the market that passed**, so a Jakarta ship permits nothing on the US.
+A licence is recorded whether or not it is ever spent, because a change argued for after
+the fact is indistinguishable from one chosen to fit the result.
+_Avoid_: the recommendation, the action item, what the run proves — and never write that a
+run "licensed" a change it did not name.
+
 **Bound basis**:
 How the hole under a market's **bias bound** was counted: against a dated listing spine
 with **recycled symbols** separated out, or against the enumeration alone, where a recycled

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -12906,6 +12906,11 @@ def _committed(name: str) -> dict:
     return json.loads((REFERENCES / name).read_text())
 
 
+def _section(page: str, heading: str) -> str:
+    """One document section: the text under `heading`, up to the next one."""
+    return page.split(heading, 1)[1].split("\n## ", 1)[0]
+
+
 def _prose(path: Path) -> str:
     """A document's text with its typographic minus folded to the ASCII one.
 
@@ -12916,7 +12921,7 @@ def _prose(path: Path) -> str:
     return path.read_text().replace("\u2212", "-")
 
 
-def _headline_cells() -> dict[str, dict[str, float]]:
+def _headline_cells() -> dict[str, dict[str, float | None]]:
     """The four pre-registered figures, read off the payload that produced them."""
     metric = _committed("backtest_primary_metric.json")
     return {
@@ -12954,6 +12959,10 @@ def test_the_machine_readable_results_are_committed_beside_both():
         "backtest_candidate_outcomes.json",
         "backtest_score_ranking.json",
         "backtest_anchors.json",
+        "backtest_full_run.json",
+        "backtest_arms_US.json",
+        "backtest_arms_IDX.json",
+        "backtest_run_contract.json",
     ):
         assert (REFERENCES / payload).exists(), payload
         assert payload in page, payload
@@ -12981,7 +12990,7 @@ def test_the_bias_bound_is_in_the_summary_and_not_in_a_footnote():
     figures appear above the summary section's end."""
     page = _prose(AUTHORITY_DOC)
     assert SUMMARY_HEADING in page
-    summary = page.split(SUMMARY_HEADING, 1)[1].split("\n## ", 1)[0]
+    summary = _section(page, SUMMARY_HEADING)
     for market, body in _verdict_markets().items():
         for cell in body["windows"]:
             assert f"{cell['pessimistic_r']:+.3f}R" in summary, (market, cell["label"])
@@ -12990,11 +12999,25 @@ def test_the_bias_bound_is_in_the_summary_and_not_in_a_footnote():
         assert f"{body['hole_share'] * 100:.1f}%" in summary, body["market"]
 
 
+def test_the_summary_carries_the_drag_the_hole_costs_the_headline():
+    """`gap_r` is the drag on the mean; `hole_share` and the trades-per-covered
+    ratio it implies are counts. They are different quantities and the first draft
+    of the plain companion ran them together, quoting the count as an R amount. So
+    the drag is asserted from the payload that computes it.
+    """
+    summary = _section(_prose(AUTHORITY_DOC), SUMMARY_HEADING)
+    metric = _committed("backtest_primary_metric.json")
+    us = next(b for b in metric["markets"] if b["market"] == "US")
+    assert f"{us['bias_bound']['gap_r']:.3f}R" in summary
+    # And the plain companion states the same drag rather than a second version.
+    assert f"{us['bias_bound']['gap_r']:.3f}R" in _prose(PLAIN_DOC)
+
+
 def test_both_markets_are_reported_separately_including_in_the_summary():
     """Findings §8: shapes travel between US and IDX and magnitudes do not, so a
     pooled figure describes neither market. The summary names both."""
     page = _prose(AUTHORITY_DOC)
-    summary = page.split(SUMMARY_HEADING, 1)[1].split("\n## ", 1)[0]
+    summary = _section(page, SUMMARY_HEADING)
     cells = _headline_cells()
     assert set(cells) == {"US", "IDX"}
     for market, windows in cells.items():
@@ -13024,7 +13047,7 @@ def test_the_licensed_change_is_named_before_any_constant_moves():
     change it licenses — and no constant in the app moved to earn it."""
     page = _prose(AUTHORITY_DOC)
     assert "## The change this licenses" in page
-    licensed = page.split("## The change this licenses", 1)[1].split("\n## ", 1)[0]
+    licensed = _section(page, "## The change this licenses")
     assert "IDX" in licensed
     # Named, and still unspent: the calibration rule is where it goes next.
     assert "findings §7" in licensed
@@ -13034,10 +13057,9 @@ def test_the_limits_are_stated_including_what_signal_level_cannot_say():
     """A limitation named in advance is a caveat; one discovered afterwards is a
     retraction. The four the plan fixed, plus the deferral in its own words."""
     for doc in (AUTHORITY_DOC, PLAIN_DOC):
-        page = _prose(doc)
-        assert LIMITS_HEADING in page or "cannot say" in page, doc.name
+        assert LIMITS_HEADING in _prose(doc), doc.name
     page = _prose(AUTHORITY_DOC)
-    limits = page.split(LIMITS_HEADING, 1)[1].split("\n## ", 1)[0]
+    limits = _section(page, LIMITS_HEADING)
     for claim in (
         "capacity",
         "concurrency",
@@ -13073,6 +13095,50 @@ def test_the_command_says_whether_it_recomputed_the_figure_or_read_it_back():
     assert "--from-store" in printed, "the recomputing path is named in the output"
     # And the document tells the reader the same two things.
     assert HEADLINE_COMMAND.name in _prose(AUTHORITY_DOC)
+
+
+def test_the_recomputing_path_cleans_up_after_itself():
+    """`--from-store` works in a temp directory and removes it on the way out.
+
+    Read off the source rather than by running it, because the recomputing path
+    re-simulates fourteen years of two markets and takes minutes. The specific
+    regression: `exec` on the last line replaces the shell image, so bash never
+    runs the EXIT trap and every run leaves its temp directory behind. The trap
+    is only as good as the absence of that `exec`, so both are asserted.
+    """
+    script = HEADLINE_COMMAND.read_text()
+    assert "trap 'rm -rf \"$WORK\"' EXIT" in script
+    assert "exec " not in script, "an exec after the trap would skip the cleanup"
+
+
+def test_the_command_explains_itself_without_running_anything():
+    """A reader who has seen none of this types --help first."""
+    printed = subprocess.run(
+        ["bash", str(HEADLINE_COMMAND), "--help"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+        env={**os.environ, "PYTHON": sys.executable},
+    )
+    assert printed.returncode == 0
+    assert "--from-store" in printed.stdout
+
+
+def test_a_missing_environment_is_named_rather_than_thrown():
+    """The reader who runs this has cloned a repository, not installed a tool.
+
+    Both paths import the backtest package, so both need duckdb even though the
+    default one reads no bars. A `ModuleNotFoundError` traceback tells that reader
+    nothing they can act on, so the command checks first and says what to install.
+    """
+    bare = subprocess.run(
+        ["bash", str(HEADLINE_COMMAND)],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+        # An interpreter that certainly cannot import the project's dependencies.
+        env={**os.environ, "PYTHON": "/usr/bin/false"},
+    )
+    assert bare.returncode == 3
+    assert "duckdb" in bare.stderr
+    assert "requirements.txt" in bare.stderr
+    assert "Traceback" not in bare.stderr
 
 
 def test_the_write_up_moves_no_committed_constant():

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import os
+import subprocess
+import sys
 from datetime import date, timedelta
 from pathlib import Path
 
@@ -12864,3 +12867,217 @@ def test_the_axes_a_sweep_reports_are_the_axes_it_ran(tmp_path):
 
     assert [block["axis"] for block in report["axes"]] == list(AXES)
     assert {v.axis for v in variants()} == set(AXES)
+
+
+# -- the write-up --------------------------------------------------------------
+#
+# Phase 7 (issue #200). The deliverables are documents and a command rather than
+# a module, so what is testable about them is the one thing a document reliably
+# gets wrong: **drift**. Every figure quoted below is re-read from the committed
+# payload that produced it, so a rerun that moves a number and leaves the prose
+# behind fails here rather than in a reader's hands.
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REFERENCES = REPO_ROOT / "references"
+AUTHORITY_DOC = REFERENCES / "backtest_findings.md"
+PLAIN_DOC = REFERENCES / "backtest_findings-plain.md"
+HEADLINE_COMMAND = REPO_ROOT / "scripts" / "backtest_headline.sh"
+
+SUMMARY_HEADING = "## The headline, and its bound"
+LIMITS_HEADING = "## What this cannot say"
+
+
+def _run_headline(*args: str) -> subprocess.CompletedProcess:
+    """The committed command, run against the interpreter the tests run under.
+
+    The script prefers ``backend/.venv/bin/python`` and honours ``PYTHON`` when
+    that is not the environment in use — a git worktree has no venv of its own,
+    and a test that silently fell back to a bare ``python3`` would be asserting on
+    an import error rather than on the headline.
+    """
+    return subprocess.run(
+        ["bash", str(HEADLINE_COMMAND), *args],
+        capture_output=True, text=True, check=True, cwd=REPO_ROOT,
+        env={**os.environ, "PYTHON": sys.executable},
+    )
+
+
+def _committed(name: str) -> dict:
+    return json.loads((REFERENCES / name).read_text())
+
+
+def _prose(path: Path) -> str:
+    """A document's text with its typographic minus folded to the ASCII one.
+
+    Prose in this repo sets a negative figure with U+2212, and a formatter prints
+    it with a hyphen. Asserting on the glyph rather than the figure would make
+    every one of these tests a test of punctuation.
+    """
+    return path.read_text().replace("\u2212", "-")
+
+
+def _headline_cells() -> dict[str, dict[str, float]]:
+    """The four pre-registered figures, read off the payload that produced them."""
+    metric = _committed("backtest_primary_metric.json")
+    return {
+        body["market"]: {
+            cell["label"]: cell["expectancy_r"] for cell in body["windows"]
+        }
+        for body in metric["markets"]
+    }
+
+
+def _verdict_markets() -> dict[str, dict]:
+    return {body["market"]: body for body in _committed("backtest_verdict.json")["markets"]}
+
+
+def test_the_authority_document_and_its_plain_companion_are_both_committed():
+    """The convention findings §0 set: an authority document, and a plain-language
+    companion beside it that assumes none of the vocabulary."""
+    assert AUTHORITY_DOC.exists()
+    assert PLAIN_DOC.exists()
+    # Each names the other, or a reader who lands on one never learns of the other.
+    assert PLAIN_DOC.name in _prose(AUTHORITY_DOC)
+    assert AUTHORITY_DOC.name in _prose(PLAIN_DOC)
+
+
+def test_the_machine_readable_results_are_committed_beside_both():
+    """Every figure the write-up quotes has a payload behind it, and the document
+    names the file rather than leaving the reader to guess which one."""
+    page = _prose(AUTHORITY_DOC)
+    for payload in (
+        "backtest_primary_metric.json",
+        "backtest_survivorship.json",
+        "backtest_verdict.json",
+        "backtest_sweep.json",
+        "backtest_regime_posture.json",
+        "backtest_candidate_outcomes.json",
+        "backtest_score_ranking.json",
+        "backtest_anchors.json",
+    ):
+        assert (REFERENCES / payload).exists(), payload
+        assert payload in page, payload
+
+
+def test_the_headline_figures_in_both_documents_are_the_committed_ones():
+    """The drift guard. A rerun that moves an expectancy and leaves the prose
+    behind is the failure this test exists for — in both documents, because a
+    plain-language companion quoting a stale number is no better than a stale
+    authority."""
+    cells = _headline_cells()
+    authority = _prose(AUTHORITY_DOC)
+    plain = _prose(PLAIN_DOC)
+    for market, windows in cells.items():
+        for expectancy in windows.values():
+            assert expectancy is not None
+            printed = f"{expectancy:+.3f}R"
+            assert printed in authority, (market, printed)
+            assert printed in plain, (market, printed)
+
+
+def test_the_bias_bound_is_in_the_summary_and_not_in_a_footnote():
+    """Phase 2's bound is larger than the effect the run is looking for, so a
+    reader who stops after the summary must already have it. Both pessimistic
+    figures appear above the summary section's end."""
+    page = _prose(AUTHORITY_DOC)
+    assert SUMMARY_HEADING in page
+    summary = page.split(SUMMARY_HEADING, 1)[1].split("\n## ", 1)[0]
+    for market, body in _verdict_markets().items():
+        for cell in body["windows"]:
+            assert f"{cell['pessimistic_r']:+.3f}R" in summary, (market, cell["label"])
+    # And the size of the hole itself, per market, not just its consequence.
+    for body in _verdict_markets().values():
+        assert f"{body['hole_share'] * 100:.1f}%" in summary, body["market"]
+
+
+def test_both_markets_are_reported_separately_including_in_the_summary():
+    """Findings §8: shapes travel between US and IDX and magnitudes do not, so a
+    pooled figure describes neither market. The summary names both."""
+    page = _prose(AUTHORITY_DOC)
+    summary = page.split(SUMMARY_HEADING, 1)[1].split("\n## ", 1)[0]
+    cells = _headline_cells()
+    assert set(cells) == {"US", "IDX"}
+    for market, windows in cells.items():
+        assert market in summary
+        for expectancy in windows.values():
+            assert f"{expectancy:+.3f}R" in summary, (market, expectancy)
+
+
+def test_the_verdict_is_stated_in_the_words_the_contract_fixed_in_advance():
+    """The licence strings are the contract's own, written before the run. Quoting
+    them verbatim is what stops the verdict being restated more warmly than it was
+    decided."""
+    page = _prose(AUTHORITY_DOC)
+    # Collapsed, and with the blockquote markers dropped: prose wraps a quotation
+    # across lines and marks each one, and the contract's words are the claim
+    # under test rather than where the line breaks and the "> " fell.
+    unwrapped = " ".join(
+        " ".join(line.lstrip("> ") for line in page.splitlines()).split()
+    )
+    for market, body in _verdict_markets().items():
+        assert body["verdict"] in page.lower(), market
+        assert " ".join(body["licenses"].split()) in unwrapped, market
+
+
+def test_the_licensed_change_is_named_before_any_constant_moves():
+    """The ship verdict's own condition. IDX ships, so the write-up names the
+    change it licenses — and no constant in the app moved to earn it."""
+    page = _prose(AUTHORITY_DOC)
+    assert "## The change this licenses" in page
+    licensed = page.split("## The change this licenses", 1)[1].split("\n## ", 1)[0]
+    assert "IDX" in licensed
+    # Named, and still unspent: the calibration rule is where it goes next.
+    assert "findings §7" in licensed
+
+
+def test_the_limits_are_stated_including_what_signal_level_cannot_say():
+    """A limitation named in advance is a caveat; one discovered afterwards is a
+    retraction. The four the plan fixed, plus the deferral in its own words."""
+    for doc in (AUTHORITY_DOC, PLAIN_DOC):
+        page = _prose(doc)
+        assert LIMITS_HEADING in page or "cannot say" in page, doc.name
+    page = _prose(AUTHORITY_DOC)
+    limits = page.split(LIMITS_HEADING, 1)[1].split("\n## ", 1)[0]
+    for claim in (
+        "capacity",
+        "concurrency",
+        "drawdown",
+        "correlated clustering",
+        "intraday",
+    ):
+        assert claim in limits, claim
+    # The portfolio question is deferred rather than dismissed, in those words.
+    assert "deferred rather than dismissed" in limits
+
+
+def test_one_committed_command_reproduces_the_headline_figure():
+    """A reader who has seen none of this runs one command and reads the four
+    figures and their bounds off its output."""
+    assert HEADLINE_COMMAND.exists()
+    assert os.access(HEADLINE_COMMAND, os.X_OK), "the command must be runnable"
+    printed = _run_headline().stdout
+    for market, body in _verdict_markets().items():
+        assert market in printed
+        for cell in body["windows"]:
+            assert f"{cell['expectancy_r']:+.3f}R" in printed, (market, cell["label"])
+            assert f"{cell['pessimistic_r']:+.3f}R" in printed, (market, cell["label"])
+
+
+def test_the_command_says_whether_it_recomputed_the_figure_or_read_it_back():
+    """Two paths, and they are not the same claim. Reading a recorded headline off
+    disk checks that the payload and the prose agree; recomputing it from the store
+    checks the figure itself. A command that did the first and let a reader believe
+    the second would be the whole write-up's credibility spent on a shortcut."""
+    printed = _run_headline().stdout
+    assert "recorded" in printed.lower()
+    assert "--from-store" in printed, "the recomputing path is named in the output"
+    # And the document tells the reader the same two things.
+    assert HEADLINE_COMMAND.name in _prose(AUTHORITY_DOC)
+
+
+def test_the_write_up_moves_no_committed_constant():
+    """Phase 7 writes. The ship verdict licenses a change and explicitly defers it,
+    so the contract this run was measured under is byte-identical after it."""
+    before = DEFAULT_CONTRACT_JSON.read_text()
+    _run_headline()
+    assert DEFAULT_CONTRACT_JSON.read_text() == before

--- a/backend/tests/test_replay_seam.py
+++ b/backend/tests/test_replay_seam.py
@@ -19,6 +19,7 @@ import dataclasses
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 from datetime import date, timedelta
@@ -12966,6 +12967,47 @@ def test_the_machine_readable_results_are_committed_beside_both():
     ):
         assert (REFERENCES / payload).exists(), payload
         assert payload in page, payload
+
+
+def test_every_payload_the_table_links_is_committed_rather_than_merely_present():
+    """"Committed beside both" is a claim about the repository, not the disk.
+
+    A payload that exists locally and is untracked or ignored reads as available to
+    every reader and is available to none of them — and the two large stores this
+    run was built from are exactly that, deliberately. So the table's rows are
+    checked against `git ls-files` rather than against `Path.exists`.
+    """
+    page = _prose(AUTHORITY_DOC)
+    table = _section(page, "## The committed payloads")
+    linked = sorted(set(re.findall(r"\((backtest_[a-z_A-Z]+\.json)\)", table)))
+    assert linked, "the payload table links no payload"
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "--", "references"],
+        capture_output=True, text=True, check=True, cwd=REPO_ROOT,
+    ).stdout.split()
+    tracked_names = {Path(row).name for row in tracked}
+    for payload in linked:
+        assert payload in tracked_names, f"{payload} is linked but not tracked"
+
+
+def test_the_committed_payloads_are_not_the_denominator_itself():
+    """The rows the denominator names live in two stores `.gitignore` keeps out.
+
+    Saying otherwise sends a reader looking in the repository for 15.1M bars. The
+    document has to name both stores and say they are absent, so the reproduction
+    section's crawl is understood as required rather than optional.
+    """
+    table = _section(_prose(AUTHORITY_DOC), "## The committed payloads")
+    assert "data/backtest.duckdb" in table
+    assert "data/backtest.duckdb.denominator.duckdb" in table
+    assert ".gitignore" in table
+    # And the claim is true: neither store is tracked.
+    tracked = subprocess.run(
+        ["git", "ls-files", "--", "data"],
+        capture_output=True, text=True, check=True, cwd=REPO_ROOT,
+    ).stdout.split()
+    assert not [row for row in tracked if row.endswith(".duckdb")]
 
 
 def test_the_headline_figures_in_both_documents_are_the_committed_ones():

--- a/docs/out-of-sample-backtest-plan.md
+++ b/docs/out-of-sample-backtest-plan.md
@@ -614,6 +614,34 @@ State the bias bound from Phase 2 in the summary, not in a footnote.
 **Done when** a reader who has seen none of this can reproduce the headline figure from the
 committed command, and can state its bound without reading the code.
 
+**Done** (2026-08-27, #200). The authority document is
+[`references/backtest_findings.md`](../references/backtest_findings.md) and its plain-language
+companion is [`backtest_findings-plain.md`](../references/backtest_findings-plain.md). The one
+command is `bash scripts/backtest_headline.sh`, which prints both markets, both windows, each
+figure beside its pessimistic twin and the verdict in the contract's own words — from the
+committed payloads by default, and recomputed from the bars with
+`--from-store data/backtest.duckdb`. The two paths are different claims and the command says on
+its first line which one it took.
+
+Writing it up ran the three Phase 5 measurements whose machinery had landed with no committed
+result — the denominator figures ([`backtest_figures.json`](../references/backtest_figures.json),
+#193), the regime posture ([`backtest_regime_posture.json`](../references/backtest_regime_posture.json),
+#192) and the candidate outcome test
+([`backtest_candidate_outcomes.json`](../references/backtest_candidate_outcomes.json), #195) —
+plus the three exit arms beside each other (`backtest_arms_{US,IDX}.json`). A phase reported
+from a payload nobody committed is a phase whose figures cannot be checked.
+
+Three results the write-up records for the first time. **Precision, at last**: 3.1% on the US
+and 2.4% on IDX at arm B, against a 12.8% / 9.5% trigger share — the false-positive rate
+findings §9 could not report and #149 could only log as volume carrying no verdict.
+**`Relative move` predicts on IDX** — a +1.927R hit-minus-miss gap on an interval clear of zero,
+the one positive cell of four, and the change the ship verdict licenses, named there before any
+constant moves. And **arm A smooths without raising expectancy**, matching arm B on the US and
+giving up 0.379R per trade on IDX for four points of hit rate.
+
+**No constant moved.** The contract, the rubric, the detector and the register are all as this
+run measured them; the licensed change is named and unspent.
+
 ---
 
 ## Traps

--- a/references/backtest_arms_IDX.json
+++ b/references/backtest_arms_IDX.json
@@ -1,0 +1,252 @@
+{
+ "contract": {
+  "contract_version": "1",
+  "label": "out-of-sample backtest \u2014 US+IDX, 2012 onward (PRD #182)",
+  "cells": [
+   {
+    "key": "scope.setups",
+    "value": "long_breakout_eod",
+    "justification": "Long breakout EOD setups only, so the run measures the same thing the reference set and the detector do (PRD story 7)."
+   },
+   {
+    "key": "scope.level",
+    "value": "signal_primary_portfolio_deferred",
+    "justification": "Signal level is declared primary and portfolio level specified but deferred, so the open question is answered without the capital model blocking it (story 8)."
+   },
+   {
+    "key": "scope.markets",
+    "value": [
+     "US",
+     "IDX"
+    ],
+    "justification": "US and IDX reported separately throughout, so findings \u00a78's result that magnitudes do not transfer is honoured rather than averaged away (story 4)."
+   },
+   {
+    "key": "window.measured_start",
+    "value": "2012-01-01",
+    "justification": "The measured window starts 2012-01-01 so the sample spans several regimes rather than one (story 5)."
+   },
+   {
+    "key": "window.measured_end",
+    "value": "latest_complete_session",
+    "justification": "The measured window runs to the latest complete session, so the sample extends as far as the data legitimately allows (story 5)."
+   },
+   {
+    "key": "window.store_start",
+    "value": "2011-01-01",
+    "justification": "The store window starts 2011-01-01 so the detector's 80-bar minimum history, the universe gates and the regime's 25-bar warm-up are all satisfied before the first measured session (story 6)."
+   },
+   {
+    "key": "universe.trend_gate",
+    "value": "close > SMA50",
+    "justification": "The trend gate is close > SMA50 on both markets, so the universe reflects the method's own precondition (story 10)."
+   },
+   {
+    "key": "universe.liquidity_floor",
+    "value": {
+     "US": 10000000.0,
+     "IDX": 10000000000.0
+    },
+    "justification": "Liquidity floors are $10M for US and Rp 10B for IDX \u2014 a deliberate contract value, not the app's inherited $20M / Rp 1B (story 11)."
+   },
+   {
+    "key": "universe.adtv",
+    "value": "median_20d_unadjusted_close_x_volume",
+    "justification": "ADTV is the 20-day median of unadjusted close \u00d7 volume, so one block trade cannot lift an illiquid name over the floor (story 12)."
+   },
+   {
+    "key": "universe.adtv_aggregator",
+    "value": "median",
+    "justification": "The aggregator is the median; a switch to mean is a deliberate act, so which spiky small caps qualify never changes by accident (story 13)."
+   },
+   {
+    "key": "universe.volatility_gate",
+    "value": "ADR20 >= 3.5%",
+    "justification": "The volatility gate is ADR20 \u2265 3.5%, set deliberately below the rubric's 5% floor so the ADR dimension is left with spread to test (story 14)."
+   },
+   {
+    "key": "universe.volatility_gap_reason",
+    "value": "gate_below_rubric_floor_is_deliberate",
+    "justification": "The gap below the rubric's 5% floor is recorded so nobody later 'fixes' it to match and silently destroys the thing being measured \u2014 findings \u00a76 Finding 2 measured the 5% floor withholding a score point from 31% of his real entries (story 15)."
+   },
+   {
+    "key": "universe.idx_price_floor",
+    "value": 100.0,
+    "justification": "A nominal price floor of Rp 100 on the split-corrected series excludes IDX names whose quotes hit the tick grid hard enough to distort ADR and range geometry (story 16)."
+   },
+   {
+    "key": "universe.idx_price_floor_role",
+    "value": "data_validity",
+    "justification": "The Rp 100 floor is data validity and never cost control, so no reader infers a penny-stock filter with an implied cost story (story 17)."
+   },
+   {
+    "key": "universe.statelessness",
+    "value": "stateless_gates_through_t_minus_1",
+    "justification": "The universe is stateless \u2014 three gates measured through t\u22121 with no reference to prior membership \u2014 a known difference from the app's hysteresis band whose boundary churn is nearly free at signal level and real at portfolio level (stories 9, 18, 19)."
+   },
+   {
+    "key": "universe.reference_exclusion",
+    "value": "exclude_index_and_benchmark_etfs",
+    "justification": "The five benchmark references stay out of the ranked field, pinned against the enumeration by a test, so this fresh build inherits the #162 fix rather than reproducing the contamination (stories 73, 74)."
+   },
+   {
+    "key": "detection.gate",
+    "value": [
+     "1m",
+     "3m",
+     "6m",
+     "12m"
+    ],
+    "justification": "The detection gate is the four-lookback width (detector v3, ADR 0003 amendment); the denominator is built against that width and it is not swept in the primary run (PRD Implementation Decisions)."
+   },
+   {
+    "key": "regime.source",
+    "value": "app_regime_off_market_index_at_t_minus_1",
+    "justification": "Regime is the app's own regime, unmodified, read off each market's own index at t\u22121 \u2014 so findings are actionable in the product and the conditioning input obeys the point-in-time rule (stories 21, 23)."
+   },
+   {
+    "key": "regime.role",
+    "value": "conditioning_variable_never_filter",
+    "justification": "Regime is a conditioning variable and never a filter: every state trades and each one's expectancy is measured instead of assumed (story 22)."
+   },
+   {
+    "key": "entry.rule",
+    "value": "detection_trigger_filled_next_session",
+    "justification": "Entry is taken at the detection's own trigger, filled the next session, so the simulated trade uses the detector's own decision rather than a second definition (story 31)."
+   },
+   {
+    "key": "stop.rule",
+    "value": "detection_stop_unmodified",
+    "justification": "The stop is the detection's own stop, used unmodified, so R is denominated the way the app denominates it (story 32)."
+   },
+   {
+    "key": "exit.arm_a",
+    "value": {
+     "scale_fraction": 0.5,
+     "scale_day": 5,
+     "trail_ma": 10,
+     "trail_live_from": "fill",
+     "arbitrary_mechanics": true
+    },
+    "justification": "Arm A scales 50% off at the close of the fifth session after entry and trails the remainder on a 10MA \u2014 the trader's documented behaviour; its R is two position-weighted legs summed, and 'day 5' and the trail are recorded as arbitrary (stories 34, 36, 37, 39). The trail is live from the fill rather than from the scale day, so a runner that rolls over before day 5 takes the whole position and the scale never happens; that is a third arbitrary choice and is recorded here rather than left in the code, so a later run can sweep it (story 39)."
+   },
+   {
+    "key": "exit.arm_b",
+    "value": {
+     "trail_ma": 10
+    },
+    "justification": "Arm B is a pure 10MA trail, directly comparable to the reference set's simulated exit and the arm the primary metric is computed on (story 35)."
+   },
+   {
+    "key": "exit.arm_c",
+    "value": {
+     "trail_ma": 20
+    },
+    "justification": "Arm C is a pure 20MA trail, the reference set's second simulated exit (story 35)."
+   },
+   {
+    "key": "exit.trail_mechanic",
+    "value": "close_through_ma_signals_fill_next_open",
+    "justification": "A trail signals on a close through the MA and fills at the next open, so the exit is point-in-time and reproducible; recorded as arbitrary so a later run can vary it deliberately (stories 38, 39)."
+   },
+   {
+    "key": "costs.per_market",
+    "value": {
+     "US": {
+      "commission_bps": 0.0,
+      "slippage_bps": 5.0
+     },
+     "IDX": {
+      "commission_bps": 15.0,
+      "slippage_bps": 25.0
+     }
+    },
+    "justification": "Commission and slippage are per-market contract values applied before any sweep, so IDX's real fees and spread are not modelled with US's near-zero assumptions; this pre-registered baseline is recorded here and swept variants are reported with the count of variants tried (story 40)."
+   },
+   {
+    "key": "metric.primary",
+    "value": "arm_b_after_cost_expectancy_r_per_market_per_year",
+    "justification": "The one pre-registered primary metric is arm B's after-cost expectancy in R, per market per year, so the headline cannot be chosen after the fact (story 41)."
+   },
+   {
+    "key": "decision.kill",
+    "value": {
+     "metric": "arm_b_after_cost_expectancy_r",
+     "comparator": "<=",
+     "threshold": 0.0,
+     "requires": [
+      "both_markets",
+      "full_window",
+      "and_excluding_2020_2021"
+     ],
+     "basis": "survivor_biased_number"
+    },
+    "justification": "Kill fires only when arm B's after-cost expectancy is \u2264 0 in both markets on the full window and with 2020\u201321 excluded, and the line is drawn on the survivor-biased number so a failure is decisive \u2014 the honest figure can only be worse (stories 42, 43)."
+   },
+   {
+    "key": "decision.ship",
+    "value": {
+     "requires": [
+      "positive_result",
+      "clears_phase2_pessimistic_bound"
+     ],
+     "scope": "per_market"
+    },
+    "justification": "Ship requires a positive result that also clears the Phase 2 pessimistic bound, scoped per market so a US pass licenses nothing in Jakarta (stories 44, 45)."
+   },
+   {
+    "key": "decision.one_market_failure",
+    "value": "method_stands_that_market_off_until_explained",
+    "justification": "A one-market failure is its own pre-named verdict: the method stands and that market is off until a run explains the difference, so it is not improvised in the moment (story 46)."
+   },
+   {
+    "key": "decision.inconclusive",
+    "value": "report_inconclusive_no_swept_tiebreak",
+    "justification": "An inconclusive run is reported as inconclusive; reaching for a swept variant to break the tie is ruled out by the contract that exists to prevent it (story 47)."
+   },
+   {
+    "key": "decision.licensed_changes",
+    "value": "write_licensed_change_before_any_constant_moves",
+    "justification": "Each verdict's licensed change is written down before any constant moves, so a result cannot be converted into an unguarded edit (story 48)."
+   }
+  ]
+ },
+ "arms": [
+  {
+   "arm": "A",
+   "trail_ma": 10,
+   "trail_mechanic": "close_through_ma_signals_fill_next_open",
+   "comparable_to_reference": false,
+   "trades": 1201,
+   "closed": 1196,
+   "open_at_end": 5,
+   "price_scale_dropped": 0,
+   "total_r": 817.2467118642807,
+   "scale_day": 5,
+   "scale_fraction": 0.5,
+   "scale_mechanic": "close_of_nth_session_after_entry"
+  },
+  {
+   "arm": "B",
+   "trail_ma": 10,
+   "trail_mechanic": "close_through_ma_signals_fill_next_open",
+   "comparable_to_reference": true,
+   "trades": 1201,
+   "closed": 1196,
+   "open_at_end": 5,
+   "price_scale_dropped": 0,
+   "total_r": 1270.6960031704275
+  },
+  {
+   "arm": "C",
+   "trail_ma": 20,
+   "trail_mechanic": "close_through_ma_signals_fill_next_open",
+   "comparable_to_reference": true,
+   "trades": 1201,
+   "closed": 1194,
+   "open_at_end": 7,
+   "price_scale_dropped": 0,
+   "total_r": 1196.6268234635968
+  }
+ ]
+}

--- a/references/backtest_arms_IDX.txt
+++ b/references/backtest_arms_IDX.txt
@@ -1,0 +1,19 @@
+arm A — 50% at the close of session 5, remainder on a 10MA trail (close_through_ma_signals_fill_next_open) — measured, not anchored
+  trades          1201
+  closed          1196
+  open at end     5
+  total R         +817.25
+  price-scale flag would drop 0 of 1201
+arm B — 10MA trail (close_through_ma_signals_fill_next_open)
+  trades          1201
+  closed          1196
+  open at end     5
+  total R         +1270.70
+  price-scale flag would drop 0 of 1201
+arm C — 20MA trail (close_through_ma_signals_fill_next_open)
+  trades          1201
+  closed          1194
+  open at end     7
+  total R         +1196.63
+  price-scale flag would drop 0 of 1201
+

--- a/references/backtest_arms_US.json
+++ b/references/backtest_arms_US.json
@@ -1,0 +1,252 @@
+{
+ "contract": {
+  "contract_version": "1",
+  "label": "out-of-sample backtest \u2014 US+IDX, 2012 onward (PRD #182)",
+  "cells": [
+   {
+    "key": "scope.setups",
+    "value": "long_breakout_eod",
+    "justification": "Long breakout EOD setups only, so the run measures the same thing the reference set and the detector do (PRD story 7)."
+   },
+   {
+    "key": "scope.level",
+    "value": "signal_primary_portfolio_deferred",
+    "justification": "Signal level is declared primary and portfolio level specified but deferred, so the open question is answered without the capital model blocking it (story 8)."
+   },
+   {
+    "key": "scope.markets",
+    "value": [
+     "US",
+     "IDX"
+    ],
+    "justification": "US and IDX reported separately throughout, so findings \u00a78's result that magnitudes do not transfer is honoured rather than averaged away (story 4)."
+   },
+   {
+    "key": "window.measured_start",
+    "value": "2012-01-01",
+    "justification": "The measured window starts 2012-01-01 so the sample spans several regimes rather than one (story 5)."
+   },
+   {
+    "key": "window.measured_end",
+    "value": "latest_complete_session",
+    "justification": "The measured window runs to the latest complete session, so the sample extends as far as the data legitimately allows (story 5)."
+   },
+   {
+    "key": "window.store_start",
+    "value": "2011-01-01",
+    "justification": "The store window starts 2011-01-01 so the detector's 80-bar minimum history, the universe gates and the regime's 25-bar warm-up are all satisfied before the first measured session (story 6)."
+   },
+   {
+    "key": "universe.trend_gate",
+    "value": "close > SMA50",
+    "justification": "The trend gate is close > SMA50 on both markets, so the universe reflects the method's own precondition (story 10)."
+   },
+   {
+    "key": "universe.liquidity_floor",
+    "value": {
+     "US": 10000000.0,
+     "IDX": 10000000000.0
+    },
+    "justification": "Liquidity floors are $10M for US and Rp 10B for IDX \u2014 a deliberate contract value, not the app's inherited $20M / Rp 1B (story 11)."
+   },
+   {
+    "key": "universe.adtv",
+    "value": "median_20d_unadjusted_close_x_volume",
+    "justification": "ADTV is the 20-day median of unadjusted close \u00d7 volume, so one block trade cannot lift an illiquid name over the floor (story 12)."
+   },
+   {
+    "key": "universe.adtv_aggregator",
+    "value": "median",
+    "justification": "The aggregator is the median; a switch to mean is a deliberate act, so which spiky small caps qualify never changes by accident (story 13)."
+   },
+   {
+    "key": "universe.volatility_gate",
+    "value": "ADR20 >= 3.5%",
+    "justification": "The volatility gate is ADR20 \u2265 3.5%, set deliberately below the rubric's 5% floor so the ADR dimension is left with spread to test (story 14)."
+   },
+   {
+    "key": "universe.volatility_gap_reason",
+    "value": "gate_below_rubric_floor_is_deliberate",
+    "justification": "The gap below the rubric's 5% floor is recorded so nobody later 'fixes' it to match and silently destroys the thing being measured \u2014 findings \u00a76 Finding 2 measured the 5% floor withholding a score point from 31% of his real entries (story 15)."
+   },
+   {
+    "key": "universe.idx_price_floor",
+    "value": 100.0,
+    "justification": "A nominal price floor of Rp 100 on the split-corrected series excludes IDX names whose quotes hit the tick grid hard enough to distort ADR and range geometry (story 16)."
+   },
+   {
+    "key": "universe.idx_price_floor_role",
+    "value": "data_validity",
+    "justification": "The Rp 100 floor is data validity and never cost control, so no reader infers a penny-stock filter with an implied cost story (story 17)."
+   },
+   {
+    "key": "universe.statelessness",
+    "value": "stateless_gates_through_t_minus_1",
+    "justification": "The universe is stateless \u2014 three gates measured through t\u22121 with no reference to prior membership \u2014 a known difference from the app's hysteresis band whose boundary churn is nearly free at signal level and real at portfolio level (stories 9, 18, 19)."
+   },
+   {
+    "key": "universe.reference_exclusion",
+    "value": "exclude_index_and_benchmark_etfs",
+    "justification": "The five benchmark references stay out of the ranked field, pinned against the enumeration by a test, so this fresh build inherits the #162 fix rather than reproducing the contamination (stories 73, 74)."
+   },
+   {
+    "key": "detection.gate",
+    "value": [
+     "1m",
+     "3m",
+     "6m",
+     "12m"
+    ],
+    "justification": "The detection gate is the four-lookback width (detector v3, ADR 0003 amendment); the denominator is built against that width and it is not swept in the primary run (PRD Implementation Decisions)."
+   },
+   {
+    "key": "regime.source",
+    "value": "app_regime_off_market_index_at_t_minus_1",
+    "justification": "Regime is the app's own regime, unmodified, read off each market's own index at t\u22121 \u2014 so findings are actionable in the product and the conditioning input obeys the point-in-time rule (stories 21, 23)."
+   },
+   {
+    "key": "regime.role",
+    "value": "conditioning_variable_never_filter",
+    "justification": "Regime is a conditioning variable and never a filter: every state trades and each one's expectancy is measured instead of assumed (story 22)."
+   },
+   {
+    "key": "entry.rule",
+    "value": "detection_trigger_filled_next_session",
+    "justification": "Entry is taken at the detection's own trigger, filled the next session, so the simulated trade uses the detector's own decision rather than a second definition (story 31)."
+   },
+   {
+    "key": "stop.rule",
+    "value": "detection_stop_unmodified",
+    "justification": "The stop is the detection's own stop, used unmodified, so R is denominated the way the app denominates it (story 32)."
+   },
+   {
+    "key": "exit.arm_a",
+    "value": {
+     "scale_fraction": 0.5,
+     "scale_day": 5,
+     "trail_ma": 10,
+     "trail_live_from": "fill",
+     "arbitrary_mechanics": true
+    },
+    "justification": "Arm A scales 50% off at the close of the fifth session after entry and trails the remainder on a 10MA \u2014 the trader's documented behaviour; its R is two position-weighted legs summed, and 'day 5' and the trail are recorded as arbitrary (stories 34, 36, 37, 39). The trail is live from the fill rather than from the scale day, so a runner that rolls over before day 5 takes the whole position and the scale never happens; that is a third arbitrary choice and is recorded here rather than left in the code, so a later run can sweep it (story 39)."
+   },
+   {
+    "key": "exit.arm_b",
+    "value": {
+     "trail_ma": 10
+    },
+    "justification": "Arm B is a pure 10MA trail, directly comparable to the reference set's simulated exit and the arm the primary metric is computed on (story 35)."
+   },
+   {
+    "key": "exit.arm_c",
+    "value": {
+     "trail_ma": 20
+    },
+    "justification": "Arm C is a pure 20MA trail, the reference set's second simulated exit (story 35)."
+   },
+   {
+    "key": "exit.trail_mechanic",
+    "value": "close_through_ma_signals_fill_next_open",
+    "justification": "A trail signals on a close through the MA and fills at the next open, so the exit is point-in-time and reproducible; recorded as arbitrary so a later run can vary it deliberately (stories 38, 39)."
+   },
+   {
+    "key": "costs.per_market",
+    "value": {
+     "US": {
+      "commission_bps": 0.0,
+      "slippage_bps": 5.0
+     },
+     "IDX": {
+      "commission_bps": 15.0,
+      "slippage_bps": 25.0
+     }
+    },
+    "justification": "Commission and slippage are per-market contract values applied before any sweep, so IDX's real fees and spread are not modelled with US's near-zero assumptions; this pre-registered baseline is recorded here and swept variants are reported with the count of variants tried (story 40)."
+   },
+   {
+    "key": "metric.primary",
+    "value": "arm_b_after_cost_expectancy_r_per_market_per_year",
+    "justification": "The one pre-registered primary metric is arm B's after-cost expectancy in R, per market per year, so the headline cannot be chosen after the fact (story 41)."
+   },
+   {
+    "key": "decision.kill",
+    "value": {
+     "metric": "arm_b_after_cost_expectancy_r",
+     "comparator": "<=",
+     "threshold": 0.0,
+     "requires": [
+      "both_markets",
+      "full_window",
+      "and_excluding_2020_2021"
+     ],
+     "basis": "survivor_biased_number"
+    },
+    "justification": "Kill fires only when arm B's after-cost expectancy is \u2264 0 in both markets on the full window and with 2020\u201321 excluded, and the line is drawn on the survivor-biased number so a failure is decisive \u2014 the honest figure can only be worse (stories 42, 43)."
+   },
+   {
+    "key": "decision.ship",
+    "value": {
+     "requires": [
+      "positive_result",
+      "clears_phase2_pessimistic_bound"
+     ],
+     "scope": "per_market"
+    },
+    "justification": "Ship requires a positive result that also clears the Phase 2 pessimistic bound, scoped per market so a US pass licenses nothing in Jakarta (stories 44, 45)."
+   },
+   {
+    "key": "decision.one_market_failure",
+    "value": "method_stands_that_market_off_until_explained",
+    "justification": "A one-market failure is its own pre-named verdict: the method stands and that market is off until a run explains the difference, so it is not improvised in the moment (story 46)."
+   },
+   {
+    "key": "decision.inconclusive",
+    "value": "report_inconclusive_no_swept_tiebreak",
+    "justification": "An inconclusive run is reported as inconclusive; reaching for a swept variant to break the tie is ruled out by the contract that exists to prevent it (story 47)."
+   },
+   {
+    "key": "decision.licensed_changes",
+    "value": "write_licensed_change_before_any_constant_moves",
+    "justification": "Each verdict's licensed change is written down before any constant moves, so a result cannot be converted into an unguarded edit (story 48)."
+   }
+  ]
+ },
+ "arms": [
+  {
+   "arm": "A",
+   "trail_ma": 10,
+   "trail_mechanic": "close_through_ma_signals_fill_next_open",
+   "comparable_to_reference": false,
+   "trades": 12350,
+   "closed": 12311,
+   "open_at_end": 39,
+   "price_scale_dropped": 0,
+   "total_r": 1180.4561558101852,
+   "scale_day": 5,
+   "scale_fraction": 0.5,
+   "scale_mechanic": "close_of_nth_session_after_entry"
+  },
+  {
+   "arm": "B",
+   "trail_ma": 10,
+   "trail_mechanic": "close_through_ma_signals_fill_next_open",
+   "comparable_to_reference": true,
+   "trades": 12350,
+   "closed": 12311,
+   "open_at_end": 39,
+   "price_scale_dropped": 0,
+   "total_r": 1187.4161833368094
+  },
+  {
+   "arm": "C",
+   "trail_ma": 20,
+   "trail_mechanic": "close_through_ma_signals_fill_next_open",
+   "comparable_to_reference": true,
+   "trades": 12350,
+   "closed": 12283,
+   "open_at_end": 67,
+   "price_scale_dropped": 0,
+   "total_r": 3424.834062801452
+  }
+ ]
+}

--- a/references/backtest_arms_US.txt
+++ b/references/backtest_arms_US.txt
@@ -1,0 +1,19 @@
+arm A — 50% at the close of session 5, remainder on a 10MA trail (close_through_ma_signals_fill_next_open) — measured, not anchored
+  trades          12350
+  closed          12311
+  open at end     39
+  total R         +1180.46
+  price-scale flag would drop 0 of 12350
+arm B — 10MA trail (close_through_ma_signals_fill_next_open)
+  trades          12350
+  closed          12311
+  open at end     39
+  total R         +1187.42
+  price-scale flag would drop 0 of 12350
+arm C — 20MA trail (close_through_ma_signals_fill_next_open)
+  trades          12350
+  closed          12283
+  open at end     67
+  total R         +3424.83
+  price-scale flag would drop 0 of 12350
+

--- a/references/backtest_candidate_outcomes.json
+++ b/references/backtest_candidate_outcomes.json
@@ -1,0 +1,1175 @@
+{
+ "contract": {
+  "contract_version": "1",
+  "label": "out-of-sample backtest \u2014 US+IDX, 2012 onward (PRD #182)",
+  "cells": [
+   {
+    "key": "scope.setups",
+    "value": "long_breakout_eod",
+    "justification": "Long breakout EOD setups only, so the run measures the same thing the reference set and the detector do (PRD story 7)."
+   },
+   {
+    "key": "scope.level",
+    "value": "signal_primary_portfolio_deferred",
+    "justification": "Signal level is declared primary and portfolio level specified but deferred, so the open question is answered without the capital model blocking it (story 8)."
+   },
+   {
+    "key": "scope.markets",
+    "value": [
+     "US",
+     "IDX"
+    ],
+    "justification": "US and IDX reported separately throughout, so findings \u00a78's result that magnitudes do not transfer is honoured rather than averaged away (story 4)."
+   },
+   {
+    "key": "window.measured_start",
+    "value": "2012-01-01",
+    "justification": "The measured window starts 2012-01-01 so the sample spans several regimes rather than one (story 5)."
+   },
+   {
+    "key": "window.measured_end",
+    "value": "latest_complete_session",
+    "justification": "The measured window runs to the latest complete session, so the sample extends as far as the data legitimately allows (story 5)."
+   },
+   {
+    "key": "window.store_start",
+    "value": "2011-01-01",
+    "justification": "The store window starts 2011-01-01 so the detector's 80-bar minimum history, the universe gates and the regime's 25-bar warm-up are all satisfied before the first measured session (story 6)."
+   },
+   {
+    "key": "universe.trend_gate",
+    "value": "close > SMA50",
+    "justification": "The trend gate is close > SMA50 on both markets, so the universe reflects the method's own precondition (story 10)."
+   },
+   {
+    "key": "universe.liquidity_floor",
+    "value": {
+     "US": 10000000.0,
+     "IDX": 10000000000.0
+    },
+    "justification": "Liquidity floors are $10M for US and Rp 10B for IDX \u2014 a deliberate contract value, not the app's inherited $20M / Rp 1B (story 11)."
+   },
+   {
+    "key": "universe.adtv",
+    "value": "median_20d_unadjusted_close_x_volume",
+    "justification": "ADTV is the 20-day median of unadjusted close \u00d7 volume, so one block trade cannot lift an illiquid name over the floor (story 12)."
+   },
+   {
+    "key": "universe.adtv_aggregator",
+    "value": "median",
+    "justification": "The aggregator is the median; a switch to mean is a deliberate act, so which spiky small caps qualify never changes by accident (story 13)."
+   },
+   {
+    "key": "universe.volatility_gate",
+    "value": "ADR20 >= 3.5%",
+    "justification": "The volatility gate is ADR20 \u2265 3.5%, set deliberately below the rubric's 5% floor so the ADR dimension is left with spread to test (story 14)."
+   },
+   {
+    "key": "universe.volatility_gap_reason",
+    "value": "gate_below_rubric_floor_is_deliberate",
+    "justification": "The gap below the rubric's 5% floor is recorded so nobody later 'fixes' it to match and silently destroys the thing being measured \u2014 findings \u00a76 Finding 2 measured the 5% floor withholding a score point from 31% of his real entries (story 15)."
+   },
+   {
+    "key": "universe.idx_price_floor",
+    "value": 100.0,
+    "justification": "A nominal price floor of Rp 100 on the split-corrected series excludes IDX names whose quotes hit the tick grid hard enough to distort ADR and range geometry (story 16)."
+   },
+   {
+    "key": "universe.idx_price_floor_role",
+    "value": "data_validity",
+    "justification": "The Rp 100 floor is data validity and never cost control, so no reader infers a penny-stock filter with an implied cost story (story 17)."
+   },
+   {
+    "key": "universe.statelessness",
+    "value": "stateless_gates_through_t_minus_1",
+    "justification": "The universe is stateless \u2014 three gates measured through t\u22121 with no reference to prior membership \u2014 a known difference from the app's hysteresis band whose boundary churn is nearly free at signal level and real at portfolio level (stories 9, 18, 19)."
+   },
+   {
+    "key": "universe.reference_exclusion",
+    "value": "exclude_index_and_benchmark_etfs",
+    "justification": "The five benchmark references stay out of the ranked field, pinned against the enumeration by a test, so this fresh build inherits the #162 fix rather than reproducing the contamination (stories 73, 74)."
+   },
+   {
+    "key": "detection.gate",
+    "value": [
+     "1m",
+     "3m",
+     "6m",
+     "12m"
+    ],
+    "justification": "The detection gate is the four-lookback width (detector v3, ADR 0003 amendment); the denominator is built against that width and it is not swept in the primary run (PRD Implementation Decisions)."
+   },
+   {
+    "key": "regime.source",
+    "value": "app_regime_off_market_index_at_t_minus_1",
+    "justification": "Regime is the app's own regime, unmodified, read off each market's own index at t\u22121 \u2014 so findings are actionable in the product and the conditioning input obeys the point-in-time rule (stories 21, 23)."
+   },
+   {
+    "key": "regime.role",
+    "value": "conditioning_variable_never_filter",
+    "justification": "Regime is a conditioning variable and never a filter: every state trades and each one's expectancy is measured instead of assumed (story 22)."
+   },
+   {
+    "key": "entry.rule",
+    "value": "detection_trigger_filled_next_session",
+    "justification": "Entry is taken at the detection's own trigger, filled the next session, so the simulated trade uses the detector's own decision rather than a second definition (story 31)."
+   },
+   {
+    "key": "stop.rule",
+    "value": "detection_stop_unmodified",
+    "justification": "The stop is the detection's own stop, used unmodified, so R is denominated the way the app denominates it (story 32)."
+   },
+   {
+    "key": "exit.arm_a",
+    "value": {
+     "scale_fraction": 0.5,
+     "scale_day": 5,
+     "trail_ma": 10,
+     "trail_live_from": "fill",
+     "arbitrary_mechanics": true
+    },
+    "justification": "Arm A scales 50% off at the close of the fifth session after entry and trails the remainder on a 10MA \u2014 the trader's documented behaviour; its R is two position-weighted legs summed, and 'day 5' and the trail are recorded as arbitrary (stories 34, 36, 37, 39). The trail is live from the fill rather than from the scale day, so a runner that rolls over before day 5 takes the whole position and the scale never happens; that is a third arbitrary choice and is recorded here rather than left in the code, so a later run can sweep it (story 39)."
+   },
+   {
+    "key": "exit.arm_b",
+    "value": {
+     "trail_ma": 10
+    },
+    "justification": "Arm B is a pure 10MA trail, directly comparable to the reference set's simulated exit and the arm the primary metric is computed on (story 35)."
+   },
+   {
+    "key": "exit.arm_c",
+    "value": {
+     "trail_ma": 20
+    },
+    "justification": "Arm C is a pure 20MA trail, the reference set's second simulated exit (story 35)."
+   },
+   {
+    "key": "exit.trail_mechanic",
+    "value": "close_through_ma_signals_fill_next_open",
+    "justification": "A trail signals on a close through the MA and fills at the next open, so the exit is point-in-time and reproducible; recorded as arbitrary so a later run can vary it deliberately (stories 38, 39)."
+   },
+   {
+    "key": "costs.per_market",
+    "value": {
+     "US": {
+      "commission_bps": 0.0,
+      "slippage_bps": 5.0
+     },
+     "IDX": {
+      "commission_bps": 15.0,
+      "slippage_bps": 25.0
+     }
+    },
+    "justification": "Commission and slippage are per-market contract values applied before any sweep, so IDX's real fees and spread are not modelled with US's near-zero assumptions; this pre-registered baseline is recorded here and swept variants are reported with the count of variants tried (story 40)."
+   },
+   {
+    "key": "metric.primary",
+    "value": "arm_b_after_cost_expectancy_r_per_market_per_year",
+    "justification": "The one pre-registered primary metric is arm B's after-cost expectancy in R, per market per year, so the headline cannot be chosen after the fact (story 41)."
+   },
+   {
+    "key": "decision.kill",
+    "value": {
+     "metric": "arm_b_after_cost_expectancy_r",
+     "comparator": "<=",
+     "threshold": 0.0,
+     "requires": [
+      "both_markets",
+      "full_window",
+      "and_excluding_2020_2021"
+     ],
+     "basis": "survivor_biased_number"
+    },
+    "justification": "Kill fires only when arm B's after-cost expectancy is \u2264 0 in both markets on the full window and with 2020\u201321 excluded, and the line is drawn on the survivor-biased number so a failure is decisive \u2014 the honest figure can only be worse (stories 42, 43)."
+   },
+   {
+    "key": "decision.ship",
+    "value": {
+     "requires": [
+      "positive_result",
+      "clears_phase2_pessimistic_bound"
+     ],
+     "scope": "per_market"
+    },
+    "justification": "Ship requires a positive result that also clears the Phase 2 pessimistic bound, scoped per market so a US pass licenses nothing in Jakarta (stories 44, 45)."
+   },
+   {
+    "key": "decision.one_market_failure",
+    "value": "method_stands_that_market_off_until_explained",
+    "justification": "A one-market failure is its own pre-named verdict: the method stands and that market is off until a run explains the difference, so it is not improvised in the moment (story 46)."
+   },
+   {
+    "key": "decision.inconclusive",
+    "value": "report_inconclusive_no_swept_tiebreak",
+    "justification": "An inconclusive run is reported as inconclusive; reaching for a swept variant to break the tie is ruled out by the contract that exists to prevent it (story 47)."
+   },
+   {
+    "key": "decision.licensed_changes",
+    "value": "write_licensed_change_before_any_constant_moves",
+    "justification": "Each verdict's licensed change is written down before any constant moves, so a result cannot be converted into an unguarded edit (story 48)."
+   }
+  ]
+ },
+ "question": "do the registered candidate dimensions predict outcomes, or only match the trader's selection?",
+ "arm": "B",
+ "registered": [
+  {
+   "candidate": "RS line",
+   "cut": "RS_today >= RS_at_base_start, over the detection's own base",
+   "value_kind": "boolean",
+   "absent_means": "a price was missing at one of the two anchors, so the question was never asked \u2014 which is a different fact from asking it and getting no"
+  },
+  {
+   "candidate": "Relative move",
+   "cut": "the 6m index-relative move in ADR units, strictly above 0.0",
+   "value_kind": "graded",
+   "absent_means": "the name had not listed six months ago, or has no ADR \u2014 never zero, which is a real value sitting exactly on the cut"
+  }
+ ],
+ "out_of_sample": "the outcome variable is R after costs on trades taken mechanically over a window his record does not cover; no rubric weight was fitted to it and no detection could see it",
+ "selection_contrast_note": "the selection contrast and this measurement are a different claim about the same dimension, and neither converts into the other: one says the trader picked names the dimension fires on, the other says the names it fires on paid. A dimension can select and not predict \u2014 his edge would be discretionary \u2014 and it can predict and not select, which is a candidate he was never using. So the two verdicts are reported side by side under their own keys and are never summed, averaged or read as confirmation of each other",
+ "admission": "this measurement admits no dimension and retires none. ADR 0005's admission instrument is the selection contrast, and an outcome claim is not one \u2014 it is evidence that goes through the calibration rule like any other change. Neither candidate's weight, the rubric version, nor the register moves here",
+ "verdict_rule": "'predicts' requires the hit-minus-miss gap to have a symbol-clustered interval entirely above zero. The gap is the whole verdict: ADR 0005 admits a dimension as a boolean, so the boolean's gap is the claim anything could act on. The correlation against the stored value is reported beside it and does not enter \u2014 only one of the two registered candidates persists a degree to run it on, so a rule reading it would mean different things for the two. The rubric reading, which folds absence into the miss side, does not enter either: it says what a shipped boolean would have done, not whether the quantity predicts. A cohort whose hit or miss side is below the cluster floor, or whose interval was refused for undefined resamples, is 'too thin to say' \u2014 the gap is taken between those two sides. The verdict reads the 95% interval's lower bound, a one-sided 2.5% test and stricter than the one-sided p printed beside it. 'no evidence it predicts' is never 'the dimension does not predict': one sample cannot license that",
+ "not_cut_per_year": "reported per market and not per year, unlike the ranking test: two candidates, three groups and three statistics each already make this the widest cell in the run, and a per year row would multiply the interval count by the length of the window to answer a question #195 does not ask. The window row is the measurement",
+ "groups": {
+  "reported": [
+   "hit",
+   "miss",
+   "absent"
+  ],
+  "in_the_gap": [
+   "hit",
+   "miss"
+  ],
+  "rule": "absence is a group, never a value on the cut: the question was not asked of those names, so they enter no gap"
+ },
+ "multiple_testing": {
+  "note": "one more view of a dataset that already carried nine before any sweep; pre-specified by #195 and computed once, not chosen after the fact",
+  "intervals_reported": 20,
+  "alpha_is_nominal": true,
+  "reading": "two candidates, three groups and three statistics each; the gap rows are the measurement and the rest are diagnostics"
+ },
+ "bootstrap": {
+  "cluster": "symbol",
+  "resamples": 2000,
+  "seed": 191,
+  "confidence": 0.95
+ },
+ "markets": [
+  {
+   "market": "US",
+   "trades": 12350,
+   "symbols": 1637,
+   "candidates": [
+    {
+     "candidate": "RS line",
+     "market": "US",
+     "arm": "B",
+     "cut": "RS_today >= RS_at_base_start, over the detection's own base",
+     "cut_applied": "at read time, by the rubric's own reader, off the value the persisted row carries \u2014 no row is re-denominated",
+     "value_kind": "boolean",
+     "absent_means": "a price was missing at one of the two anchors, so the question was never asked \u2014 which is a different fact from asking it and getting no",
+     "trades": 12350,
+     "symbols": 1637,
+     "closed": 12311,
+     "groups": {
+      "hit": {
+       "group": "hit",
+       "share_of_closed": 0.21972219965884168,
+       "label": "hit",
+       "trades": 2715,
+       "closed": 2705,
+       "open_at_end": 10,
+       "undenominated": 0,
+       "symbols": 1026,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.09886595953083081,
+       "expectancy_r_before_cost": -0.04992703901674319,
+       "cost_r": 0.04893892051408762,
+       "win_rate": 0.24103512014787432,
+       "wins": 652,
+       "losses": 2053,
+       "total_r": -267.43242053089733,
+       "distribution": {
+        "min": -34.85378847996743,
+        "p10": -3.434441733153782,
+        "q1": -2.332209656365202,
+        "median": -1.3926940372847147,
+        "q3": -0.033548117322897794,
+        "p90": 4.4666925637623835,
+        "max": 72.75342933324276,
+        "mean_win": 6.149592493990247,
+        "mean_loss": -2.083276535125445
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1023,
+        "observations": 2705,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.3386058809937753,
+        "ci_high": 0.13370304670066527,
+        "p_value": 0.806
+       }
+      },
+      "miss": {
+       "group": "miss",
+       "share_of_closed": 0.7800341158313703,
+       "label": "miss",
+       "trades": 9632,
+       "closed": 9603,
+       "open_at_end": 29,
+       "undenominated": 0,
+       "symbols": 1521,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.09242956300215834,
+       "expectancy_r_before_cost": 0.13845524793711245,
+       "cost_r": 0.046025684934954104,
+       "win_rate": 0.24273664479850046,
+       "wins": 2331,
+       "losses": 7272,
+       "total_r": 887.6010935097265,
+       "distribution": {
+        "min": -79.84078091028827,
+        "p10": -3.413808923461271,
+        "q1": -2.2972531690380507,
+        "median": -1.3619878060082895,
+        "q3": -0.03157053299208025,
+        "p90": 4.9688829134458965,
+        "max": 141.8356198363432,
+        "mean_win": 6.857095822710171,
+        "mean_loss": -2.075947369255732
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1513,
+        "observations": 9603,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.06455510682099204,
+        "ci_high": 0.2606431992003028,
+        "p_value": 0.1355
+       }
+      },
+      "absent": {
+       "group": "absent",
+       "share_of_closed": 0.00024368450978799449,
+       "label": "absent",
+       "trades": 3,
+       "closed": 3,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 1,
+       "price_scale_dropped": 0,
+       "expectancy_r": -2.413295098629895,
+       "expectancy_r_before_cost": -2.3723073543303523,
+       "cost_r": 0.040987744299542876,
+       "win_rate": 0.0,
+       "wins": 0,
+       "losses": 3,
+       "total_r": -7.239885295889685,
+       "distribution": {
+        "min": -3.047706755937924,
+        "p10": -3.0381536679254384,
+        "q1": -3.0238240359067095,
+        "median": -2.999941315875495,
+        "q3": -2.096089269975881,
+        "p90": -1.5537780424361123,
+        "max": -1.1922372240762669,
+        "mean_win": null,
+        "mean_loss": -2.413295098629895
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1,
+        "observations": 3,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": "1 symbols is fewer than 5: too thin for an interval, and a degenerate one would read as significance",
+        "ci_low": null,
+        "ci_high": null,
+        "p_value": null
+       },
+       "absent_means": "a price was missing at one of the two anchors, so the question was never asked \u2014 which is a different fact from asking it and getting no",
+       "enters_the_gap": false
+      }
+     },
+     "gap": {
+      "statistic": "mean after-cost R, hit minus miss",
+      "reads_absence_as": "absent \u2014 it enters neither side",
+      "enters_the_verdict": true,
+      "value": -0.19129552253298915,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 1631,
+       "observations": 12311,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": -0.4533113312295887,
+       "ci_high": 0.069039332304325,
+       "p_value": 0.919
+      }
+     },
+     "rubric_reading": {
+      "statistic": "mean after-cost R, hit minus (miss and absent)",
+      "reads_absence_as": "a miss \u2014 the pre-registered readers score an absent value False, so this is what the dimension would do as a rubric row",
+      "enters_the_verdict": false,
+      "value": -0.19051297266989356,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 1631,
+       "observations": 12311,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": -0.4518591274195448,
+       "ci_high": 0.0703214083013084,
+       "p_value": 0.9185
+      }
+     },
+     "value_correlation": {
+      "statistic": "spearman_rho",
+      "ties": "averaged",
+      "against": "the persisted value, over the rows that have one",
+      "enters_the_verdict": false,
+      "value_kind": "boolean",
+      "unavailable": "RS line persists a boolean, not a degree: there is no value to rank, and correlating a verdict with the outcome would restate the gap",
+      "rho": null,
+      "pairs": 0,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 1631,
+       "observations": 12311,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": "RS line persists a boolean, not a degree: there is no value to rank, and correlating a verdict with the outcome would restate the gap",
+       "ci_low": null,
+       "ci_high": null,
+       "p_value": null
+      }
+     },
+     "verdict": "no_evidence",
+     "selection_contrast": {
+      "instrument": "selection contrast",
+      "measures": "his taken detections against the ones he passed over",
+      "source": "findings \u00a75d",
+      "detector": "v3 (live)",
+      "taken_hit_rate": 0.1,
+      "taken_n": 140,
+      "not_taken_hit_rate": 0.121,
+      "not_taken_n": 34543,
+      "delta_pp": -2.1,
+      "pooled_spread": 0.326,
+      "adr_0005_verdict": "not admitted",
+      "recorded_as": "refused on criterion 4 \u2014 a wrong-way gap",
+      "why": "refused on criterion 4, a wrong-way gap, with the anchor named as the mechanism: base_start is a local high under both detector branches, so the rule asks a name to hold its ratio to the index measured from a local maximum"
+     }
+    },
+    {
+     "candidate": "Relative move",
+     "market": "US",
+     "arm": "B",
+     "cut": "the 6m index-relative move in ADR units, strictly above 0.0",
+     "cut_applied": "at read time, by the rubric's own reader, off the value the persisted row carries \u2014 no row is re-denominated",
+     "value_kind": "graded",
+     "absent_means": "the name had not listed six months ago, or has no ADR \u2014 never zero, which is a real value sitting exactly on the cut",
+     "trades": 12350,
+     "symbols": 1637,
+     "closed": 12311,
+     "groups": {
+      "hit": {
+       "group": "hit",
+       "share_of_closed": 0.894647063601657,
+       "label": "hit",
+       "trades": 11050,
+       "closed": 11014,
+       "open_at_end": 36,
+       "undenominated": 0,
+       "symbols": 1529,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.09757437466563303,
+       "expectancy_r_before_cost": 0.14485993031780492,
+       "cost_r": 0.04728555565217189,
+       "win_rate": 0.24477937170873434,
+       "wins": 2696,
+       "losses": 8318,
+       "total_r": 1074.684162567282,
+       "distribution": {
+        "min": -35.977822684303476,
+        "p10": -3.413821494161457,
+        "q1": -2.313248207940856,
+        "median": -1.3725714184500057,
+        "q3": -0.025710514873242284,
+        "p90": 4.9498730680250045,
+        "max": 141.8356198363432,
+        "mean_win": 6.785204601182081,
+        "mean_loss": -2.0699960858643434
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1523,
+        "observations": 11014,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.05790273425870082,
+        "ci_high": 0.2567372400899548,
+        "p_value": 0.0965
+       }
+      },
+      "miss": {
+       "group": "miss",
+       "share_of_closed": 0.09885468280399642,
+       "label": "miss",
+       "trades": 1220,
+       "closed": 1217,
+       "open_at_end": 3,
+       "undenominated": 0,
+       "symbols": 581,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.29822054323555286,
+       "expectancy_r_before_cost": -0.25618427570071667,
+       "cost_r": 0.04203626753483621,
+       "win_rate": 0.22514379622021363,
+       "wins": 274,
+       "losses": 943,
+       "total_r": -362.93440111766785,
+       "distribution": {
+        "min": -79.84078091028827,
+        "p10": -3.4045056435292054,
+        "q1": -2.2374136590836775,
+        "median": -1.3182328916369304,
+        "q3": -0.05166978766241504,
+        "p90": 4.150696411423249,
+        "max": 62.97115271607035,
+        "mean_win": 5.982258039408484,
+        "mean_loss": -2.123089187609324
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 579,
+        "observations": 1217,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.6261010107912246,
+        "ci_high": 0.10107000508599463,
+        "p_value": 0.928
+       }
+      },
+      "absent": {
+       "group": "absent",
+       "share_of_closed": 0.00649825359434652,
+       "label": "absent",
+       "trades": 80,
+       "closed": 80,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 45,
+       "price_scale_dropped": 0,
+       "expectancy_r": -1.2352621720834347,
+       "expectancy_r_before_cost": -1.2036853206965223,
+       "cost_r": 0.03157685138691251,
+       "win_rate": 0.1625,
+       "wins": 13,
+       "losses": 67,
+       "total_r": -98.82097376667477,
+       "distribution": {
+        "min": -9.773430402766413,
+        "p10": -3.8228735298161416,
+        "q1": -2.5924472531477143,
+        "median": -1.766551819563852,
+        "q3": -0.8741200767368722,
+        "p90": 3.3950299576234255,
+        "max": 9.533119052458574,
+        "mean_win": 4.721104710325525,
+        "mean_loss": -2.3909751492672626
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 45,
+        "observations": 80,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -2.1002363034602762,
+        "ci_high": -0.4230446513367067,
+        "p_value": 0.997
+       },
+       "absent_means": "the name had not listed six months ago, or has no ADR \u2014 never zero, which is a real value sitting exactly on the cut",
+       "enters_the_gap": false
+      }
+     },
+     "gap": {
+      "statistic": "mean after-cost R, hit minus miss",
+      "reads_absence_as": "absent \u2014 it enters neither side",
+      "enters_the_verdict": true,
+      "value": 0.39579491790118587,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 1631,
+       "observations": 12311,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": -0.02685534054642588,
+       "ci_high": 0.7744111815052866,
+       "p_value": 0.0325
+      }
+     },
+     "rubric_reading": {
+      "statistic": "mean after-cost R, hit minus (miss and absent)",
+      "reads_absence_as": "a miss \u2014 the pre-registered readers score an absent value False, so this is what the dimension would do as a rubric row",
+      "enters_the_verdict": false,
+      "value": 0.4535923969357507,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 1631,
+       "observations": 12311,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": 0.04788364360849213,
+       "ci_high": 0.8184291467813066,
+       "p_value": 0.0145
+      }
+     },
+     "value_correlation": {
+      "statistic": "spearman_rho",
+      "ties": "averaged",
+      "against": "the persisted value, over the rows that have one",
+      "enters_the_verdict": false,
+      "value_kind": "graded",
+      "unavailable": null,
+      "rho": -0.02147948747594429,
+      "pairs": 12231,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 1631,
+       "observations": 12311,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": -0.04285454685209004,
+       "ci_high": -0.0019700619247729196,
+       "p_value": 0.985
+      }
+     },
+     "verdict": "no_evidence",
+     "selection_contrast": {
+      "instrument": "selection contrast",
+      "measures": "his taken detections against the ones he passed over",
+      "source": "findings \u00a75e",
+      "detector": "v3 (live)",
+      "taken_hit_rate": 0.886,
+      "taken_n": 140,
+      "not_taken_hit_rate": 0.8494,
+      "not_taken_n": 34543,
+      "delta_pp": 3.6,
+      "pooled_spread": 0.357,
+      "adr_0005_verdict": "not admitted",
+      "recorded_as": "on_the_bound \u2014 the criteria do not separate",
+      "why": "positive on both fields, and then 0.06pp inside criterion 1's ~85% not-taken hit-rate ceiling \u2014 0.29 standard errors from it. That ceiling and criterion 2's ~15% disagreement floor are one threshold read from two sides, so the two criteria give opposite answers on the same number, and the ADR calls that magnitude a judgement rather than a measurement. The criteria do not separate, so nothing shipped"
+     }
+    }
+   ]
+  },
+  {
+   "market": "IDX",
+   "trades": 1201,
+   "symbols": 249,
+   "candidates": [
+    {
+     "candidate": "RS line",
+     "market": "IDX",
+     "arm": "B",
+     "cut": "RS_today >= RS_at_base_start, over the detection's own base",
+     "cut_applied": "at read time, by the rubric's own reader, off the value the persisted row carries \u2014 no row is re-denominated",
+     "value_kind": "boolean",
+     "absent_means": "a price was missing at one of the two anchors, so the question was never asked \u2014 which is a different fact from asking it and getting no",
+     "trades": 1201,
+     "symbols": 249,
+     "closed": 1196,
+     "groups": {
+      "hit": {
+       "group": "hit",
+       "share_of_closed": 0.26588628762541805,
+       "label": "hit",
+       "trades": 319,
+       "closed": 318,
+       "open_at_end": 1,
+       "undenominated": 0,
+       "symbols": 144,
+       "price_scale_dropped": 0,
+       "expectancy_r": 1.065574156975815,
+       "expectancy_r_before_cost": 1.45333290038869,
+       "cost_r": 0.3877587434128749,
+       "win_rate": 0.27672955974842767,
+       "wins": 88,
+       "losses": 230,
+       "total_r": 338.85258191830917,
+       "distribution": {
+        "min": -16.975065333581725,
+        "p10": -4.235217749322471,
+        "q1": -2.857745752400098,
+        "median": -1.7964882342636814,
+        "q3": 1.006570633008457,
+        "p90": 8.94873099983077,
+        "max": 76.09611993498979,
+        "mean_win": 10.76402343841036,
+        "mean_loss": -2.6451368724426194
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 143,
+        "observations": 318,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.030542368288689378,
+        "ci_high": 2.245038199966278,
+        "p_value": 0.0295
+       }
+      },
+      "miss": {
+       "group": "miss",
+       "share_of_closed": 0.7307692307692307,
+       "label": "miss",
+       "trades": 878,
+       "closed": 874,
+       "open_at_end": 4,
+       "undenominated": 0,
+       "symbols": 224,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.5408871719463653,
+       "expectancy_r_before_cost": 0.9219470223442333,
+       "cost_r": 0.38105985039786816,
+       "win_rate": 0.22768878718535468,
+       "wins": 199,
+       "losses": 675,
+       "total_r": 472.7353882811232,
+       "distribution": {
+        "min": -16.685163502499186,
+        "p10": -3.722840638796173,
+        "q1": -2.7391912043727222,
+        "median": -1.8994660541279536,
+        "q3": -0.37235669915377556,
+        "p90": 7.402715627966106,
+        "max": 152.37834670993914,
+        "mean_win": 10.673657530527962,
+        "mean_loss": -2.446403644879913
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 222,
+        "observations": 874,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.2426863753686146,
+        "ci_high": 1.41525066563375,
+        "p_value": 0.098
+       }
+      },
+      "absent": {
+       "group": "absent",
+       "share_of_closed": 0.0033444816053511705,
+       "label": "absent",
+       "trades": 4,
+       "closed": 4,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 4,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.37559364248674926,
+       "expectancy_r_before_cost": 0.6886108294910492,
+       "cost_r": 0.31301718700429987,
+       "win_rate": 0.25,
+       "wins": 1,
+       "losses": 3,
+       "total_r": 1.502374569946997,
+       "distribution": {
+        "min": -2.136731537921844,
+        "p10": -2.12102509195569,
+        "q1": -2.097465423006459,
+        "median": -1.7811994639201854,
+        "q3": 0.6918596015730232,
+        "p90": 4.597646862054739,
+        "max": 7.201505035709212,
+        "mean_win": 7.201505035709212,
+        "mean_loss": -1.8997101552540716
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 4,
+        "observations": 4,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": "4 symbols is fewer than 5: too thin for an interval, and a degenerate one would read as significance",
+        "ci_low": null,
+        "ci_high": null,
+        "p_value": null
+       },
+       "absent_means": "a price was missing at one of the two anchors, so the question was never asked \u2014 which is a different fact from asking it and getting no",
+       "enters_the_gap": false
+      }
+     },
+     "gap": {
+      "statistic": "mean after-cost R, hit minus miss",
+      "reads_absence_as": "absent \u2014 it enters neither side",
+      "enters_the_verdict": true,
+      "value": 0.5246869850294498,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 247,
+       "observations": 1196,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": -0.7275252263933428,
+       "ci_high": 1.8873106293666493,
+       "p_value": 0.211
+      }
+     },
+     "rubric_reading": {
+      "statistic": "mean after-cost R, hit minus (miss and absent)",
+      "reads_absence_as": "a miss \u2014 the pre-registered readers score an absent value False, so this is what the dimension would do as a rubric row",
+      "enters_the_verdict": false,
+      "value": 0.5254400307217487,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 247,
+       "observations": 1196,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": -0.7223818391527145,
+       "ci_high": 1.882809679143346,
+       "p_value": 0.2105
+      }
+     },
+     "value_correlation": {
+      "statistic": "spearman_rho",
+      "ties": "averaged",
+      "against": "the persisted value, over the rows that have one",
+      "enters_the_verdict": false,
+      "value_kind": "boolean",
+      "unavailable": "RS line persists a boolean, not a degree: there is no value to rank, and correlating a verdict with the outcome would restate the gap",
+      "rho": null,
+      "pairs": 0,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 247,
+       "observations": 1196,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": "RS line persists a boolean, not a degree: there is no value to rank, and correlating a verdict with the outcome would restate the gap",
+       "ci_low": null,
+       "ci_high": null,
+       "p_value": null
+      }
+     },
+     "verdict": "no_evidence",
+     "selection_contrast": {
+      "instrument": "selection contrast",
+      "measures": "his taken detections against the ones he passed over",
+      "source": "findings \u00a75d",
+      "detector": "v3 (live)",
+      "taken_hit_rate": 0.1,
+      "taken_n": 140,
+      "not_taken_hit_rate": 0.121,
+      "not_taken_n": 34543,
+      "delta_pp": -2.1,
+      "pooled_spread": 0.326,
+      "adr_0005_verdict": "not admitted",
+      "recorded_as": "refused on criterion 4 \u2014 a wrong-way gap",
+      "why": "refused on criterion 4, a wrong-way gap, with the anchor named as the mechanism: base_start is a local high under both detector branches, so the rule asks a name to hold its ratio to the index measured from a local maximum"
+     }
+    },
+    {
+     "candidate": "Relative move",
+     "market": "IDX",
+     "arm": "B",
+     "cut": "the 6m index-relative move in ADR units, strictly above 0.0",
+     "cut_applied": "at read time, by the rubric's own reader, off the value the persisted row carries \u2014 no row is re-denominated",
+     "value_kind": "graded",
+     "absent_means": "the name had not listed six months ago, or has no ADR \u2014 never zero, which is a real value sitting exactly on the cut",
+     "trades": 1201,
+     "symbols": 249,
+     "closed": 1196,
+     "groups": {
+      "hit": {
+       "group": "hit",
+       "share_of_closed": 0.9088628762541806,
+       "label": "hit",
+       "trades": 1092,
+       "closed": 1087,
+       "open_at_end": 5,
+       "undenominated": 0,
+       "symbols": 239,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.8520698195020323,
+       "expectancy_r_before_cost": 1.235683106143743,
+       "cost_r": 0.38361328664171057,
+       "win_rate": 0.24839006439742412,
+       "wins": 270,
+       "losses": 817,
+       "total_r": 926.1998937987091,
+       "distribution": {
+        "min": -16.975065333581725,
+        "p10": -3.808633733424905,
+        "q1": -2.733688877097592,
+        "median": -1.8892403222769583,
+        "q3": -0.04497917240120798,
+        "p90": 8.18034073741871,
+        "max": 152.37834670993914,
+        "mean_win": 11.009090785532123,
+        "mean_loss": -2.5045956160281078
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 237,
+        "observations": 1087,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": 0.05445863345873355,
+        "ci_high": 1.7404018036442421,
+        "p_value": 0.0155
+       }
+      },
+      "miss": {
+       "group": "miss",
+       "share_of_closed": 0.07692307692307693,
+       "label": "miss",
+       "trades": 92,
+       "closed": 92,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 55,
+       "price_scale_dropped": 0,
+       "expectancy_r": -1.0747363800709184,
+       "expectancy_r_before_cost": -0.6771693366655068,
+       "cost_r": 0.39756704340541144,
+       "win_rate": 0.15217391304347827,
+       "wins": 14,
+       "losses": 78,
+       "total_r": -98.87574696652449,
+       "distribution": {
+        "min": -6.123071805753554,
+        "p10": -3.7255173425873105,
+        "q1": -3.0951340191393673,
+        "median": -1.8367613984404532,
+        "q3": -0.7348253193402594,
+        "p90": 1.3538856363816725,
+        "max": 19.292668457213058,
+        "mean_win": 6.30934257990466,
+        "mean_loss": -2.4000838857075606
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 55,
+        "observations": 92,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -1.953582447277971,
+        "ci_high": 0.016762148691119153,
+        "p_value": 0.974
+       }
+      },
+      "absent": {
+       "group": "absent",
+       "share_of_closed": 0.014214046822742474,
+       "label": "absent",
+       "trades": 17,
+       "closed": 17,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 7,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.837282474282667,
+       "expectancy_r_before_cost": -0.5995267196820263,
+       "cost_r": 0.23775575460064058,
+       "win_rate": 0.23529411764705882,
+       "wins": 4,
+       "losses": 13,
+       "total_r": -14.233802062805339,
+       "distribution": {
+        "min": -4.062640756177353,
+        "p10": -3.82676425860062,
+        "q1": -3.1203524400446216,
+        "median": -2.095199092742527,
+        "q3": -0.24215110712470966,
+        "p90": 4.493299743782684,
+        "max": 6.6306812389706495,
+        "mean_win": 4.427026994636719,
+        "mean_loss": -2.4570700031809394
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 7,
+        "observations": 17,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -2.3664499512694834,
+        "ci_high": 1.3589260757110377,
+        "p_value": 0.808
+       },
+       "absent_means": "the name had not listed six months ago, or has no ADR \u2014 never zero, which is a real value sitting exactly on the cut",
+       "enters_the_gap": false
+      }
+     },
+     "gap": {
+      "statistic": "mean after-cost R, hit minus miss",
+      "reads_absence_as": "absent \u2014 it enters neither side",
+      "enters_the_verdict": true,
+      "value": 1.9268061995729506,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 247,
+       "observations": 1196,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": 0.5732693324052631,
+       "ci_high": 3.1378569981849407,
+       "p_value": 0.002
+      }
+     },
+     "rubric_reading": {
+      "statistic": "mean after-cost R, hit minus (miss and absent)",
+      "reads_absence_as": "a miss \u2014 the pre-registered readers score an absent value False, so this is what the dimension would do as a rubric row",
+      "enters_the_verdict": false,
+      "value": 1.8897721041747828,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 247,
+       "observations": 1196,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": 0.608951983929816,
+       "ci_high": 3.0881532395827893,
+       "p_value": 0.002
+      }
+     },
+     "value_correlation": {
+      "statistic": "spearman_rho",
+      "ties": "averaged",
+      "against": "the persisted value, over the rows that have one",
+      "enters_the_verdict": false,
+      "value_kind": "graded",
+      "unavailable": null,
+      "rho": 0.06751278799672815,
+      "pairs": 1179,
+      "bootstrap": {
+       "cluster": "symbol",
+       "clusters": 247,
+       "observations": 1196,
+       "resamples": 2000,
+       "seed": 191,
+       "confidence": 0.95,
+       "min_clusters": 5,
+       "undefined": 0,
+       "max_undefined_share": 0.1,
+       "suppressed": null,
+       "ci_low": -0.004577640579328532,
+       "ci_high": 0.13269644452334722,
+       "p_value": 0.034
+      }
+     },
+     "verdict": "predicts",
+     "selection_contrast": {
+      "instrument": "selection contrast",
+      "measures": "his taken detections against the ones he passed over",
+      "source": "findings \u00a75e",
+      "detector": "v3 (live)",
+      "taken_hit_rate": 0.886,
+      "taken_n": 140,
+      "not_taken_hit_rate": 0.8494,
+      "not_taken_n": 34543,
+      "delta_pp": 3.6,
+      "pooled_spread": 0.357,
+      "adr_0005_verdict": "not admitted",
+      "recorded_as": "on_the_bound \u2014 the criteria do not separate",
+      "why": "positive on both fields, and then 0.06pp inside criterion 1's ~85% not-taken hit-rate ceiling \u2014 0.29 standard errors from it. That ceiling and criterion 2's ~15% disagreement floor are one threshold read from two sides, so the two criteria give opposite answers on the same number, and the ADR calls that magnitude a judgement rather than a measurement. The criteria do not separate, so nothing shipped"
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/references/backtest_candidate_outcomes.txt
+++ b/references/backtest_candidate_outcomes.txt
@@ -1,0 +1,50 @@
+do the registered candidate dimensions predict outcomes, or only match the trader's selection? — arm B
+  the outcome variable is R after costs on trades taken mechanically over a window his record does not cover; no rubric weight was fitted to it and no detection could see it
+  the selection contrast and this measurement are a different claim about the same dimension, and neither converts into the other
+  this measurement admits no dimension and retires none. ADR 0005's admission instrument is the selection contrast, and an outcome claim is not one — it is evidence that goes through the calibration rule like any other change. Neither candidate's weight, the rubric version, nor the register moves here
+  bootstrap 2000× clustered by symbol, seed 191
+
+US — RS line (12350 trades, 1637 symbols)
+  selection contrast (findings §5d, detector v3 (live)): Δ -2.1pp — not admitted
+    recorded as: refused on criterion 4 — a wrong-way gap
+  hit     n=2705  -0.099R  win 24.1%  1026 symbols  [-0.34, +0.13] p=0.806 on 1023 symbols
+  miss    n=9603  +0.092R  win 24.3%  1521 symbols  [-0.06, +0.26] p=0.136 on 1513 symbols
+  absent  n=3     -2.413R  win 0.0%  1 symbols  1 symbols — no interval
+  gap    hit − miss -0.191R  [-0.45, +0.07] p=0.919 on 1631 symbols
+  as shipped (absent read as a miss) -0.191R  [-0.45, +0.07] p=0.918 on 1631 symbols
+  rho    — RS line persists a boolean, not a degree: there is no value to rank, and correlating a verdict with the outcome would restate the gap
+  verdict: no evidence it predicts
+
+US — Relative move (12350 trades, 1637 symbols)
+  selection contrast (findings §5e, detector v3 (live)): Δ +3.6pp — not admitted
+    recorded as: on_the_bound — the criteria do not separate
+  hit     n=11014 +0.098R  win 24.5%  1529 symbols  [-0.06, +0.26] p=0.097 on 1523 symbols
+  miss    n=1217  -0.298R  win 22.5%  581 symbols  [-0.63, +0.10] p=0.928 on 579 symbols
+  absent  n=80    -1.235R  win 16.2%  45 symbols  [-2.10, -0.42] p=0.997 on 45 symbols
+  gap    hit − miss +0.396R  [-0.03, +0.77] p=0.033 on 1631 symbols
+  as shipped (absent read as a miss) +0.454R  [+0.05, +0.82] p=0.015 on 1631 symbols
+  rho    -0.021 over 12231 valued trades  [-0.04, -0.00] p=0.985 on 1631 symbols
+  verdict: no evidence it predicts
+
+IDX — RS line (1201 trades, 249 symbols)
+  selection contrast (findings §5d, detector v3 (live)): Δ -2.1pp — not admitted
+    recorded as: refused on criterion 4 — a wrong-way gap
+  hit     n=318   +1.066R  win 27.7%  144 symbols  [-0.03, +2.25] p=0.029 on 143 symbols
+  miss    n=874   +0.541R  win 22.8%  224 symbols  [-0.24, +1.42] p=0.098 on 222 symbols
+  absent  n=4     +0.376R  win 25.0%  4 symbols  4 symbols — no interval
+  gap    hit − miss +0.525R  [-0.73, +1.89] p=0.211 on 247 symbols
+  as shipped (absent read as a miss) +0.525R  [-0.72, +1.88] p=0.210 on 247 symbols
+  rho    — RS line persists a boolean, not a degree: there is no value to rank, and correlating a verdict with the outcome would restate the gap
+  verdict: no evidence it predicts
+
+IDX — Relative move (1201 trades, 249 symbols)
+  selection contrast (findings §5e, detector v3 (live)): Δ +3.6pp — not admitted
+    recorded as: on_the_bound — the criteria do not separate
+  hit     n=1087  +0.852R  win 24.8%  239 symbols  [+0.05, +1.74] p=0.015 on 237 symbols
+  miss    n=92    -1.075R  win 15.2%  55 symbols  [-1.95, +0.02] p=0.974 on 55 symbols
+  absent  n=17    -0.837R  win 23.5%  7 symbols  [-2.37, +1.36] p=0.808 on 7 symbols
+  gap    hit − miss +1.927R  [+0.57, +3.14] p=0.002 on 247 symbols
+  as shipped (absent read as a miss) +1.890R  [+0.61, +3.09] p=0.002 on 247 symbols
+  rho    +0.068 over 1179 valued trades  [-0.00, +0.13] p=0.034 on 247 symbols
+  verdict: predicts
+

--- a/references/backtest_figures.json
+++ b/references/backtest_figures.json
@@ -1,0 +1,5730 @@
+{
+ "contract": {
+  "contract_version": "1",
+  "label": "out-of-sample backtest \u2014 US+IDX, 2012 onward (PRD #182)",
+  "cells": [
+   {
+    "key": "scope.setups",
+    "value": "long_breakout_eod",
+    "justification": "Long breakout EOD setups only, so the run measures the same thing the reference set and the detector do (PRD story 7)."
+   },
+   {
+    "key": "scope.level",
+    "value": "signal_primary_portfolio_deferred",
+    "justification": "Signal level is declared primary and portfolio level specified but deferred, so the open question is answered without the capital model blocking it (story 8)."
+   },
+   {
+    "key": "scope.markets",
+    "value": [
+     "US",
+     "IDX"
+    ],
+    "justification": "US and IDX reported separately throughout, so findings \u00a78's result that magnitudes do not transfer is honoured rather than averaged away (story 4)."
+   },
+   {
+    "key": "window.measured_start",
+    "value": "2012-01-01",
+    "justification": "The measured window starts 2012-01-01 so the sample spans several regimes rather than one (story 5)."
+   },
+   {
+    "key": "window.measured_end",
+    "value": "latest_complete_session",
+    "justification": "The measured window runs to the latest complete session, so the sample extends as far as the data legitimately allows (story 5)."
+   },
+   {
+    "key": "window.store_start",
+    "value": "2011-01-01",
+    "justification": "The store window starts 2011-01-01 so the detector's 80-bar minimum history, the universe gates and the regime's 25-bar warm-up are all satisfied before the first measured session (story 6)."
+   },
+   {
+    "key": "universe.trend_gate",
+    "value": "close > SMA50",
+    "justification": "The trend gate is close > SMA50 on both markets, so the universe reflects the method's own precondition (story 10)."
+   },
+   {
+    "key": "universe.liquidity_floor",
+    "value": {
+     "US": 10000000.0,
+     "IDX": 10000000000.0
+    },
+    "justification": "Liquidity floors are $10M for US and Rp 10B for IDX \u2014 a deliberate contract value, not the app's inherited $20M / Rp 1B (story 11)."
+   },
+   {
+    "key": "universe.adtv",
+    "value": "median_20d_unadjusted_close_x_volume",
+    "justification": "ADTV is the 20-day median of unadjusted close \u00d7 volume, so one block trade cannot lift an illiquid name over the floor (story 12)."
+   },
+   {
+    "key": "universe.adtv_aggregator",
+    "value": "median",
+    "justification": "The aggregator is the median; a switch to mean is a deliberate act, so which spiky small caps qualify never changes by accident (story 13)."
+   },
+   {
+    "key": "universe.volatility_gate",
+    "value": "ADR20 >= 3.5%",
+    "justification": "The volatility gate is ADR20 \u2265 3.5%, set deliberately below the rubric's 5% floor so the ADR dimension is left with spread to test (story 14)."
+   },
+   {
+    "key": "universe.volatility_gap_reason",
+    "value": "gate_below_rubric_floor_is_deliberate",
+    "justification": "The gap below the rubric's 5% floor is recorded so nobody later 'fixes' it to match and silently destroys the thing being measured \u2014 findings \u00a76 Finding 2 measured the 5% floor withholding a score point from 31% of his real entries (story 15)."
+   },
+   {
+    "key": "universe.idx_price_floor",
+    "value": 100.0,
+    "justification": "A nominal price floor of Rp 100 on the split-corrected series excludes IDX names whose quotes hit the tick grid hard enough to distort ADR and range geometry (story 16)."
+   },
+   {
+    "key": "universe.idx_price_floor_role",
+    "value": "data_validity",
+    "justification": "The Rp 100 floor is data validity and never cost control, so no reader infers a penny-stock filter with an implied cost story (story 17)."
+   },
+   {
+    "key": "universe.statelessness",
+    "value": "stateless_gates_through_t_minus_1",
+    "justification": "The universe is stateless \u2014 three gates measured through t\u22121 with no reference to prior membership \u2014 a known difference from the app's hysteresis band whose boundary churn is nearly free at signal level and real at portfolio level (stories 9, 18, 19)."
+   },
+   {
+    "key": "universe.reference_exclusion",
+    "value": "exclude_index_and_benchmark_etfs",
+    "justification": "The five benchmark references stay out of the ranked field, pinned against the enumeration by a test, so this fresh build inherits the #162 fix rather than reproducing the contamination (stories 73, 74)."
+   },
+   {
+    "key": "detection.gate",
+    "value": [
+     "1m",
+     "3m",
+     "6m",
+     "12m"
+    ],
+    "justification": "The detection gate is the four-lookback width (detector v3, ADR 0003 amendment); the denominator is built against that width and it is not swept in the primary run (PRD Implementation Decisions)."
+   },
+   {
+    "key": "regime.source",
+    "value": "app_regime_off_market_index_at_t_minus_1",
+    "justification": "Regime is the app's own regime, unmodified, read off each market's own index at t\u22121 \u2014 so findings are actionable in the product and the conditioning input obeys the point-in-time rule (stories 21, 23)."
+   },
+   {
+    "key": "regime.role",
+    "value": "conditioning_variable_never_filter",
+    "justification": "Regime is a conditioning variable and never a filter: every state trades and each one's expectancy is measured instead of assumed (story 22)."
+   },
+   {
+    "key": "entry.rule",
+    "value": "detection_trigger_filled_next_session",
+    "justification": "Entry is taken at the detection's own trigger, filled the next session, so the simulated trade uses the detector's own decision rather than a second definition (story 31)."
+   },
+   {
+    "key": "stop.rule",
+    "value": "detection_stop_unmodified",
+    "justification": "The stop is the detection's own stop, used unmodified, so R is denominated the way the app denominates it (story 32)."
+   },
+   {
+    "key": "exit.arm_a",
+    "value": {
+     "scale_fraction": 0.5,
+     "scale_day": 5,
+     "trail_ma": 10,
+     "trail_live_from": "fill",
+     "arbitrary_mechanics": true
+    },
+    "justification": "Arm A scales 50% off at the close of the fifth session after entry and trails the remainder on a 10MA \u2014 the trader's documented behaviour; its R is two position-weighted legs summed, and 'day 5' and the trail are recorded as arbitrary (stories 34, 36, 37, 39). The trail is live from the fill rather than from the scale day, so a runner that rolls over before day 5 takes the whole position and the scale never happens; that is a third arbitrary choice and is recorded here rather than left in the code, so a later run can sweep it (story 39)."
+   },
+   {
+    "key": "exit.arm_b",
+    "value": {
+     "trail_ma": 10
+    },
+    "justification": "Arm B is a pure 10MA trail, directly comparable to the reference set's simulated exit and the arm the primary metric is computed on (story 35)."
+   },
+   {
+    "key": "exit.arm_c",
+    "value": {
+     "trail_ma": 20
+    },
+    "justification": "Arm C is a pure 20MA trail, the reference set's second simulated exit (story 35)."
+   },
+   {
+    "key": "exit.trail_mechanic",
+    "value": "close_through_ma_signals_fill_next_open",
+    "justification": "A trail signals on a close through the MA and fills at the next open, so the exit is point-in-time and reproducible; recorded as arbitrary so a later run can vary it deliberately (stories 38, 39)."
+   },
+   {
+    "key": "costs.per_market",
+    "value": {
+     "US": {
+      "commission_bps": 0.0,
+      "slippage_bps": 5.0
+     },
+     "IDX": {
+      "commission_bps": 15.0,
+      "slippage_bps": 25.0
+     }
+    },
+    "justification": "Commission and slippage are per-market contract values applied before any sweep, so IDX's real fees and spread are not modelled with US's near-zero assumptions; this pre-registered baseline is recorded here and swept variants are reported with the count of variants tried (story 40)."
+   },
+   {
+    "key": "metric.primary",
+    "value": "arm_b_after_cost_expectancy_r_per_market_per_year",
+    "justification": "The one pre-registered primary metric is arm B's after-cost expectancy in R, per market per year, so the headline cannot be chosen after the fact (story 41)."
+   },
+   {
+    "key": "decision.kill",
+    "value": {
+     "metric": "arm_b_after_cost_expectancy_r",
+     "comparator": "<=",
+     "threshold": 0.0,
+     "requires": [
+      "both_markets",
+      "full_window",
+      "and_excluding_2020_2021"
+     ],
+     "basis": "survivor_biased_number"
+    },
+    "justification": "Kill fires only when arm B's after-cost expectancy is \u2264 0 in both markets on the full window and with 2020\u201321 excluded, and the line is drawn on the survivor-biased number so a failure is decisive \u2014 the honest figure can only be worse (stories 42, 43)."
+   },
+   {
+    "key": "decision.ship",
+    "value": {
+     "requires": [
+      "positive_result",
+      "clears_phase2_pessimistic_bound"
+     ],
+     "scope": "per_market"
+    },
+    "justification": "Ship requires a positive result that also clears the Phase 2 pessimistic bound, scoped per market so a US pass licenses nothing in Jakarta (stories 44, 45)."
+   },
+   {
+    "key": "decision.one_market_failure",
+    "value": "method_stands_that_market_off_until_explained",
+    "justification": "A one-market failure is its own pre-named verdict: the method stands and that market is off until a run explains the difference, so it is not improvised in the moment (story 46)."
+   },
+   {
+    "key": "decision.inconclusive",
+    "value": "report_inconclusive_no_swept_tiebreak",
+    "justification": "An inconclusive run is reported as inconclusive; reaching for a swept variant to break the tie is ruled out by the contract that exists to prevent it (story 47)."
+   },
+   {
+    "key": "decision.licensed_changes",
+    "value": "write_licensed_change_before_any_constant_moves",
+    "justification": "Each verdict's licensed change is written down before any constant moves, so a result cannot be converted into an unguarded edit (story 48)."
+   }
+  ]
+ },
+ "sma50_overlap": "the contract's close > SMA50 universe gate overlaps the detector's own trend logic, so these counts sit below an unfiltered run \u2014 the gate working, not the detector becoming more selective",
+ "favourable_rule": "R > 0 on a closed trade, before costs",
+ "costs_applied": false,
+ "costs_note": "these are before costs \u2014 commission and slippage are applied by the phase that computes the pre-registered primary metric, and precision computed before them overstates",
+ "collapse_rule": {
+  "detections_fraction": 0.25,
+  "sessions_fraction": 0.5,
+  "basis": "the market's own median year",
+  "edges_exempt_from_sessions_flag": true
+ },
+ "markets": [
+  {
+   "market": "US",
+   "sma50_overlap": "the contract's close > SMA50 universe gate overlaps the detector's own trend logic, so these counts sit below an unfiltered run \u2014 the gate working, not the detector becoming more selective",
+   "sessions": 3682,
+   "detections": 96914,
+   "detections_per_session": 26.321021184139056,
+   "triggered": {
+    "hits": 12362,
+    "of": 96830,
+    "rate": 0.1276670453371889
+   },
+   "no_break": 84468,
+   "unfilled": 12,
+   "undecided": 84,
+   "arms": [
+    {
+     "arm": "A",
+     "filled": 12350,
+     "closed": 12311,
+     "open_at_end": 39,
+     "favourable": 3492,
+     "precision": {
+      "hits": 3492,
+      "of": 96779,
+      "rate": 0.03608220791700679
+     },
+     "win_rate": {
+      "hits": 3492,
+      "of": 12311,
+      "rate": 0.2836487693932256
+     }
+    },
+    {
+     "arm": "B",
+     "filled": 12350,
+     "closed": 12311,
+     "open_at_end": 39,
+     "favourable": 3010,
+     "precision": {
+      "hits": 3010,
+      "of": 96779,
+      "rate": 0.031101788611165644
+     },
+     "win_rate": {
+      "hits": 3010,
+      "of": 12311,
+      "rate": 0.24449679148728778
+     }
+    },
+    {
+     "arm": "C",
+     "filled": 12350,
+     "closed": 12283,
+     "open_at_end": 67,
+     "favourable": 2535,
+     "precision": {
+      "hits": 2535,
+      "of": 96751,
+      "rate": 0.026201279573337743
+     },
+     "win_rate": {
+      "hits": 2535,
+      "of": 12283,
+      "rate": 0.2063828055035415
+     }
+    }
+   ],
+   "price_scale_dropped": 0,
+   "years": [
+    {
+     "market": "US",
+     "year": 2012,
+     "sessions": 250,
+     "detections": 1927,
+     "detections_per_session": 7.708,
+     "triggered": {
+      "hits": 273,
+      "of": 1927,
+      "rate": 0.1416709911779969
+     },
+     "no_break": 1654,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 273,
+       "closed": 273,
+       "open_at_end": 0,
+       "favourable": 78,
+       "precision": {
+        "hits": 78,
+        "of": 1927,
+        "rate": 0.040477426050856254
+       },
+       "win_rate": {
+        "hits": 78,
+        "of": 273,
+        "rate": 0.2857142857142857
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 273,
+       "closed": 273,
+       "open_at_end": 0,
+       "favourable": 65,
+       "precision": {
+        "hits": 65,
+        "of": 1927,
+        "rate": 0.033731188375713546
+       },
+       "win_rate": {
+        "hits": 65,
+        "of": 273,
+        "rate": 0.23809523809523808
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 273,
+       "closed": 273,
+       "open_at_end": 0,
+       "favourable": 53,
+       "precision": {
+        "hits": 53,
+        "of": 1927,
+        "rate": 0.027503892060197196
+       },
+       "win_rate": {
+        "hits": 53,
+        "of": 273,
+        "rate": 0.19413919413919414
+       }
+      }
+     ],
+     "covered_days": 364,
+     "sessions_per_covered_day": 0.6868131868131868,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2013,
+     "sessions": 252,
+     "detections": 1671,
+     "detections_per_session": 6.630952380952381,
+     "triggered": {
+      "hits": 231,
+      "of": 1671,
+      "rate": 0.13824057450628366
+     },
+     "no_break": 1440,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 231,
+       "closed": 231,
+       "open_at_end": 0,
+       "favourable": 77,
+       "precision": {
+        "hits": 77,
+        "of": 1671,
+        "rate": 0.04608019150209455
+       },
+       "win_rate": {
+        "hits": 77,
+        "of": 231,
+        "rate": 0.3333333333333333
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 231,
+       "closed": 231,
+       "open_at_end": 0,
+       "favourable": 71,
+       "precision": {
+        "hits": 71,
+        "of": 1671,
+        "rate": 0.04248952722920407
+       },
+       "win_rate": {
+        "hits": 71,
+        "of": 231,
+        "rate": 0.30735930735930733
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 231,
+       "closed": 231,
+       "open_at_end": 0,
+       "favourable": 63,
+       "precision": {
+        "hits": 63,
+        "of": 1671,
+        "rate": 0.03770197486535009
+       },
+       "win_rate": {
+        "hits": 63,
+        "of": 231,
+        "rate": 0.2727272727272727
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6904109589041096,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2014,
+     "sessions": 252,
+     "detections": 1940,
+     "detections_per_session": 7.698412698412699,
+     "triggered": {
+      "hits": 226,
+      "of": 1938,
+      "rate": 0.11661506707946337
+     },
+     "no_break": 1712,
+     "unfilled": 0,
+     "undecided": 2,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 226,
+       "closed": 226,
+       "open_at_end": 0,
+       "favourable": 53,
+       "precision": {
+        "hits": 53,
+        "of": 1938,
+        "rate": 0.027347781217750257
+       },
+       "win_rate": {
+        "hits": 53,
+        "of": 226,
+        "rate": 0.2345132743362832
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 226,
+       "closed": 226,
+       "open_at_end": 0,
+       "favourable": 47,
+       "precision": {
+        "hits": 47,
+        "of": 1938,
+        "rate": 0.024251805985552117
+       },
+       "win_rate": {
+        "hits": 47,
+        "of": 226,
+        "rate": 0.2079646017699115
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 226,
+       "closed": 226,
+       "open_at_end": 0,
+       "favourable": 45,
+       "precision": {
+        "hits": 45,
+        "of": 1938,
+        "rate": 0.02321981424148607
+       },
+       "win_rate": {
+        "hits": 45,
+        "of": 226,
+        "rate": 0.19911504424778761
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6904109589041096,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2015,
+     "sessions": 252,
+     "detections": 2760,
+     "detections_per_session": 10.952380952380953,
+     "triggered": {
+      "hits": 317,
+      "of": 2757,
+      "rate": 0.11498005077983316
+     },
+     "no_break": 2440,
+     "unfilled": 0,
+     "undecided": 3,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 317,
+       "closed": 317,
+       "open_at_end": 0,
+       "favourable": 85,
+       "precision": {
+        "hits": 85,
+        "of": 2757,
+        "rate": 0.030830612985128764
+       },
+       "win_rate": {
+        "hits": 85,
+        "of": 317,
+        "rate": 0.26813880126182965
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 317,
+       "closed": 317,
+       "open_at_end": 0,
+       "favourable": 72,
+       "precision": {
+        "hits": 72,
+        "of": 2757,
+        "rate": 0.026115342763873776
+       },
+       "win_rate": {
+        "hits": 72,
+        "of": 317,
+        "rate": 0.22712933753943218
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 317,
+       "closed": 317,
+       "open_at_end": 0,
+       "favourable": 57,
+       "precision": {
+        "hits": 57,
+        "of": 2757,
+        "rate": 0.020674646354733407
+       },
+       "win_rate": {
+        "hits": 57,
+        "of": 317,
+        "rate": 0.17981072555205047
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6904109589041096,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2016,
+     "sessions": 252,
+     "detections": 3471,
+     "detections_per_session": 13.773809523809524,
+     "triggered": {
+      "hits": 438,
+      "of": 3471,
+      "rate": 0.12618841832324978
+     },
+     "no_break": 3033,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 438,
+       "closed": 438,
+       "open_at_end": 0,
+       "favourable": 155,
+       "precision": {
+        "hits": 155,
+        "of": 3471,
+        "rate": 0.04465571881302218
+       },
+       "win_rate": {
+        "hits": 155,
+        "of": 438,
+        "rate": 0.3538812785388128
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 438,
+       "closed": 438,
+       "open_at_end": 0,
+       "favourable": 132,
+       "precision": {
+        "hits": 132,
+        "of": 3471,
+        "rate": 0.03802938634399308
+       },
+       "win_rate": {
+        "hits": 132,
+        "of": 438,
+        "rate": 0.3013698630136986
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 438,
+       "closed": 438,
+       "open_at_end": 0,
+       "favourable": 124,
+       "precision": {
+        "hits": 124,
+        "of": 3471,
+        "rate": 0.03572457505041775
+       },
+       "win_rate": {
+        "hits": 124,
+        "of": 438,
+        "rate": 0.2831050228310502
+       }
+      }
+     ],
+     "covered_days": 366,
+     "sessions_per_covered_day": 0.6885245901639344,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2017,
+     "sessions": 251,
+     "detections": 2336,
+     "detections_per_session": 9.306772908366534,
+     "triggered": {
+      "hits": 304,
+      "of": 2336,
+      "rate": 0.13013698630136986
+     },
+     "no_break": 2032,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 304,
+       "closed": 304,
+       "open_at_end": 0,
+       "favourable": 92,
+       "precision": {
+        "hits": 92,
+        "of": 2336,
+        "rate": 0.039383561643835614
+       },
+       "win_rate": {
+        "hits": 92,
+        "of": 304,
+        "rate": 0.3026315789473684
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 304,
+       "closed": 304,
+       "open_at_end": 0,
+       "favourable": 76,
+       "precision": {
+        "hits": 76,
+        "of": 2336,
+        "rate": 0.032534246575342464
+       },
+       "win_rate": {
+        "hits": 76,
+        "of": 304,
+        "rate": 0.25
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 304,
+       "closed": 304,
+       "open_at_end": 0,
+       "favourable": 70,
+       "precision": {
+        "hits": 70,
+        "of": 2336,
+        "rate": 0.029965753424657533
+       },
+       "win_rate": {
+        "hits": 70,
+        "of": 304,
+        "rate": 0.23026315789473684
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6876712328767123,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2018,
+     "sessions": 251,
+     "detections": 3650,
+     "detections_per_session": 14.541832669322709,
+     "triggered": {
+      "hits": 448,
+      "of": 3650,
+      "rate": 0.12273972602739726
+     },
+     "no_break": 3202,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 448,
+       "closed": 448,
+       "open_at_end": 0,
+       "favourable": 128,
+       "precision": {
+        "hits": 128,
+        "of": 3650,
+        "rate": 0.03506849315068493
+       },
+       "win_rate": {
+        "hits": 128,
+        "of": 448,
+        "rate": 0.2857142857142857
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 448,
+       "closed": 448,
+       "open_at_end": 0,
+       "favourable": 108,
+       "precision": {
+        "hits": 108,
+        "of": 3650,
+        "rate": 0.02958904109589041
+       },
+       "win_rate": {
+        "hits": 108,
+        "of": 448,
+        "rate": 0.24107142857142858
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 448,
+       "closed": 448,
+       "open_at_end": 0,
+       "favourable": 92,
+       "precision": {
+        "hits": 92,
+        "of": 3650,
+        "rate": 0.025205479452054796
+       },
+       "win_rate": {
+        "hits": 92,
+        "of": 448,
+        "rate": 0.20535714285714285
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6876712328767123,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2019,
+     "sessions": 252,
+     "detections": 4036,
+     "detections_per_session": 16.015873015873016,
+     "triggered": {
+      "hits": 560,
+      "of": 4036,
+      "rate": 0.13875123885034688
+     },
+     "no_break": 3476,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 560,
+       "closed": 560,
+       "open_at_end": 0,
+       "favourable": 161,
+       "precision": {
+        "hits": 161,
+        "of": 4036,
+        "rate": 0.039890981169474725
+       },
+       "win_rate": {
+        "hits": 161,
+        "of": 560,
+        "rate": 0.2875
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 560,
+       "closed": 560,
+       "open_at_end": 0,
+       "favourable": 141,
+       "precision": {
+        "hits": 141,
+        "of": 4036,
+        "rate": 0.034935579781962336
+       },
+       "win_rate": {
+        "hits": 141,
+        "of": 560,
+        "rate": 0.2517857142857143
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 560,
+       "closed": 560,
+       "open_at_end": 0,
+       "favourable": 117,
+       "precision": {
+        "hits": 117,
+        "of": 4036,
+        "rate": 0.028989098116947474
+       },
+       "win_rate": {
+        "hits": 117,
+        "of": 560,
+        "rate": 0.20892857142857144
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6904109589041096,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2020,
+     "sessions": 253,
+     "detections": 12684,
+     "detections_per_session": 50.134387351778656,
+     "triggered": {
+      "hits": 1737,
+      "of": 12684,
+      "rate": 0.1369441816461684
+     },
+     "no_break": 10947,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 1737,
+       "closed": 1737,
+       "open_at_end": 0,
+       "favourable": 561,
+       "precision": {
+        "hits": 561,
+        "of": 12684,
+        "rate": 0.04422894985808893
+       },
+       "win_rate": {
+        "hits": 561,
+        "of": 1737,
+        "rate": 0.3229706390328152
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 1737,
+       "closed": 1737,
+       "open_at_end": 0,
+       "favourable": 499,
+       "precision": {
+        "hits": 499,
+        "of": 12684,
+        "rate": 0.03934090192368338
+       },
+       "win_rate": {
+        "hits": 499,
+        "of": 1737,
+        "rate": 0.2872769142199194
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 1737,
+       "closed": 1737,
+       "open_at_end": 0,
+       "favourable": 444,
+       "precision": {
+        "hits": 444,
+        "of": 12684,
+        "rate": 0.03500473036896878
+       },
+       "win_rate": {
+        "hits": 444,
+        "of": 1737,
+        "rate": 0.2556131260794473
+       }
+      }
+     ],
+     "covered_days": 366,
+     "sessions_per_covered_day": 0.6912568306010929,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2021,
+     "sessions": 252,
+     "detections": 12150,
+     "detections_per_session": 48.214285714285715,
+     "triggered": {
+      "hits": 1485,
+      "of": 12149,
+      "rate": 0.1222322824923862
+     },
+     "no_break": 10664,
+     "unfilled": 0,
+     "undecided": 1,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 1485,
+       "closed": 1485,
+       "open_at_end": 0,
+       "favourable": 415,
+       "precision": {
+        "hits": 415,
+        "of": 12149,
+        "rate": 0.0341591900567948
+       },
+       "win_rate": {
+        "hits": 415,
+        "of": 1485,
+        "rate": 0.27946127946127947
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 1485,
+       "closed": 1485,
+       "open_at_end": 0,
+       "favourable": 334,
+       "precision": {
+        "hits": 334,
+        "of": 12149,
+        "rate": 0.027491974648119186
+       },
+       "win_rate": {
+        "hits": 334,
+        "of": 1485,
+        "rate": 0.2249158249158249
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 1485,
+       "closed": 1485,
+       "open_at_end": 0,
+       "favourable": 257,
+       "precision": {
+        "hits": 257,
+        "of": 12149,
+        "rate": 0.021154004444810273
+       },
+       "win_rate": {
+        "hits": 257,
+        "of": 1485,
+        "rate": 0.17306397306397306
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6904109589041096,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2022,
+     "sessions": 251,
+     "detections": 10269,
+     "detections_per_session": 40.91235059760956,
+     "triggered": {
+      "hits": 1403,
+      "of": 10269,
+      "rate": 0.13662479306651085
+     },
+     "no_break": 8866,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 1403,
+       "closed": 1403,
+       "open_at_end": 0,
+       "favourable": 363,
+       "precision": {
+        "hits": 363,
+        "of": 10269,
+        "rate": 0.03534910896874087
+       },
+       "win_rate": {
+        "hits": 363,
+        "of": 1403,
+        "rate": 0.2587312900926586
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 1403,
+       "closed": 1403,
+       "open_at_end": 0,
+       "favourable": 304,
+       "precision": {
+        "hits": 304,
+        "of": 10269,
+        "rate": 0.029603661505501998
+       },
+       "win_rate": {
+        "hits": 304,
+        "of": 1403,
+        "rate": 0.2166785459729152
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 1403,
+       "closed": 1403,
+       "open_at_end": 0,
+       "favourable": 250,
+       "precision": {
+        "hits": 250,
+        "of": 10269,
+        "rate": 0.024345116369656247
+       },
+       "win_rate": {
+        "hits": 250,
+        "of": 1403,
+        "rate": 0.1781895937277263
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6876712328767123,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2023,
+     "sessions": 250,
+     "detections": 7514,
+     "detections_per_session": 30.056,
+     "triggered": {
+      "hits": 900,
+      "of": 7514,
+      "rate": 0.11977641735427202
+     },
+     "no_break": 6614,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 900,
+       "closed": 900,
+       "open_at_end": 0,
+       "favourable": 231,
+       "precision": {
+        "hits": 231,
+        "of": 7514,
+        "rate": 0.030742613787596487
+       },
+       "win_rate": {
+        "hits": 231,
+        "of": 900,
+        "rate": 0.25666666666666665
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 900,
+       "closed": 900,
+       "open_at_end": 0,
+       "favourable": 202,
+       "precision": {
+        "hits": 202,
+        "of": 7514,
+        "rate": 0.0268831514506255
+       },
+       "win_rate": {
+        "hits": 202,
+        "of": 900,
+        "rate": 0.22444444444444445
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 900,
+       "closed": 900,
+       "open_at_end": 0,
+       "favourable": 161,
+       "precision": {
+        "hits": 161,
+        "of": 7514,
+        "rate": 0.021426670215597552
+       },
+       "win_rate": {
+        "hits": 161,
+        "of": 900,
+        "rate": 0.17888888888888888
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.684931506849315,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2024,
+     "sessions": 252,
+     "detections": 8379,
+     "detections_per_session": 33.25,
+     "triggered": {
+      "hits": 1028,
+      "of": 8379,
+      "rate": 0.12268767155985201
+     },
+     "no_break": 7351,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 1028,
+       "closed": 1028,
+       "open_at_end": 0,
+       "favourable": 290,
+       "precision": {
+        "hits": 290,
+        "of": 8379,
+        "rate": 0.03461033536221506
+       },
+       "win_rate": {
+        "hits": 290,
+        "of": 1028,
+        "rate": 0.2821011673151751
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 1028,
+       "closed": 1028,
+       "open_at_end": 0,
+       "favourable": 254,
+       "precision": {
+        "hits": 254,
+        "of": 8379,
+        "rate": 0.03031387993794009
+       },
+       "win_rate": {
+        "hits": 254,
+        "of": 1028,
+        "rate": 0.24708171206225682
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 1028,
+       "closed": 1028,
+       "open_at_end": 0,
+       "favourable": 223,
+       "precision": {
+        "hits": 223,
+        "of": 8379,
+        "rate": 0.026614154433703307
+       },
+       "win_rate": {
+        "hits": 223,
+        "of": 1028,
+        "rate": 0.2169260700389105
+       }
+      }
+     ],
+     "covered_days": 366,
+     "sessions_per_covered_day": 0.6885245901639344,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2025,
+     "sessions": 250,
+     "detections": 12182,
+     "detections_per_session": 48.728,
+     "triggered": {
+      "hits": 1420,
+      "of": 12182,
+      "rate": 0.1165654243966508
+     },
+     "no_break": 10762,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 1420,
+       "closed": 1420,
+       "open_at_end": 0,
+       "favourable": 409,
+       "precision": {
+        "hits": 409,
+        "of": 12182,
+        "rate": 0.03357412575931702
+       },
+       "win_rate": {
+        "hits": 409,
+        "of": 1420,
+        "rate": 0.2880281690140845
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 1420,
+       "closed": 1420,
+       "open_at_end": 0,
+       "favourable": 367,
+       "precision": {
+        "hits": 367,
+        "of": 12182,
+        "rate": 0.03012641602364144
+       },
+       "win_rate": {
+        "hits": 367,
+        "of": 1420,
+        "rate": 0.2584507042253521
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 1420,
+       "closed": 1420,
+       "open_at_end": 0,
+       "favourable": 330,
+       "precision": {
+        "hits": 330,
+        "of": 12182,
+        "rate": 0.027089147923165326
+       },
+       "win_rate": {
+        "hits": 330,
+        "of": 1420,
+        "rate": 0.2323943661971831
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.684931506849315,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "US",
+     "year": 2026,
+     "sessions": 162,
+     "detections": 11945,
+     "detections_per_session": 73.73456790123457,
+     "triggered": {
+      "hits": 1592,
+      "of": 11867,
+      "rate": 0.13415353501306143
+     },
+     "no_break": 10275,
+     "unfilled": 12,
+     "undecided": 78,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 1580,
+       "closed": 1541,
+       "open_at_end": 39,
+       "favourable": 394,
+       "precision": {
+        "hits": 394,
+        "of": 11816,
+        "rate": 0.03334461746784022
+       },
+       "win_rate": {
+        "hits": 394,
+        "of": 1541,
+        "rate": 0.2556781310837119
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 1580,
+       "closed": 1541,
+       "open_at_end": 39,
+       "favourable": 338,
+       "precision": {
+        "hits": 338,
+        "of": 11816,
+        "rate": 0.028605280974949222
+       },
+       "win_rate": {
+        "hits": 338,
+        "of": 1541,
+        "rate": 0.21933809214795588
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 1580,
+       "closed": 1513,
+       "open_at_end": 67,
+       "favourable": 249,
+       "precision": {
+        "hits": 249,
+        "of": 11788,
+        "rate": 0.021123176111299626
+       },
+       "win_rate": {
+        "hits": 249,
+        "of": 1513,
+        "rate": 0.16457369464639787
+       }
+      }
+     ],
+     "covered_days": 237,
+     "sessions_per_covered_day": 0.6835443037974683,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    }
+   ],
+   "months": [
+    {
+     "month": "2012-01",
+     "year": 2012,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 158,
+     "detections_per_session": 7.9,
+     "hole": false
+    },
+    {
+     "month": "2012-02",
+     "year": 2012,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 230,
+     "detections_per_session": 11.5,
+     "hole": false
+    },
+    {
+     "month": "2012-03",
+     "year": 2012,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 229,
+     "detections_per_session": 10.409090909090908,
+     "hole": false
+    },
+    {
+     "month": "2012-04",
+     "year": 2012,
+     "month_of_year": 4,
+     "sessions": 20,
+     "detections": 91,
+     "detections_per_session": 4.55,
+     "hole": false
+    },
+    {
+     "month": "2012-05",
+     "year": 2012,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 111,
+     "detections_per_session": 5.045454545454546,
+     "hole": false
+    },
+    {
+     "month": "2012-06",
+     "year": 2012,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 174,
+     "detections_per_session": 8.285714285714286,
+     "hole": false
+    },
+    {
+     "month": "2012-07",
+     "year": 2012,
+     "month_of_year": 7,
+     "sessions": 21,
+     "detections": 161,
+     "detections_per_session": 7.666666666666667,
+     "hole": false
+    },
+    {
+     "month": "2012-08",
+     "year": 2012,
+     "month_of_year": 8,
+     "sessions": 23,
+     "detections": 257,
+     "detections_per_session": 11.173913043478262,
+     "hole": false
+    },
+    {
+     "month": "2012-09",
+     "year": 2012,
+     "month_of_year": 9,
+     "sessions": 19,
+     "detections": 107,
+     "detections_per_session": 5.631578947368421,
+     "hole": false
+    },
+    {
+     "month": "2012-10",
+     "year": 2012,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 166,
+     "detections_per_session": 7.904761904761905,
+     "hole": false
+    },
+    {
+     "month": "2012-11",
+     "year": 2012,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 155,
+     "detections_per_session": 7.380952380952381,
+     "hole": false
+    },
+    {
+     "month": "2012-12",
+     "year": 2012,
+     "month_of_year": 12,
+     "sessions": 20,
+     "detections": 88,
+     "detections_per_session": 4.4,
+     "hole": false
+    },
+    {
+     "month": "2013-01",
+     "year": 2013,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 93,
+     "detections_per_session": 4.428571428571429,
+     "hole": false
+    },
+    {
+     "month": "2013-02",
+     "year": 2013,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 121,
+     "detections_per_session": 6.368421052631579,
+     "hole": false
+    },
+    {
+     "month": "2013-03",
+     "year": 2013,
+     "month_of_year": 3,
+     "sessions": 20,
+     "detections": 100,
+     "detections_per_session": 5.0,
+     "hole": false
+    },
+    {
+     "month": "2013-04",
+     "year": 2013,
+     "month_of_year": 4,
+     "sessions": 22,
+     "detections": 96,
+     "detections_per_session": 4.363636363636363,
+     "hole": false
+    },
+    {
+     "month": "2013-05",
+     "year": 2013,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 161,
+     "detections_per_session": 7.318181818181818,
+     "hole": false
+    },
+    {
+     "month": "2013-06",
+     "year": 2013,
+     "month_of_year": 6,
+     "sessions": 20,
+     "detections": 170,
+     "detections_per_session": 8.5,
+     "hole": false
+    },
+    {
+     "month": "2013-07",
+     "year": 2013,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 122,
+     "detections_per_session": 5.545454545454546,
+     "hole": false
+    },
+    {
+     "month": "2013-08",
+     "year": 2013,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 162,
+     "detections_per_session": 7.363636363636363,
+     "hole": false
+    },
+    {
+     "month": "2013-09",
+     "year": 2013,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 119,
+     "detections_per_session": 5.95,
+     "hole": false
+    },
+    {
+     "month": "2013-10",
+     "year": 2013,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 190,
+     "detections_per_session": 8.26086956521739,
+     "hole": false
+    },
+    {
+     "month": "2013-11",
+     "year": 2013,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 168,
+     "detections_per_session": 8.4,
+     "hole": false
+    },
+    {
+     "month": "2013-12",
+     "year": 2013,
+     "month_of_year": 12,
+     "sessions": 21,
+     "detections": 169,
+     "detections_per_session": 8.047619047619047,
+     "hole": false
+    },
+    {
+     "month": "2014-01",
+     "year": 2014,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 127,
+     "detections_per_session": 6.0476190476190474,
+     "hole": false
+    },
+    {
+     "month": "2014-02",
+     "year": 2014,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 254,
+     "detections_per_session": 13.368421052631579,
+     "hole": false
+    },
+    {
+     "month": "2014-03",
+     "year": 2014,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 228,
+     "detections_per_session": 10.857142857142858,
+     "hole": false
+    },
+    {
+     "month": "2014-04",
+     "year": 2014,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 190,
+     "detections_per_session": 9.047619047619047,
+     "hole": false
+    },
+    {
+     "month": "2014-05",
+     "year": 2014,
+     "month_of_year": 5,
+     "sessions": 21,
+     "detections": 143,
+     "detections_per_session": 6.809523809523809,
+     "hole": false
+    },
+    {
+     "month": "2014-06",
+     "year": 2014,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 147,
+     "detections_per_session": 7.0,
+     "hole": false
+    },
+    {
+     "month": "2014-07",
+     "year": 2014,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 201,
+     "detections_per_session": 9.136363636363637,
+     "hole": false
+    },
+    {
+     "month": "2014-08",
+     "year": 2014,
+     "month_of_year": 8,
+     "sessions": 21,
+     "detections": 85,
+     "detections_per_session": 4.0476190476190474,
+     "hole": false
+    },
+    {
+     "month": "2014-09",
+     "year": 2014,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 106,
+     "detections_per_session": 5.0476190476190474,
+     "hole": false
+    },
+    {
+     "month": "2014-10",
+     "year": 2014,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 118,
+     "detections_per_session": 5.130434782608695,
+     "hole": false
+    },
+    {
+     "month": "2014-11",
+     "year": 2014,
+     "month_of_year": 11,
+     "sessions": 19,
+     "detections": 168,
+     "detections_per_session": 8.842105263157896,
+     "hole": false
+    },
+    {
+     "month": "2014-12",
+     "year": 2014,
+     "month_of_year": 12,
+     "sessions": 22,
+     "detections": 173,
+     "detections_per_session": 7.863636363636363,
+     "hole": false
+    },
+    {
+     "month": "2015-01",
+     "year": 2015,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 176,
+     "detections_per_session": 8.8,
+     "hole": false
+    },
+    {
+     "month": "2015-02",
+     "year": 2015,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 357,
+     "detections_per_session": 18.789473684210527,
+     "hole": false
+    },
+    {
+     "month": "2015-03",
+     "year": 2015,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 192,
+     "detections_per_session": 8.727272727272727,
+     "hole": false
+    },
+    {
+     "month": "2015-04",
+     "year": 2015,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 266,
+     "detections_per_session": 12.666666666666666,
+     "hole": false
+    },
+    {
+     "month": "2015-05",
+     "year": 2015,
+     "month_of_year": 5,
+     "sessions": 20,
+     "detections": 190,
+     "detections_per_session": 9.5,
+     "hole": false
+    },
+    {
+     "month": "2015-06",
+     "year": 2015,
+     "month_of_year": 6,
+     "sessions": 22,
+     "detections": 156,
+     "detections_per_session": 7.090909090909091,
+     "hole": false
+    },
+    {
+     "month": "2015-07",
+     "year": 2015,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 152,
+     "detections_per_session": 6.909090909090909,
+     "hole": false
+    },
+    {
+     "month": "2015-08",
+     "year": 2015,
+     "month_of_year": 8,
+     "sessions": 21,
+     "detections": 140,
+     "detections_per_session": 6.666666666666667,
+     "hole": false
+    },
+    {
+     "month": "2015-09",
+     "year": 2015,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 196,
+     "detections_per_session": 9.333333333333334,
+     "hole": false
+    },
+    {
+     "month": "2015-10",
+     "year": 2015,
+     "month_of_year": 10,
+     "sessions": 22,
+     "detections": 333,
+     "detections_per_session": 15.136363636363637,
+     "hole": false
+    },
+    {
+     "month": "2015-11",
+     "year": 2015,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 304,
+     "detections_per_session": 15.2,
+     "hole": false
+    },
+    {
+     "month": "2015-12",
+     "year": 2015,
+     "month_of_year": 12,
+     "sessions": 22,
+     "detections": 298,
+     "detections_per_session": 13.545454545454545,
+     "hole": false
+    },
+    {
+     "month": "2016-01",
+     "year": 2016,
+     "month_of_year": 1,
+     "sessions": 19,
+     "detections": 129,
+     "detections_per_session": 6.7894736842105265,
+     "hole": false
+    },
+    {
+     "month": "2016-02",
+     "year": 2016,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 263,
+     "detections_per_session": 13.15,
+     "hole": false
+    },
+    {
+     "month": "2016-03",
+     "year": 2016,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 824,
+     "detections_per_session": 37.45454545454545,
+     "hole": false
+    },
+    {
+     "month": "2016-04",
+     "year": 2016,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 391,
+     "detections_per_session": 18.61904761904762,
+     "hole": false
+    },
+    {
+     "month": "2016-05",
+     "year": 2016,
+     "month_of_year": 5,
+     "sessions": 21,
+     "detections": 419,
+     "detections_per_session": 19.952380952380953,
+     "hole": false
+    },
+    {
+     "month": "2016-06",
+     "year": 2016,
+     "month_of_year": 6,
+     "sessions": 22,
+     "detections": 208,
+     "detections_per_session": 9.454545454545455,
+     "hole": false
+    },
+    {
+     "month": "2016-07",
+     "year": 2016,
+     "month_of_year": 7,
+     "sessions": 20,
+     "detections": 154,
+     "detections_per_session": 7.7,
+     "hole": false
+    },
+    {
+     "month": "2016-08",
+     "year": 2016,
+     "month_of_year": 8,
+     "sessions": 23,
+     "detections": 221,
+     "detections_per_session": 9.608695652173912,
+     "hole": false
+    },
+    {
+     "month": "2016-09",
+     "year": 2016,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 184,
+     "detections_per_session": 8.761904761904763,
+     "hole": false
+    },
+    {
+     "month": "2016-10",
+     "year": 2016,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 181,
+     "detections_per_session": 8.619047619047619,
+     "hole": false
+    },
+    {
+     "month": "2016-11",
+     "year": 2016,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 163,
+     "detections_per_session": 7.761904761904762,
+     "hole": false
+    },
+    {
+     "month": "2016-12",
+     "year": 2016,
+     "month_of_year": 12,
+     "sessions": 21,
+     "detections": 334,
+     "detections_per_session": 15.904761904761905,
+     "hole": false
+    },
+    {
+     "month": "2017-01",
+     "year": 2017,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 202,
+     "detections_per_session": 10.1,
+     "hole": false
+    },
+    {
+     "month": "2017-02",
+     "year": 2017,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 137,
+     "detections_per_session": 7.2105263157894735,
+     "hole": false
+    },
+    {
+     "month": "2017-03",
+     "year": 2017,
+     "month_of_year": 3,
+     "sessions": 23,
+     "detections": 215,
+     "detections_per_session": 9.347826086956522,
+     "hole": false
+    },
+    {
+     "month": "2017-04",
+     "year": 2017,
+     "month_of_year": 4,
+     "sessions": 19,
+     "detections": 164,
+     "detections_per_session": 8.631578947368421,
+     "hole": false
+    },
+    {
+     "month": "2017-05",
+     "year": 2017,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 165,
+     "detections_per_session": 7.5,
+     "hole": false
+    },
+    {
+     "month": "2017-06",
+     "year": 2017,
+     "month_of_year": 6,
+     "sessions": 22,
+     "detections": 292,
+     "detections_per_session": 13.272727272727273,
+     "hole": false
+    },
+    {
+     "month": "2017-07",
+     "year": 2017,
+     "month_of_year": 7,
+     "sessions": 20,
+     "detections": 203,
+     "detections_per_session": 10.15,
+     "hole": false
+    },
+    {
+     "month": "2017-08",
+     "year": 2017,
+     "month_of_year": 8,
+     "sessions": 23,
+     "detections": 247,
+     "detections_per_session": 10.73913043478261,
+     "hole": false
+    },
+    {
+     "month": "2017-09",
+     "year": 2017,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 129,
+     "detections_per_session": 6.45,
+     "hole": false
+    },
+    {
+     "month": "2017-10",
+     "year": 2017,
+     "month_of_year": 10,
+     "sessions": 22,
+     "detections": 203,
+     "detections_per_session": 9.227272727272727,
+     "hole": false
+    },
+    {
+     "month": "2017-11",
+     "year": 2017,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 142,
+     "detections_per_session": 6.761904761904762,
+     "hole": false
+    },
+    {
+     "month": "2017-12",
+     "year": 2017,
+     "month_of_year": 12,
+     "sessions": 20,
+     "detections": 237,
+     "detections_per_session": 11.85,
+     "hole": false
+    },
+    {
+     "month": "2018-01",
+     "year": 2018,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 194,
+     "detections_per_session": 9.238095238095237,
+     "hole": false
+    },
+    {
+     "month": "2018-02",
+     "year": 2018,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 415,
+     "detections_per_session": 21.842105263157894,
+     "hole": false
+    },
+    {
+     "month": "2018-03",
+     "year": 2018,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 443,
+     "detections_per_session": 21.095238095238095,
+     "hole": false
+    },
+    {
+     "month": "2018-04",
+     "year": 2018,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 358,
+     "detections_per_session": 17.047619047619047,
+     "hole": false
+    },
+    {
+     "month": "2018-05",
+     "year": 2018,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 253,
+     "detections_per_session": 11.5,
+     "hole": false
+    },
+    {
+     "month": "2018-06",
+     "year": 2018,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 318,
+     "detections_per_session": 15.142857142857142,
+     "hole": false
+    },
+    {
+     "month": "2018-07",
+     "year": 2018,
+     "month_of_year": 7,
+     "sessions": 21,
+     "detections": 326,
+     "detections_per_session": 15.523809523809524,
+     "hole": false
+    },
+    {
+     "month": "2018-08",
+     "year": 2018,
+     "month_of_year": 8,
+     "sessions": 23,
+     "detections": 205,
+     "detections_per_session": 8.91304347826087,
+     "hole": false
+    },
+    {
+     "month": "2018-09",
+     "year": 2018,
+     "month_of_year": 9,
+     "sessions": 19,
+     "detections": 183,
+     "detections_per_session": 9.631578947368421,
+     "hole": false
+    },
+    {
+     "month": "2018-10",
+     "year": 2018,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 190,
+     "detections_per_session": 8.26086956521739,
+     "hole": false
+    },
+    {
+     "month": "2018-11",
+     "year": 2018,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 410,
+     "detections_per_session": 19.523809523809526,
+     "hole": false
+    },
+    {
+     "month": "2018-12",
+     "year": 2018,
+     "month_of_year": 12,
+     "sessions": 19,
+     "detections": 355,
+     "detections_per_session": 18.68421052631579,
+     "hole": false
+    },
+    {
+     "month": "2019-01",
+     "year": 2019,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 486,
+     "detections_per_session": 23.142857142857142,
+     "hole": false
+    },
+    {
+     "month": "2019-02",
+     "year": 2019,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 330,
+     "detections_per_session": 17.36842105263158,
+     "hole": false
+    },
+    {
+     "month": "2019-03",
+     "year": 2019,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 432,
+     "detections_per_session": 20.571428571428573,
+     "hole": false
+    },
+    {
+     "month": "2019-04",
+     "year": 2019,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 397,
+     "detections_per_session": 18.904761904761905,
+     "hole": false
+    },
+    {
+     "month": "2019-05",
+     "year": 2019,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 285,
+     "detections_per_session": 12.954545454545455,
+     "hole": false
+    },
+    {
+     "month": "2019-06",
+     "year": 2019,
+     "month_of_year": 6,
+     "sessions": 20,
+     "detections": 225,
+     "detections_per_session": 11.25,
+     "hole": false
+    },
+    {
+     "month": "2019-07",
+     "year": 2019,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 303,
+     "detections_per_session": 13.772727272727273,
+     "hole": false
+    },
+    {
+     "month": "2019-08",
+     "year": 2019,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 324,
+     "detections_per_session": 14.727272727272727,
+     "hole": false
+    },
+    {
+     "month": "2019-09",
+     "year": 2019,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 411,
+     "detections_per_session": 20.55,
+     "hole": false
+    },
+    {
+     "month": "2019-10",
+     "year": 2019,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 253,
+     "detections_per_session": 11.0,
+     "hole": false
+    },
+    {
+     "month": "2019-11",
+     "year": 2019,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 306,
+     "detections_per_session": 15.3,
+     "hole": false
+    },
+    {
+     "month": "2019-12",
+     "year": 2019,
+     "month_of_year": 12,
+     "sessions": 21,
+     "detections": 284,
+     "detections_per_session": 13.523809523809524,
+     "hole": false
+    },
+    {
+     "month": "2020-01",
+     "year": 2020,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 279,
+     "detections_per_session": 13.285714285714286,
+     "hole": false
+    },
+    {
+     "month": "2020-02",
+     "year": 2020,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 278,
+     "detections_per_session": 14.631578947368421,
+     "hole": false
+    },
+    {
+     "month": "2020-03",
+     "year": 2020,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 283,
+     "detections_per_session": 12.863636363636363,
+     "hole": false
+    },
+    {
+     "month": "2020-04",
+     "year": 2020,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 726,
+     "detections_per_session": 34.57142857142857,
+     "hole": false
+    },
+    {
+     "month": "2020-05",
+     "year": 2020,
+     "month_of_year": 5,
+     "sessions": 20,
+     "detections": 1954,
+     "detections_per_session": 97.7,
+     "hole": false
+    },
+    {
+     "month": "2020-06",
+     "year": 2020,
+     "month_of_year": 6,
+     "sessions": 22,
+     "detections": 2758,
+     "detections_per_session": 125.36363636363636,
+     "hole": false
+    },
+    {
+     "month": "2020-07",
+     "year": 2020,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 1323,
+     "detections_per_session": 60.13636363636363,
+     "hole": false
+    },
+    {
+     "month": "2020-08",
+     "year": 2020,
+     "month_of_year": 8,
+     "sessions": 21,
+     "detections": 1126,
+     "detections_per_session": 53.61904761904762,
+     "hole": false
+    },
+    {
+     "month": "2020-09",
+     "year": 2020,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 828,
+     "detections_per_session": 39.42857142857143,
+     "hole": false
+    },
+    {
+     "month": "2020-10",
+     "year": 2020,
+     "month_of_year": 10,
+     "sessions": 22,
+     "detections": 848,
+     "detections_per_session": 38.54545454545455,
+     "hole": false
+    },
+    {
+     "month": "2020-11",
+     "year": 2020,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 949,
+     "detections_per_session": 47.45,
+     "hole": false
+    },
+    {
+     "month": "2020-12",
+     "year": 2020,
+     "month_of_year": 12,
+     "sessions": 22,
+     "detections": 1332,
+     "detections_per_session": 60.54545454545455,
+     "hole": false
+    },
+    {
+     "month": "2021-01",
+     "year": 2021,
+     "month_of_year": 1,
+     "sessions": 19,
+     "detections": 1137,
+     "detections_per_session": 59.8421052631579,
+     "hole": false
+    },
+    {
+     "month": "2021-02",
+     "year": 2021,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 1853,
+     "detections_per_session": 97.52631578947368,
+     "hole": false
+    },
+    {
+     "month": "2021-03",
+     "year": 2021,
+     "month_of_year": 3,
+     "sessions": 23,
+     "detections": 2151,
+     "detections_per_session": 93.52173913043478,
+     "hole": false
+    },
+    {
+     "month": "2021-04",
+     "year": 2021,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 1088,
+     "detections_per_session": 51.80952380952381,
+     "hole": false
+    },
+    {
+     "month": "2021-05",
+     "year": 2021,
+     "month_of_year": 5,
+     "sessions": 20,
+     "detections": 739,
+     "detections_per_session": 36.95,
+     "hole": false
+    },
+    {
+     "month": "2021-06",
+     "year": 2021,
+     "month_of_year": 6,
+     "sessions": 22,
+     "detections": 935,
+     "detections_per_session": 42.5,
+     "hole": false
+    },
+    {
+     "month": "2021-07",
+     "year": 2021,
+     "month_of_year": 7,
+     "sessions": 21,
+     "detections": 671,
+     "detections_per_session": 31.952380952380953,
+     "hole": false
+    },
+    {
+     "month": "2021-08",
+     "year": 2021,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 509,
+     "detections_per_session": 23.136363636363637,
+     "hole": false
+    },
+    {
+     "month": "2021-09",
+     "year": 2021,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 707,
+     "detections_per_session": 33.666666666666664,
+     "hole": false
+    },
+    {
+     "month": "2021-10",
+     "year": 2021,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 679,
+     "detections_per_session": 32.333333333333336,
+     "hole": false
+    },
+    {
+     "month": "2021-11",
+     "year": 2021,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 879,
+     "detections_per_session": 41.857142857142854,
+     "hole": false
+    },
+    {
+     "month": "2021-12",
+     "year": 2021,
+     "month_of_year": 12,
+     "sessions": 22,
+     "detections": 802,
+     "detections_per_session": 36.45454545454545,
+     "hole": false
+    },
+    {
+     "month": "2022-01",
+     "year": 2022,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 403,
+     "detections_per_session": 20.15,
+     "hole": false
+    },
+    {
+     "month": "2022-02",
+     "year": 2022,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 685,
+     "detections_per_session": 36.05263157894737,
+     "hole": false
+    },
+    {
+     "month": "2022-03",
+     "year": 2022,
+     "month_of_year": 3,
+     "sessions": 23,
+     "detections": 1052,
+     "detections_per_session": 45.73913043478261,
+     "hole": false
+    },
+    {
+     "month": "2022-04",
+     "year": 2022,
+     "month_of_year": 4,
+     "sessions": 20,
+     "detections": 871,
+     "detections_per_session": 43.55,
+     "hole": false
+    },
+    {
+     "month": "2022-05",
+     "year": 2022,
+     "month_of_year": 5,
+     "sessions": 21,
+     "detections": 527,
+     "detections_per_session": 25.095238095238095,
+     "hole": false
+    },
+    {
+     "month": "2022-06",
+     "year": 2022,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 636,
+     "detections_per_session": 30.285714285714285,
+     "hole": false
+    },
+    {
+     "month": "2022-07",
+     "year": 2022,
+     "month_of_year": 7,
+     "sessions": 20,
+     "detections": 917,
+     "detections_per_session": 45.85,
+     "hole": false
+    },
+    {
+     "month": "2022-08",
+     "year": 2022,
+     "month_of_year": 8,
+     "sessions": 23,
+     "detections": 1269,
+     "detections_per_session": 55.17391304347826,
+     "hole": false
+    },
+    {
+     "month": "2022-09",
+     "year": 2022,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 887,
+     "detections_per_session": 42.23809523809524,
+     "hole": false
+    },
+    {
+     "month": "2022-10",
+     "year": 2022,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 460,
+     "detections_per_session": 21.904761904761905,
+     "hole": false
+    },
+    {
+     "month": "2022-11",
+     "year": 2022,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 1519,
+     "detections_per_session": 72.33333333333333,
+     "hole": false
+    },
+    {
+     "month": "2022-12",
+     "year": 2022,
+     "month_of_year": 12,
+     "sessions": 21,
+     "detections": 1043,
+     "detections_per_session": 49.666666666666664,
+     "hole": false
+    },
+    {
+     "month": "2023-01",
+     "year": 2023,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 737,
+     "detections_per_session": 36.85,
+     "hole": false
+    },
+    {
+     "month": "2023-02",
+     "year": 2023,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 1205,
+     "detections_per_session": 63.421052631578945,
+     "hole": false
+    },
+    {
+     "month": "2023-03",
+     "year": 2023,
+     "month_of_year": 3,
+     "sessions": 23,
+     "detections": 696,
+     "detections_per_session": 30.26086956521739,
+     "hole": false
+    },
+    {
+     "month": "2023-04",
+     "year": 2023,
+     "month_of_year": 4,
+     "sessions": 19,
+     "detections": 439,
+     "detections_per_session": 23.105263157894736,
+     "hole": false
+    },
+    {
+     "month": "2023-05",
+     "year": 2023,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 576,
+     "detections_per_session": 26.181818181818183,
+     "hole": false
+    },
+    {
+     "month": "2023-06",
+     "year": 2023,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 855,
+     "detections_per_session": 40.714285714285715,
+     "hole": false
+    },
+    {
+     "month": "2023-07",
+     "year": 2023,
+     "month_of_year": 7,
+     "sessions": 20,
+     "detections": 687,
+     "detections_per_session": 34.35,
+     "hole": false
+    },
+    {
+     "month": "2023-08",
+     "year": 2023,
+     "month_of_year": 8,
+     "sessions": 23,
+     "detections": 720,
+     "detections_per_session": 31.304347826086957,
+     "hole": false
+    },
+    {
+     "month": "2023-09",
+     "year": 2023,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 346,
+     "detections_per_session": 17.3,
+     "hole": false
+    },
+    {
+     "month": "2023-10",
+     "year": 2023,
+     "month_of_year": 10,
+     "sessions": 22,
+     "detections": 296,
+     "detections_per_session": 13.454545454545455,
+     "hole": false
+    },
+    {
+     "month": "2023-11",
+     "year": 2023,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 465,
+     "detections_per_session": 22.142857142857142,
+     "hole": false
+    },
+    {
+     "month": "2023-12",
+     "year": 2023,
+     "month_of_year": 12,
+     "sessions": 20,
+     "detections": 492,
+     "detections_per_session": 24.6,
+     "hole": false
+    },
+    {
+     "month": "2024-01",
+     "year": 2024,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 829,
+     "detections_per_session": 39.476190476190474,
+     "hole": false
+    },
+    {
+     "month": "2024-02",
+     "year": 2024,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 434,
+     "detections_per_session": 21.7,
+     "hole": false
+    },
+    {
+     "month": "2024-03",
+     "year": 2024,
+     "month_of_year": 3,
+     "sessions": 20,
+     "detections": 702,
+     "detections_per_session": 35.1,
+     "hole": false
+    },
+    {
+     "month": "2024-04",
+     "year": 2024,
+     "month_of_year": 4,
+     "sessions": 22,
+     "detections": 727,
+     "detections_per_session": 33.04545454545455,
+     "hole": false
+    },
+    {
+     "month": "2024-05",
+     "year": 2024,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 559,
+     "detections_per_session": 25.40909090909091,
+     "hole": false
+    },
+    {
+     "month": "2024-06",
+     "year": 2024,
+     "month_of_year": 6,
+     "sessions": 19,
+     "detections": 572,
+     "detections_per_session": 30.105263157894736,
+     "hole": false
+    },
+    {
+     "month": "2024-07",
+     "year": 2024,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 702,
+     "detections_per_session": 31.90909090909091,
+     "hole": false
+    },
+    {
+     "month": "2024-08",
+     "year": 2024,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 938,
+     "detections_per_session": 42.63636363636363,
+     "hole": false
+    },
+    {
+     "month": "2024-09",
+     "year": 2024,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 540,
+     "detections_per_session": 27.0,
+     "hole": false
+    },
+    {
+     "month": "2024-10",
+     "year": 2024,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 745,
+     "detections_per_session": 32.391304347826086,
+     "hole": false
+    },
+    {
+     "month": "2024-11",
+     "year": 2024,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 703,
+     "detections_per_session": 35.15,
+     "hole": false
+    },
+    {
+     "month": "2024-12",
+     "year": 2024,
+     "month_of_year": 12,
+     "sessions": 21,
+     "detections": 928,
+     "detections_per_session": 44.19047619047619,
+     "hole": false
+    },
+    {
+     "month": "2025-01",
+     "year": 2025,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 961,
+     "detections_per_session": 48.05,
+     "hole": false
+    },
+    {
+     "month": "2025-02",
+     "year": 2025,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 695,
+     "detections_per_session": 36.578947368421055,
+     "hole": false
+    },
+    {
+     "month": "2025-03",
+     "year": 2025,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 671,
+     "detections_per_session": 31.952380952380953,
+     "hole": false
+    },
+    {
+     "month": "2025-04",
+     "year": 2025,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 688,
+     "detections_per_session": 32.76190476190476,
+     "hole": false
+    },
+    {
+     "month": "2025-05",
+     "year": 2025,
+     "month_of_year": 5,
+     "sessions": 21,
+     "detections": 978,
+     "detections_per_session": 46.57142857142857,
+     "hole": false
+    },
+    {
+     "month": "2025-06",
+     "year": 2025,
+     "month_of_year": 6,
+     "sessions": 20,
+     "detections": 883,
+     "detections_per_session": 44.15,
+     "hole": false
+    },
+    {
+     "month": "2025-07",
+     "year": 2025,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 1218,
+     "detections_per_session": 55.36363636363637,
+     "hole": false
+    },
+    {
+     "month": "2025-08",
+     "year": 2025,
+     "month_of_year": 8,
+     "sessions": 21,
+     "detections": 1149,
+     "detections_per_session": 54.714285714285715,
+     "hole": false
+    },
+    {
+     "month": "2025-09",
+     "year": 2025,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 901,
+     "detections_per_session": 42.904761904761905,
+     "hole": false
+    },
+    {
+     "month": "2025-10",
+     "year": 2025,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 1514,
+     "detections_per_session": 65.82608695652173,
+     "hole": false
+    },
+    {
+     "month": "2025-11",
+     "year": 2025,
+     "month_of_year": 11,
+     "sessions": 19,
+     "detections": 1117,
+     "detections_per_session": 58.78947368421053,
+     "hole": false
+    },
+    {
+     "month": "2025-12",
+     "year": 2025,
+     "month_of_year": 12,
+     "sessions": 22,
+     "detections": 1407,
+     "detections_per_session": 63.95454545454545,
+     "hole": false
+    },
+    {
+     "month": "2026-01",
+     "year": 2026,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 985,
+     "detections_per_session": 49.25,
+     "hole": false
+    },
+    {
+     "month": "2026-02",
+     "year": 2026,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 1445,
+     "detections_per_session": 76.05263157894737,
+     "hole": false
+    },
+    {
+     "month": "2026-03",
+     "year": 2026,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 1369,
+     "detections_per_session": 62.22727272727273,
+     "hole": false
+    },
+    {
+     "month": "2026-04",
+     "year": 2026,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 1176,
+     "detections_per_session": 56.0,
+     "hole": false
+    },
+    {
+     "month": "2026-05",
+     "year": 2026,
+     "month_of_year": 5,
+     "sessions": 20,
+     "detections": 1414,
+     "detections_per_session": 70.7,
+     "hole": false
+    },
+    {
+     "month": "2026-06",
+     "year": 2026,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 1933,
+     "detections_per_session": 92.04761904761905,
+     "hole": false
+    },
+    {
+     "month": "2026-07",
+     "year": 2026,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 2333,
+     "detections_per_session": 106.04545454545455,
+     "hole": false
+    },
+    {
+     "month": "2026-08",
+     "year": 2026,
+     "month_of_year": 8,
+     "sessions": 17,
+     "detections": 1290,
+     "detections_per_session": 75.88235294117646,
+     "hole": false
+    }
+   ]
+  },
+  {
+   "market": "IDX",
+   "sma50_overlap": "the contract's close > SMA50 universe gate overlaps the detector's own trend logic, so these counts sit below an unfiltered run \u2014 the gate working, not the detector becoming more selective",
+   "sessions": 3542,
+   "detections": 12821,
+   "detections_per_session": 3.6197063805759457,
+   "triggered": {
+    "hits": 1203,
+    "of": 12727,
+    "rate": 0.09452345407401587
+   },
+   "no_break": 11524,
+   "unfilled": 2,
+   "undecided": 94,
+   "arms": [
+    {
+     "arm": "A",
+     "filled": 1201,
+     "closed": 1196,
+     "open_at_end": 5,
+     "favourable": 353,
+     "precision": {
+      "hits": 353,
+      "of": 12720,
+      "rate": 0.027751572327044026
+     },
+     "win_rate": {
+      "hits": 353,
+      "of": 1196,
+      "rate": 0.29515050167224083
+     }
+    },
+    {
+     "arm": "B",
+     "filled": 1201,
+     "closed": 1196,
+     "open_at_end": 5,
+     "favourable": 302,
+     "precision": {
+      "hits": 302,
+      "of": 12720,
+      "rate": 0.023742138364779876
+     },
+     "win_rate": {
+      "hits": 302,
+      "of": 1196,
+      "rate": 0.2525083612040134
+     }
+    },
+    {
+     "arm": "C",
+     "filled": 1201,
+     "closed": 1194,
+     "open_at_end": 7,
+     "favourable": 275,
+     "precision": {
+      "hits": 275,
+      "of": 12718,
+      "rate": 0.021622896681868217
+     },
+     "win_rate": {
+      "hits": 275,
+      "of": 1194,
+      "rate": 0.23031825795644892
+     }
+    }
+   ],
+   "price_scale_dropped": 0,
+   "years": [
+    {
+     "market": "IDX",
+     "year": 2012,
+     "sessions": 246,
+     "detections": 452,
+     "detections_per_session": 1.8373983739837398,
+     "triggered": {
+      "hits": 33,
+      "of": 450,
+      "rate": 0.07333333333333333
+     },
+     "no_break": 417,
+     "unfilled": 0,
+     "undecided": 2,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 33,
+       "closed": 33,
+       "open_at_end": 0,
+       "favourable": 13,
+       "precision": {
+        "hits": 13,
+        "of": 450,
+        "rate": 0.028888888888888888
+       },
+       "win_rate": {
+        "hits": 13,
+        "of": 33,
+        "rate": 0.3939393939393939
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 33,
+       "closed": 33,
+       "open_at_end": 0,
+       "favourable": 11,
+       "precision": {
+        "hits": 11,
+        "of": 450,
+        "rate": 0.024444444444444446
+       },
+       "win_rate": {
+        "hits": 11,
+        "of": 33,
+        "rate": 0.3333333333333333
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 33,
+       "closed": 33,
+       "open_at_end": 0,
+       "favourable": 11,
+       "precision": {
+        "hits": 11,
+        "of": 450,
+        "rate": 0.024444444444444446
+       },
+       "win_rate": {
+        "hits": 11,
+        "of": 33,
+        "rate": 0.3333333333333333
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.673972602739726,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2013,
+     "sessions": 244,
+     "detections": 829,
+     "detections_per_session": 3.3975409836065573,
+     "triggered": {
+      "hits": 73,
+      "of": 820,
+      "rate": 0.08902439024390243
+     },
+     "no_break": 747,
+     "unfilled": 0,
+     "undecided": 9,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 73,
+       "closed": 73,
+       "open_at_end": 0,
+       "favourable": 21,
+       "precision": {
+        "hits": 21,
+        "of": 820,
+        "rate": 0.025609756097560974
+       },
+       "win_rate": {
+        "hits": 21,
+        "of": 73,
+        "rate": 0.2876712328767123
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 73,
+       "closed": 73,
+       "open_at_end": 0,
+       "favourable": 19,
+       "precision": {
+        "hits": 19,
+        "of": 820,
+        "rate": 0.023170731707317073
+       },
+       "win_rate": {
+        "hits": 19,
+        "of": 73,
+        "rate": 0.2602739726027397
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 73,
+       "closed": 73,
+       "open_at_end": 0,
+       "favourable": 18,
+       "precision": {
+        "hits": 18,
+        "of": 820,
+        "rate": 0.02195121951219512
+       },
+       "win_rate": {
+        "hits": 18,
+        "of": 73,
+        "rate": 0.2465753424657534
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6684931506849315,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2014,
+     "sessions": 242,
+     "detections": 515,
+     "detections_per_session": 2.128099173553719,
+     "triggered": {
+      "hits": 74,
+      "of": 515,
+      "rate": 0.1436893203883495
+     },
+     "no_break": 441,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 74,
+       "closed": 74,
+       "open_at_end": 0,
+       "favourable": 19,
+       "precision": {
+        "hits": 19,
+        "of": 515,
+        "rate": 0.036893203883495145
+       },
+       "win_rate": {
+        "hits": 19,
+        "of": 74,
+        "rate": 0.25675675675675674
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 74,
+       "closed": 74,
+       "open_at_end": 0,
+       "favourable": 16,
+       "precision": {
+        "hits": 16,
+        "of": 515,
+        "rate": 0.031067961165048542
+       },
+       "win_rate": {
+        "hits": 16,
+        "of": 74,
+        "rate": 0.21621621621621623
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 74,
+       "closed": 74,
+       "open_at_end": 0,
+       "favourable": 16,
+       "precision": {
+        "hits": 16,
+        "of": 515,
+        "rate": 0.031067961165048542
+       },
+       "win_rate": {
+        "hits": 16,
+        "of": 74,
+        "rate": 0.21621621621621623
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.663013698630137,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2015,
+     "sessions": 244,
+     "detections": 469,
+     "detections_per_session": 1.9221311475409837,
+     "triggered": {
+      "hits": 40,
+      "of": 469,
+      "rate": 0.08528784648187633
+     },
+     "no_break": 429,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 40,
+       "closed": 40,
+       "open_at_end": 0,
+       "favourable": 11,
+       "precision": {
+        "hits": 11,
+        "of": 469,
+        "rate": 0.023454157782515993
+       },
+       "win_rate": {
+        "hits": 11,
+        "of": 40,
+        "rate": 0.275
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 40,
+       "closed": 40,
+       "open_at_end": 0,
+       "favourable": 8,
+       "precision": {
+        "hits": 8,
+        "of": 469,
+        "rate": 0.017057569296375266
+       },
+       "win_rate": {
+        "hits": 8,
+        "of": 40,
+        "rate": 0.2
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 40,
+       "closed": 40,
+       "open_at_end": 0,
+       "favourable": 4,
+       "precision": {
+        "hits": 4,
+        "of": 469,
+        "rate": 0.008528784648187633
+       },
+       "win_rate": {
+        "hits": 4,
+        "of": 40,
+        "rate": 0.1
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6684931506849315,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2016,
+     "sessions": 246,
+     "detections": 636,
+     "detections_per_session": 2.5853658536585367,
+     "triggered": {
+      "hits": 49,
+      "of": 611,
+      "rate": 0.08019639934533551
+     },
+     "no_break": 562,
+     "unfilled": 0,
+     "undecided": 25,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 49,
+       "closed": 49,
+       "open_at_end": 0,
+       "favourable": 14,
+       "precision": {
+        "hits": 14,
+        "of": 611,
+        "rate": 0.022913256955810146
+       },
+       "win_rate": {
+        "hits": 14,
+        "of": 49,
+        "rate": 0.2857142857142857
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 49,
+       "closed": 49,
+       "open_at_end": 0,
+       "favourable": 13,
+       "precision": {
+        "hits": 13,
+        "of": 611,
+        "rate": 0.02127659574468085
+       },
+       "win_rate": {
+        "hits": 13,
+        "of": 49,
+        "rate": 0.2653061224489796
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 49,
+       "closed": 49,
+       "open_at_end": 0,
+       "favourable": 12,
+       "precision": {
+        "hits": 12,
+        "of": 611,
+        "rate": 0.019639934533551555
+       },
+       "win_rate": {
+        "hits": 12,
+        "of": 49,
+        "rate": 0.24489795918367346
+       }
+      }
+     ],
+     "covered_days": 366,
+     "sessions_per_covered_day": 0.6721311475409836,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2017,
+     "sessions": 238,
+     "detections": 460,
+     "detections_per_session": 1.9327731092436975,
+     "triggered": {
+      "hits": 42,
+      "of": 456,
+      "rate": 0.09210526315789473
+     },
+     "no_break": 414,
+     "unfilled": 0,
+     "undecided": 4,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 42,
+       "closed": 42,
+       "open_at_end": 0,
+       "favourable": 19,
+       "precision": {
+        "hits": 19,
+        "of": 456,
+        "rate": 0.041666666666666664
+       },
+       "win_rate": {
+        "hits": 19,
+        "of": 42,
+        "rate": 0.4523809523809524
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 42,
+       "closed": 42,
+       "open_at_end": 0,
+       "favourable": 17,
+       "precision": {
+        "hits": 17,
+        "of": 456,
+        "rate": 0.03728070175438596
+       },
+       "win_rate": {
+        "hits": 17,
+        "of": 42,
+        "rate": 0.40476190476190477
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 42,
+       "closed": 42,
+       "open_at_end": 0,
+       "favourable": 16,
+       "precision": {
+        "hits": 16,
+        "of": 456,
+        "rate": 0.03508771929824561
+       },
+       "win_rate": {
+        "hits": 16,
+        "of": 42,
+        "rate": 0.38095238095238093
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6520547945205479,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2018,
+     "sessions": 240,
+     "detections": 664,
+     "detections_per_session": 2.7666666666666666,
+     "triggered": {
+      "hits": 78,
+      "of": 642,
+      "rate": 0.12149532710280374
+     },
+     "no_break": 564,
+     "unfilled": 0,
+     "undecided": 22,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 78,
+       "closed": 78,
+       "open_at_end": 0,
+       "favourable": 26,
+       "precision": {
+        "hits": 26,
+        "of": 642,
+        "rate": 0.040498442367601244
+       },
+       "win_rate": {
+        "hits": 26,
+        "of": 78,
+        "rate": 0.3333333333333333
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 78,
+       "closed": 78,
+       "open_at_end": 0,
+       "favourable": 23,
+       "precision": {
+        "hits": 23,
+        "of": 642,
+        "rate": 0.03582554517133956
+       },
+       "win_rate": {
+        "hits": 23,
+        "of": 78,
+        "rate": 0.2948717948717949
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 78,
+       "closed": 78,
+       "open_at_end": 0,
+       "favourable": 22,
+       "precision": {
+        "hits": 22,
+        "of": 642,
+        "rate": 0.03426791277258567
+       },
+       "win_rate": {
+        "hits": 22,
+        "of": 78,
+        "rate": 0.28205128205128205
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6575342465753424,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2019,
+     "sessions": 245,
+     "detections": 807,
+     "detections_per_session": 3.293877551020408,
+     "triggered": {
+      "hits": 67,
+      "of": 804,
+      "rate": 0.08333333333333333
+     },
+     "no_break": 737,
+     "unfilled": 0,
+     "undecided": 3,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 67,
+       "closed": 67,
+       "open_at_end": 0,
+       "favourable": 16,
+       "precision": {
+        "hits": 16,
+        "of": 804,
+        "rate": 0.01990049751243781
+       },
+       "win_rate": {
+        "hits": 16,
+        "of": 67,
+        "rate": 0.23880597014925373
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 67,
+       "closed": 67,
+       "open_at_end": 0,
+       "favourable": 13,
+       "precision": {
+        "hits": 13,
+        "of": 804,
+        "rate": 0.01616915422885572
+       },
+       "win_rate": {
+        "hits": 13,
+        "of": 67,
+        "rate": 0.19402985074626866
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 67,
+       "closed": 67,
+       "open_at_end": 0,
+       "favourable": 10,
+       "precision": {
+        "hits": 10,
+        "of": 804,
+        "rate": 0.012437810945273632
+       },
+       "win_rate": {
+        "hits": 10,
+        "of": 67,
+        "rate": 0.14925373134328357
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6712328767123288,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2020,
+     "sessions": 242,
+     "detections": 1032,
+     "detections_per_session": 4.264462809917355,
+     "triggered": {
+      "hits": 89,
+      "of": 1031,
+      "rate": 0.0863239573229874
+     },
+     "no_break": 942,
+     "unfilled": 0,
+     "undecided": 1,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 89,
+       "closed": 89,
+       "open_at_end": 0,
+       "favourable": 27,
+       "precision": {
+        "hits": 27,
+        "of": 1031,
+        "rate": 0.026188166828322017
+       },
+       "win_rate": {
+        "hits": 27,
+        "of": 89,
+        "rate": 0.30337078651685395
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 89,
+       "closed": 89,
+       "open_at_end": 0,
+       "favourable": 27,
+       "precision": {
+        "hits": 27,
+        "of": 1031,
+        "rate": 0.026188166828322017
+       },
+       "win_rate": {
+        "hits": 27,
+        "of": 89,
+        "rate": 0.30337078651685395
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 89,
+       "closed": 89,
+       "open_at_end": 0,
+       "favourable": 23,
+       "precision": {
+        "hits": 23,
+        "of": 1031,
+        "rate": 0.02230843840931135
+       },
+       "win_rate": {
+        "hits": 23,
+        "of": 89,
+        "rate": 0.25842696629213485
+       }
+      }
+     ],
+     "covered_days": 366,
+     "sessions_per_covered_day": 0.6612021857923497,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2021,
+     "sessions": 247,
+     "detections": 1461,
+     "detections_per_session": 5.91497975708502,
+     "triggered": {
+      "hits": 123,
+      "of": 1459,
+      "rate": 0.08430431802604524
+     },
+     "no_break": 1336,
+     "unfilled": 0,
+     "undecided": 2,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 123,
+       "closed": 123,
+       "open_at_end": 0,
+       "favourable": 35,
+       "precision": {
+        "hits": 35,
+        "of": 1459,
+        "rate": 0.023989033584647018
+       },
+       "win_rate": {
+        "hits": 35,
+        "of": 123,
+        "rate": 0.2845528455284553
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 123,
+       "closed": 123,
+       "open_at_end": 0,
+       "favourable": 31,
+       "precision": {
+        "hits": 31,
+        "of": 1459,
+        "rate": 0.021247429746401644
+       },
+       "win_rate": {
+        "hits": 31,
+        "of": 123,
+        "rate": 0.25203252032520324
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 123,
+       "closed": 123,
+       "open_at_end": 0,
+       "favourable": 31,
+       "precision": {
+        "hits": 31,
+        "of": 1459,
+        "rate": 0.021247429746401644
+       },
+       "win_rate": {
+        "hits": 31,
+        "of": 123,
+        "rate": 0.25203252032520324
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6767123287671233,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2022,
+     "sessions": 246,
+     "detections": 1307,
+     "detections_per_session": 5.313008130081301,
+     "triggered": {
+      "hits": 115,
+      "of": 1306,
+      "rate": 0.08805513016845329
+     },
+     "no_break": 1191,
+     "unfilled": 0,
+     "undecided": 1,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 115,
+       "closed": 115,
+       "open_at_end": 0,
+       "favourable": 30,
+       "precision": {
+        "hits": 30,
+        "of": 1306,
+        "rate": 0.022970903522205207
+       },
+       "win_rate": {
+        "hits": 30,
+        "of": 115,
+        "rate": 0.2608695652173913
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 115,
+       "closed": 115,
+       "open_at_end": 0,
+       "favourable": 25,
+       "precision": {
+        "hits": 25,
+        "of": 1306,
+        "rate": 0.01914241960183767
+       },
+       "win_rate": {
+        "hits": 25,
+        "of": 115,
+        "rate": 0.21739130434782608
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 115,
+       "closed": 115,
+       "open_at_end": 0,
+       "favourable": 23,
+       "precision": {
+        "hits": 23,
+        "of": 1306,
+        "rate": 0.01761102603369066
+       },
+       "win_rate": {
+        "hits": 23,
+        "of": 115,
+        "rate": 0.2
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.673972602739726,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2023,
+     "sessions": 239,
+     "detections": 819,
+     "detections_per_session": 3.426778242677824,
+     "triggered": {
+      "hits": 75,
+      "of": 819,
+      "rate": 0.09157509157509157
+     },
+     "no_break": 744,
+     "unfilled": 0,
+     "undecided": 0,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 75,
+       "closed": 75,
+       "open_at_end": 0,
+       "favourable": 25,
+       "precision": {
+        "hits": 25,
+        "of": 819,
+        "rate": 0.030525030525030524
+       },
+       "win_rate": {
+        "hits": 25,
+        "of": 75,
+        "rate": 0.3333333333333333
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 75,
+       "closed": 75,
+       "open_at_end": 0,
+       "favourable": 21,
+       "precision": {
+        "hits": 21,
+        "of": 819,
+        "rate": 0.02564102564102564
+       },
+       "win_rate": {
+        "hits": 21,
+        "of": 75,
+        "rate": 0.28
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 75,
+       "closed": 75,
+       "open_at_end": 0,
+       "favourable": 21,
+       "precision": {
+        "hits": 21,
+        "of": 819,
+        "rate": 0.02564102564102564
+       },
+       "win_rate": {
+        "hits": 21,
+        "of": 75,
+        "rate": 0.28
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6547945205479452,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2024,
+     "sessions": 237,
+     "detections": 1069,
+     "detections_per_session": 4.510548523206751,
+     "triggered": {
+      "hits": 114,
+      "of": 1060,
+      "rate": 0.10754716981132076
+     },
+     "no_break": 946,
+     "unfilled": 0,
+     "undecided": 9,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 114,
+       "closed": 114,
+       "open_at_end": 0,
+       "favourable": 31,
+       "precision": {
+        "hits": 31,
+        "of": 1060,
+        "rate": 0.029245283018867925
+       },
+       "win_rate": {
+        "hits": 31,
+        "of": 114,
+        "rate": 0.2719298245614035
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 114,
+       "closed": 114,
+       "open_at_end": 0,
+       "favourable": 24,
+       "precision": {
+        "hits": 24,
+        "of": 1060,
+        "rate": 0.022641509433962263
+       },
+       "win_rate": {
+        "hits": 24,
+        "of": 114,
+        "rate": 0.21052631578947367
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 114,
+       "closed": 114,
+       "open_at_end": 0,
+       "favourable": 23,
+       "precision": {
+        "hits": 23,
+        "of": 1060,
+        "rate": 0.02169811320754717
+       },
+       "win_rate": {
+        "hits": 23,
+        "of": 114,
+        "rate": 0.20175438596491227
+       }
+      }
+     ],
+     "covered_days": 366,
+     "sessions_per_covered_day": 0.6475409836065574,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2025,
+     "sessions": 236,
+     "detections": 1361,
+     "detections_per_session": 5.766949152542373,
+     "triggered": {
+      "hits": 142,
+      "of": 1359,
+      "rate": 0.10448859455481972
+     },
+     "no_break": 1217,
+     "unfilled": 0,
+     "undecided": 2,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 142,
+       "closed": 142,
+       "open_at_end": 0,
+       "favourable": 45,
+       "precision": {
+        "hits": 45,
+        "of": 1359,
+        "rate": 0.033112582781456956
+       },
+       "win_rate": {
+        "hits": 45,
+        "of": 142,
+        "rate": 0.31690140845070425
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 142,
+       "closed": 142,
+       "open_at_end": 0,
+       "favourable": 39,
+       "precision": {
+        "hits": 39,
+        "of": 1359,
+        "rate": 0.02869757174392936
+       },
+       "win_rate": {
+        "hits": 39,
+        "of": 142,
+        "rate": 0.2746478873239437
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 142,
+       "closed": 142,
+       "open_at_end": 0,
+       "favourable": 35,
+       "precision": {
+        "hits": 35,
+        "of": 1359,
+        "rate": 0.025754231052244298
+       },
+       "win_rate": {
+        "hits": 35,
+        "of": 142,
+        "rate": 0.24647887323943662
+       }
+      }
+     ],
+     "covered_days": 365,
+     "sessions_per_covered_day": 0.6465753424657534,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    },
+    {
+     "market": "IDX",
+     "year": 2026,
+     "sessions": 150,
+     "detections": 940,
+     "detections_per_session": 6.266666666666667,
+     "triggered": {
+      "hits": 89,
+      "of": 926,
+      "rate": 0.09611231101511879
+     },
+     "no_break": 837,
+     "unfilled": 2,
+     "undecided": 14,
+     "arms": [
+      {
+       "arm": "A",
+       "filled": 87,
+       "closed": 82,
+       "open_at_end": 5,
+       "favourable": 21,
+       "precision": {
+        "hits": 21,
+        "of": 919,
+        "rate": 0.022850924918389554
+       },
+       "win_rate": {
+        "hits": 21,
+        "of": 82,
+        "rate": 0.25609756097560976
+       }
+      },
+      {
+       "arm": "B",
+       "filled": 87,
+       "closed": 82,
+       "open_at_end": 5,
+       "favourable": 15,
+       "precision": {
+        "hits": 15,
+        "of": 919,
+        "rate": 0.01632208922742111
+       },
+       "win_rate": {
+        "hits": 15,
+        "of": 82,
+        "rate": 0.18292682926829268
+       }
+      },
+      {
+       "arm": "C",
+       "filled": 87,
+       "closed": 80,
+       "open_at_end": 7,
+       "favourable": 10,
+       "precision": {
+        "hits": 10,
+        "of": 917,
+        "rate": 0.010905125408942203
+       },
+       "win_rate": {
+        "hits": 10,
+        "of": 80,
+        "rate": 0.125
+       }
+      }
+     ],
+     "covered_days": 236,
+     "sessions_per_covered_day": 0.635593220338983,
+     "sessions_collapsed": false,
+     "detections_collapsed": false,
+     "flags": []
+    }
+   ],
+   "months": [
+    {
+     "month": "2012-01",
+     "year": 2012,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 28,
+     "detections_per_session": 1.3333333333333333,
+     "hole": false
+    },
+    {
+     "month": "2012-02",
+     "year": 2012,
+     "month_of_year": 2,
+     "sessions": 21,
+     "detections": 57,
+     "detections_per_session": 2.7142857142857144,
+     "hole": false
+    },
+    {
+     "month": "2012-03",
+     "year": 2012,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 37,
+     "detections_per_session": 1.7619047619047619,
+     "hole": false
+    },
+    {
+     "month": "2012-04",
+     "year": 2012,
+     "month_of_year": 4,
+     "sessions": 20,
+     "detections": 40,
+     "detections_per_session": 2.0,
+     "hole": false
+    },
+    {
+     "month": "2012-05",
+     "year": 2012,
+     "month_of_year": 5,
+     "sessions": 21,
+     "detections": 52,
+     "detections_per_session": 2.4761904761904763,
+     "hole": false
+    },
+    {
+     "month": "2012-06",
+     "year": 2012,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 31,
+     "detections_per_session": 1.4761904761904763,
+     "hole": false
+    },
+    {
+     "month": "2012-07",
+     "year": 2012,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 53,
+     "detections_per_session": 2.409090909090909,
+     "hole": false
+    },
+    {
+     "month": "2012-08",
+     "year": 2012,
+     "month_of_year": 8,
+     "sessions": 19,
+     "detections": 29,
+     "detections_per_session": 1.5263157894736843,
+     "hole": false
+    },
+    {
+     "month": "2012-09",
+     "year": 2012,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 21,
+     "detections_per_session": 1.05,
+     "hole": false
+    },
+    {
+     "month": "2012-10",
+     "year": 2012,
+     "month_of_year": 10,
+     "sessions": 22,
+     "detections": 34,
+     "detections_per_session": 1.5454545454545454,
+     "hole": false
+    },
+    {
+     "month": "2012-11",
+     "year": 2012,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 35,
+     "detections_per_session": 1.75,
+     "hole": false
+    },
+    {
+     "month": "2012-12",
+     "year": 2012,
+     "month_of_year": 12,
+     "sessions": 18,
+     "detections": 35,
+     "detections_per_session": 1.9444444444444444,
+     "hole": false
+    },
+    {
+     "month": "2013-01",
+     "year": 2013,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 63,
+     "detections_per_session": 3.0,
+     "hole": false
+    },
+    {
+     "month": "2013-02",
+     "year": 2013,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 38,
+     "detections_per_session": 1.9,
+     "hole": false
+    },
+    {
+     "month": "2013-03",
+     "year": 2013,
+     "month_of_year": 3,
+     "sessions": 19,
+     "detections": 46,
+     "detections_per_session": 2.4210526315789473,
+     "hole": false
+    },
+    {
+     "month": "2013-04",
+     "year": 2013,
+     "month_of_year": 4,
+     "sessions": 22,
+     "detections": 137,
+     "detections_per_session": 6.2272727272727275,
+     "hole": false
+    },
+    {
+     "month": "2013-05",
+     "year": 2013,
+     "month_of_year": 5,
+     "sessions": 22,
+     "detections": 46,
+     "detections_per_session": 2.090909090909091,
+     "hole": false
+    },
+    {
+     "month": "2013-06",
+     "year": 2013,
+     "month_of_year": 6,
+     "sessions": 19,
+     "detections": 60,
+     "detections_per_session": 3.1578947368421053,
+     "hole": false
+    },
+    {
+     "month": "2013-07",
+     "year": 2013,
+     "month_of_year": 7,
+     "sessions": 23,
+     "detections": 51,
+     "detections_per_session": 2.217391304347826,
+     "hole": false
+    },
+    {
+     "month": "2013-08",
+     "year": 2013,
+     "month_of_year": 8,
+     "sessions": 17,
+     "detections": 24,
+     "detections_per_session": 1.411764705882353,
+     "hole": false
+    },
+    {
+     "month": "2013-09",
+     "year": 2013,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 122,
+     "detections_per_session": 5.809523809523809,
+     "hole": false
+    },
+    {
+     "month": "2013-10",
+     "year": 2013,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 117,
+     "detections_per_session": 5.571428571428571,
+     "hole": false
+    },
+    {
+     "month": "2013-11",
+     "year": 2013,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 72,
+     "detections_per_session": 3.6,
+     "hole": false
+    },
+    {
+     "month": "2013-12",
+     "year": 2013,
+     "month_of_year": 12,
+     "sessions": 19,
+     "detections": 53,
+     "detections_per_session": 2.789473684210526,
+     "hole": false
+    },
+    {
+     "month": "2014-01",
+     "year": 2014,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 37,
+     "detections_per_session": 1.85,
+     "hole": false
+    },
+    {
+     "month": "2014-02",
+     "year": 2014,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 45,
+     "detections_per_session": 2.25,
+     "hole": false
+    },
+    {
+     "month": "2014-03",
+     "year": 2014,
+     "month_of_year": 3,
+     "sessions": 20,
+     "detections": 58,
+     "detections_per_session": 2.9,
+     "hole": false
+    },
+    {
+     "month": "2014-04",
+     "year": 2014,
+     "month_of_year": 4,
+     "sessions": 20,
+     "detections": 62,
+     "detections_per_session": 3.1,
+     "hole": false
+    },
+    {
+     "month": "2014-05",
+     "year": 2014,
+     "month_of_year": 5,
+     "sessions": 18,
+     "detections": 46,
+     "detections_per_session": 2.5555555555555554,
+     "hole": false
+    },
+    {
+     "month": "2014-06",
+     "year": 2014,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 24,
+     "detections_per_session": 1.1428571428571428,
+     "hole": false
+    },
+    {
+     "month": "2014-07",
+     "year": 2014,
+     "month_of_year": 7,
+     "sessions": 18,
+     "detections": 24,
+     "detections_per_session": 1.3333333333333333,
+     "hole": false
+    },
+    {
+     "month": "2014-08",
+     "year": 2014,
+     "month_of_year": 8,
+     "sessions": 20,
+     "detections": 69,
+     "detections_per_session": 3.45,
+     "hole": false
+    },
+    {
+     "month": "2014-09",
+     "year": 2014,
+     "month_of_year": 9,
+     "sessions": 22,
+     "detections": 22,
+     "detections_per_session": 1.0,
+     "hole": false
+    },
+    {
+     "month": "2014-10",
+     "year": 2014,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 56,
+     "detections_per_session": 2.4347826086956523,
+     "hole": false
+    },
+    {
+     "month": "2014-11",
+     "year": 2014,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 33,
+     "detections_per_session": 1.65,
+     "hole": false
+    },
+    {
+     "month": "2014-12",
+     "year": 2014,
+     "month_of_year": 12,
+     "sessions": 20,
+     "detections": 39,
+     "detections_per_session": 1.95,
+     "hole": false
+    },
+    {
+     "month": "2015-01",
+     "year": 2015,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 34,
+     "detections_per_session": 1.619047619047619,
+     "hole": false
+    },
+    {
+     "month": "2015-02",
+     "year": 2015,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 31,
+     "detections_per_session": 1.631578947368421,
+     "hole": false
+    },
+    {
+     "month": "2015-03",
+     "year": 2015,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 39,
+     "detections_per_session": 1.7727272727272727,
+     "hole": false
+    },
+    {
+     "month": "2015-04",
+     "year": 2015,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 48,
+     "detections_per_session": 2.2857142857142856,
+     "hole": false
+    },
+    {
+     "month": "2015-05",
+     "year": 2015,
+     "month_of_year": 5,
+     "sessions": 19,
+     "detections": 45,
+     "detections_per_session": 2.3684210526315788,
+     "hole": false
+    },
+    {
+     "month": "2015-06",
+     "year": 2015,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 33,
+     "detections_per_session": 1.5714285714285714,
+     "hole": false
+    },
+    {
+     "month": "2015-07",
+     "year": 2015,
+     "month_of_year": 7,
+     "sessions": 19,
+     "detections": 27,
+     "detections_per_session": 1.4210526315789473,
+     "hole": false
+    },
+    {
+     "month": "2015-08",
+     "year": 2015,
+     "month_of_year": 8,
+     "sessions": 20,
+     "detections": 16,
+     "detections_per_session": 0.8,
+     "hole": false
+    },
+    {
+     "month": "2015-09",
+     "year": 2015,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 8,
+     "detections_per_session": 0.38095238095238093,
+     "hole": false
+    },
+    {
+     "month": "2015-10",
+     "year": 2015,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 75,
+     "detections_per_session": 3.5714285714285716,
+     "hole": false
+    },
+    {
+     "month": "2015-11",
+     "year": 2015,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 68,
+     "detections_per_session": 3.238095238095238,
+     "hole": false
+    },
+    {
+     "month": "2015-12",
+     "year": 2015,
+     "month_of_year": 12,
+     "sessions": 19,
+     "detections": 45,
+     "detections_per_session": 2.3684210526315788,
+     "hole": false
+    },
+    {
+     "month": "2016-01",
+     "year": 2016,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 70,
+     "detections_per_session": 3.5,
+     "hole": false
+    },
+    {
+     "month": "2016-02",
+     "year": 2016,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 48,
+     "detections_per_session": 2.4,
+     "hole": false
+    },
+    {
+     "month": "2016-03",
+     "year": 2016,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 68,
+     "detections_per_session": 3.238095238095238,
+     "hole": false
+    },
+    {
+     "month": "2016-04",
+     "year": 2016,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 64,
+     "detections_per_session": 3.0476190476190474,
+     "hole": false
+    },
+    {
+     "month": "2016-05",
+     "year": 2016,
+     "month_of_year": 5,
+     "sessions": 20,
+     "detections": 50,
+     "detections_per_session": 2.5,
+     "hole": false
+    },
+    {
+     "month": "2016-06",
+     "year": 2016,
+     "month_of_year": 6,
+     "sessions": 22,
+     "detections": 27,
+     "detections_per_session": 1.2272727272727273,
+     "hole": false
+    },
+    {
+     "month": "2016-07",
+     "year": 2016,
+     "month_of_year": 7,
+     "sessions": 16,
+     "detections": 29,
+     "detections_per_session": 1.8125,
+     "hole": false
+    },
+    {
+     "month": "2016-08",
+     "year": 2016,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 62,
+     "detections_per_session": 2.8181818181818183,
+     "hole": false
+    },
+    {
+     "month": "2016-09",
+     "year": 2016,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 48,
+     "detections_per_session": 2.2857142857142856,
+     "hole": false
+    },
+    {
+     "month": "2016-10",
+     "year": 2016,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 24,
+     "detections_per_session": 1.1428571428571428,
+     "hole": false
+    },
+    {
+     "month": "2016-11",
+     "year": 2016,
+     "month_of_year": 11,
+     "sessions": 22,
+     "detections": 75,
+     "detections_per_session": 3.409090909090909,
+     "hole": false
+    },
+    {
+     "month": "2016-12",
+     "year": 2016,
+     "month_of_year": 12,
+     "sessions": 20,
+     "detections": 71,
+     "detections_per_session": 3.55,
+     "hole": false
+    },
+    {
+     "month": "2017-01",
+     "year": 2017,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 27,
+     "detections_per_session": 1.2857142857142858,
+     "hole": false
+    },
+    {
+     "month": "2017-02",
+     "year": 2017,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 46,
+     "detections_per_session": 2.4210526315789473,
+     "hole": false
+    },
+    {
+     "month": "2017-03",
+     "year": 2017,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 49,
+     "detections_per_session": 2.227272727272727,
+     "hole": false
+    },
+    {
+     "month": "2017-04",
+     "year": 2017,
+     "month_of_year": 4,
+     "sessions": 17,
+     "detections": 48,
+     "detections_per_session": 2.823529411764706,
+     "hole": false
+    },
+    {
+     "month": "2017-05",
+     "year": 2017,
+     "month_of_year": 5,
+     "sessions": 20,
+     "detections": 35,
+     "detections_per_session": 1.75,
+     "hole": false
+    },
+    {
+     "month": "2017-06",
+     "year": 2017,
+     "month_of_year": 6,
+     "sessions": 15,
+     "detections": 59,
+     "detections_per_session": 3.933333333333333,
+     "hole": false
+    },
+    {
+     "month": "2017-07",
+     "year": 2017,
+     "month_of_year": 7,
+     "sessions": 21,
+     "detections": 36,
+     "detections_per_session": 1.7142857142857142,
+     "hole": false
+    },
+    {
+     "month": "2017-08",
+     "year": 2017,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 23,
+     "detections_per_session": 1.0454545454545454,
+     "hole": false
+    },
+    {
+     "month": "2017-09",
+     "year": 2017,
+     "month_of_year": 9,
+     "sessions": 19,
+     "detections": 22,
+     "detections_per_session": 1.1578947368421053,
+     "hole": false
+    },
+    {
+     "month": "2017-10",
+     "year": 2017,
+     "month_of_year": 10,
+     "sessions": 22,
+     "detections": 41,
+     "detections_per_session": 1.8636363636363635,
+     "hole": false
+    },
+    {
+     "month": "2017-11",
+     "year": 2017,
+     "month_of_year": 11,
+     "sessions": 22,
+     "detections": 39,
+     "detections_per_session": 1.7727272727272727,
+     "hole": false
+    },
+    {
+     "month": "2017-12",
+     "year": 2017,
+     "month_of_year": 12,
+     "sessions": 18,
+     "detections": 35,
+     "detections_per_session": 1.9444444444444444,
+     "hole": false
+    },
+    {
+     "month": "2018-01",
+     "year": 2018,
+     "month_of_year": 1,
+     "sessions": 22,
+     "detections": 21,
+     "detections_per_session": 0.9545454545454546,
+     "hole": false
+    },
+    {
+     "month": "2018-02",
+     "year": 2018,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 63,
+     "detections_per_session": 3.3157894736842106,
+     "hole": false
+    },
+    {
+     "month": "2018-03",
+     "year": 2018,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 56,
+     "detections_per_session": 2.6666666666666665,
+     "hole": false
+    },
+    {
+     "month": "2018-04",
+     "year": 2018,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 61,
+     "detections_per_session": 2.9047619047619047,
+     "hole": false
+    },
+    {
+     "month": "2018-05",
+     "year": 2018,
+     "month_of_year": 5,
+     "sessions": 20,
+     "detections": 24,
+     "detections_per_session": 1.2,
+     "hole": false
+    },
+    {
+     "month": "2018-06",
+     "year": 2018,
+     "month_of_year": 6,
+     "sessions": 13,
+     "detections": 18,
+     "detections_per_session": 1.3846153846153846,
+     "hole": false
+    },
+    {
+     "month": "2018-07",
+     "year": 2018,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 83,
+     "detections_per_session": 3.772727272727273,
+     "hole": false
+    },
+    {
+     "month": "2018-08",
+     "year": 2018,
+     "month_of_year": 8,
+     "sessions": 21,
+     "detections": 100,
+     "detections_per_session": 4.761904761904762,
+     "hole": false
+    },
+    {
+     "month": "2018-09",
+     "year": 2018,
+     "month_of_year": 9,
+     "sessions": 19,
+     "detections": 95,
+     "detections_per_session": 5.0,
+     "hole": false
+    },
+    {
+     "month": "2018-10",
+     "year": 2018,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 45,
+     "detections_per_session": 1.9565217391304348,
+     "hole": false
+    },
+    {
+     "month": "2018-11",
+     "year": 2018,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 29,
+     "detections_per_session": 1.380952380952381,
+     "hole": false
+    },
+    {
+     "month": "2018-12",
+     "year": 2018,
+     "month_of_year": 12,
+     "sessions": 18,
+     "detections": 69,
+     "detections_per_session": 3.8333333333333335,
+     "hole": false
+    },
+    {
+     "month": "2019-01",
+     "year": 2019,
+     "month_of_year": 1,
+     "sessions": 22,
+     "detections": 63,
+     "detections_per_session": 2.8636363636363638,
+     "hole": false
+    },
+    {
+     "month": "2019-02",
+     "year": 2019,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 90,
+     "detections_per_session": 4.7368421052631575,
+     "hole": false
+    },
+    {
+     "month": "2019-03",
+     "year": 2019,
+     "month_of_year": 3,
+     "sessions": 20,
+     "detections": 68,
+     "detections_per_session": 3.4,
+     "hole": false
+    },
+    {
+     "month": "2019-04",
+     "year": 2019,
+     "month_of_year": 4,
+     "sessions": 19,
+     "detections": 46,
+     "detections_per_session": 2.4210526315789473,
+     "hole": false
+    },
+    {
+     "month": "2019-05",
+     "year": 2019,
+     "month_of_year": 5,
+     "sessions": 21,
+     "detections": 43,
+     "detections_per_session": 2.0476190476190474,
+     "hole": false
+    },
+    {
+     "month": "2019-06",
+     "year": 2019,
+     "month_of_year": 6,
+     "sessions": 15,
+     "detections": 38,
+     "detections_per_session": 2.533333333333333,
+     "hole": false
+    },
+    {
+     "month": "2019-07",
+     "year": 2019,
+     "month_of_year": 7,
+     "sessions": 23,
+     "detections": 109,
+     "detections_per_session": 4.739130434782608,
+     "hole": false
+    },
+    {
+     "month": "2019-08",
+     "year": 2019,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 83,
+     "detections_per_session": 3.772727272727273,
+     "hole": false
+    },
+    {
+     "month": "2019-09",
+     "year": 2019,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 80,
+     "detections_per_session": 3.8095238095238093,
+     "hole": false
+    },
+    {
+     "month": "2019-10",
+     "year": 2019,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 76,
+     "detections_per_session": 3.3043478260869565,
+     "hole": false
+    },
+    {
+     "month": "2019-11",
+     "year": 2019,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 54,
+     "detections_per_session": 2.5714285714285716,
+     "hole": false
+    },
+    {
+     "month": "2019-12",
+     "year": 2019,
+     "month_of_year": 12,
+     "sessions": 19,
+     "detections": 57,
+     "detections_per_session": 3.0,
+     "hole": false
+    },
+    {
+     "month": "2020-01",
+     "year": 2020,
+     "month_of_year": 1,
+     "sessions": 22,
+     "detections": 64,
+     "detections_per_session": 2.909090909090909,
+     "hole": false
+    },
+    {
+     "month": "2020-02",
+     "year": 2020,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 36,
+     "detections_per_session": 1.8,
+     "hole": false
+    },
+    {
+     "month": "2020-03",
+     "year": 2020,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 20,
+     "detections_per_session": 0.9523809523809523,
+     "hole": false
+    },
+    {
+     "month": "2020-04",
+     "year": 2020,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 39,
+     "detections_per_session": 1.8571428571428572,
+     "hole": false
+    },
+    {
+     "month": "2020-05",
+     "year": 2020,
+     "month_of_year": 5,
+     "sessions": 16,
+     "detections": 70,
+     "detections_per_session": 4.375,
+     "hole": false
+    },
+    {
+     "month": "2020-06",
+     "year": 2020,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 229,
+     "detections_per_session": 10.904761904761905,
+     "hole": false
+    },
+    {
+     "month": "2020-07",
+     "year": 2020,
+     "month_of_year": 7,
+     "sessions": 22,
+     "detections": 100,
+     "detections_per_session": 4.545454545454546,
+     "hole": false
+    },
+    {
+     "month": "2020-08",
+     "year": 2020,
+     "month_of_year": 8,
+     "sessions": 18,
+     "detections": 109,
+     "detections_per_session": 6.055555555555555,
+     "hole": false
+    },
+    {
+     "month": "2020-09",
+     "year": 2020,
+     "month_of_year": 9,
+     "sessions": 22,
+     "detections": 126,
+     "detections_per_session": 5.7272727272727275,
+     "hole": false
+    },
+    {
+     "month": "2020-10",
+     "year": 2020,
+     "month_of_year": 10,
+     "sessions": 19,
+     "detections": 65,
+     "detections_per_session": 3.4210526315789473,
+     "hole": false
+    },
+    {
+     "month": "2020-11",
+     "year": 2020,
+     "month_of_year": 11,
+     "sessions": 21,
+     "detections": 87,
+     "detections_per_session": 4.142857142857143,
+     "hole": false
+    },
+    {
+     "month": "2020-12",
+     "year": 2020,
+     "month_of_year": 12,
+     "sessions": 19,
+     "detections": 87,
+     "detections_per_session": 4.578947368421052,
+     "hole": false
+    },
+    {
+     "month": "2021-01",
+     "year": 2021,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 159,
+     "detections_per_session": 7.95,
+     "hole": false
+    },
+    {
+     "month": "2021-02",
+     "year": 2021,
+     "month_of_year": 2,
+     "sessions": 19,
+     "detections": 130,
+     "detections_per_session": 6.842105263157895,
+     "hole": false
+    },
+    {
+     "month": "2021-03",
+     "year": 2021,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 159,
+     "detections_per_session": 7.2272727272727275,
+     "hole": false
+    },
+    {
+     "month": "2021-04",
+     "year": 2021,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 71,
+     "detections_per_session": 3.380952380952381,
+     "hole": false
+    },
+    {
+     "month": "2021-05",
+     "year": 2021,
+     "month_of_year": 5,
+     "sessions": 17,
+     "detections": 31,
+     "detections_per_session": 1.8235294117647058,
+     "hole": false
+    },
+    {
+     "month": "2021-06",
+     "year": 2021,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 67,
+     "detections_per_session": 3.1904761904761907,
+     "hole": false
+    },
+    {
+     "month": "2021-07",
+     "year": 2021,
+     "month_of_year": 7,
+     "sessions": 21,
+     "detections": 97,
+     "detections_per_session": 4.619047619047619,
+     "hole": false
+    },
+    {
+     "month": "2021-08",
+     "year": 2021,
+     "month_of_year": 8,
+     "sessions": 20,
+     "detections": 146,
+     "detections_per_session": 7.3,
+     "hole": false
+    },
+    {
+     "month": "2021-09",
+     "year": 2021,
+     "month_of_year": 9,
+     "sessions": 22,
+     "detections": 190,
+     "detections_per_session": 8.636363636363637,
+     "hole": false
+    },
+    {
+     "month": "2021-10",
+     "year": 2021,
+     "month_of_year": 10,
+     "sessions": 20,
+     "detections": 169,
+     "detections_per_session": 8.45,
+     "hole": false
+    },
+    {
+     "month": "2021-11",
+     "year": 2021,
+     "month_of_year": 11,
+     "sessions": 22,
+     "detections": 112,
+     "detections_per_session": 5.090909090909091,
+     "hole": false
+    },
+    {
+     "month": "2021-12",
+     "year": 2021,
+     "month_of_year": 12,
+     "sessions": 22,
+     "detections": 130,
+     "detections_per_session": 5.909090909090909,
+     "hole": false
+    },
+    {
+     "month": "2022-01",
+     "year": 2022,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 106,
+     "detections_per_session": 5.0476190476190474,
+     "hole": false
+    },
+    {
+     "month": "2022-02",
+     "year": 2022,
+     "month_of_year": 2,
+     "sessions": 18,
+     "detections": 69,
+     "detections_per_session": 3.8333333333333335,
+     "hole": false
+    },
+    {
+     "month": "2022-03",
+     "year": 2022,
+     "month_of_year": 3,
+     "sessions": 22,
+     "detections": 151,
+     "detections_per_session": 6.863636363636363,
+     "hole": false
+    },
+    {
+     "month": "2022-04",
+     "year": 2022,
+     "month_of_year": 4,
+     "sessions": 19,
+     "detections": 109,
+     "detections_per_session": 5.7368421052631575,
+     "hole": false
+    },
+    {
+     "month": "2022-05",
+     "year": 2022,
+     "month_of_year": 5,
+     "sessions": 15,
+     "detections": 90,
+     "detections_per_session": 6.0,
+     "hole": false
+    },
+    {
+     "month": "2022-06",
+     "year": 2022,
+     "month_of_year": 6,
+     "sessions": 21,
+     "detections": 137,
+     "detections_per_session": 6.523809523809524,
+     "hole": false
+    },
+    {
+     "month": "2022-07",
+     "year": 2022,
+     "month_of_year": 7,
+     "sessions": 21,
+     "detections": 68,
+     "detections_per_session": 3.238095238095238,
+     "hole": false
+    },
+    {
+     "month": "2022-08",
+     "year": 2022,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 118,
+     "detections_per_session": 5.363636363636363,
+     "hole": false
+    },
+    {
+     "month": "2022-09",
+     "year": 2022,
+     "month_of_year": 9,
+     "sessions": 22,
+     "detections": 126,
+     "detections_per_session": 5.7272727272727275,
+     "hole": false
+    },
+    {
+     "month": "2022-10",
+     "year": 2022,
+     "month_of_year": 10,
+     "sessions": 21,
+     "detections": 113,
+     "detections_per_session": 5.380952380952381,
+     "hole": false
+    },
+    {
+     "month": "2022-11",
+     "year": 2022,
+     "month_of_year": 11,
+     "sessions": 22,
+     "detections": 134,
+     "detections_per_session": 6.090909090909091,
+     "hole": false
+    },
+    {
+     "month": "2022-12",
+     "year": 2022,
+     "month_of_year": 12,
+     "sessions": 22,
+     "detections": 86,
+     "detections_per_session": 3.909090909090909,
+     "hole": false
+    },
+    {
+     "month": "2023-01",
+     "year": 2023,
+     "month_of_year": 1,
+     "sessions": 21,
+     "detections": 44,
+     "detections_per_session": 2.0952380952380953,
+     "hole": false
+    },
+    {
+     "month": "2023-02",
+     "year": 2023,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 92,
+     "detections_per_session": 4.6,
+     "hole": false
+    },
+    {
+     "month": "2023-03",
+     "year": 2023,
+     "month_of_year": 3,
+     "sessions": 21,
+     "detections": 87,
+     "detections_per_session": 4.142857142857143,
+     "hole": false
+    },
+    {
+     "month": "2023-04",
+     "year": 2023,
+     "month_of_year": 4,
+     "sessions": 14,
+     "detections": 27,
+     "detections_per_session": 1.9285714285714286,
+     "hole": false
+    },
+    {
+     "month": "2023-05",
+     "year": 2023,
+     "month_of_year": 5,
+     "sessions": 21,
+     "detections": 36,
+     "detections_per_session": 1.7142857142857142,
+     "hole": false
+    },
+    {
+     "month": "2023-06",
+     "year": 2023,
+     "month_of_year": 6,
+     "sessions": 17,
+     "detections": 82,
+     "detections_per_session": 4.823529411764706,
+     "hole": false
+    },
+    {
+     "month": "2023-07",
+     "year": 2023,
+     "month_of_year": 7,
+     "sessions": 20,
+     "detections": 91,
+     "detections_per_session": 4.55,
+     "hole": false
+    },
+    {
+     "month": "2023-08",
+     "year": 2023,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 96,
+     "detections_per_session": 4.363636363636363,
+     "hole": false
+    },
+    {
+     "month": "2023-09",
+     "year": 2023,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 72,
+     "detections_per_session": 3.6,
+     "hole": false
+    },
+    {
+     "month": "2023-10",
+     "year": 2023,
+     "month_of_year": 10,
+     "sessions": 22,
+     "detections": 63,
+     "detections_per_session": 2.8636363636363638,
+     "hole": false
+    },
+    {
+     "month": "2023-11",
+     "year": 2023,
+     "month_of_year": 11,
+     "sessions": 22,
+     "detections": 78,
+     "detections_per_session": 3.5454545454545454,
+     "hole": false
+    },
+    {
+     "month": "2023-12",
+     "year": 2023,
+     "month_of_year": 12,
+     "sessions": 19,
+     "detections": 51,
+     "detections_per_session": 2.6842105263157894,
+     "hole": false
+    },
+    {
+     "month": "2024-01",
+     "year": 2024,
+     "month_of_year": 1,
+     "sessions": 22,
+     "detections": 100,
+     "detections_per_session": 4.545454545454546,
+     "hole": false
+    },
+    {
+     "month": "2024-02",
+     "year": 2024,
+     "month_of_year": 2,
+     "sessions": 18,
+     "detections": 63,
+     "detections_per_session": 3.5,
+     "hole": false
+    },
+    {
+     "month": "2024-03",
+     "year": 2024,
+     "month_of_year": 3,
+     "sessions": 18,
+     "detections": 67,
+     "detections_per_session": 3.7222222222222223,
+     "hole": false
+    },
+    {
+     "month": "2024-04",
+     "year": 2024,
+     "month_of_year": 4,
+     "sessions": 16,
+     "detections": 73,
+     "detections_per_session": 4.5625,
+     "hole": false
+    },
+    {
+     "month": "2024-05",
+     "year": 2024,
+     "month_of_year": 5,
+     "sessions": 18,
+     "detections": 80,
+     "detections_per_session": 4.444444444444445,
+     "hole": false
+    },
+    {
+     "month": "2024-06",
+     "year": 2024,
+     "month_of_year": 6,
+     "sessions": 18,
+     "detections": 94,
+     "detections_per_session": 5.222222222222222,
+     "hole": false
+    },
+    {
+     "month": "2024-07",
+     "year": 2024,
+     "month_of_year": 7,
+     "sessions": 23,
+     "detections": 83,
+     "detections_per_session": 3.608695652173913,
+     "hole": false
+    },
+    {
+     "month": "2024-08",
+     "year": 2024,
+     "month_of_year": 8,
+     "sessions": 22,
+     "detections": 95,
+     "detections_per_session": 4.318181818181818,
+     "hole": false
+    },
+    {
+     "month": "2024-09",
+     "year": 2024,
+     "month_of_year": 9,
+     "sessions": 20,
+     "detections": 103,
+     "detections_per_session": 5.15,
+     "hole": false
+    },
+    {
+     "month": "2024-10",
+     "year": 2024,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 144,
+     "detections_per_session": 6.260869565217392,
+     "hole": false
+    },
+    {
+     "month": "2024-11",
+     "year": 2024,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 116,
+     "detections_per_session": 5.8,
+     "hole": false
+    },
+    {
+     "month": "2024-12",
+     "year": 2024,
+     "month_of_year": 12,
+     "sessions": 19,
+     "detections": 51,
+     "detections_per_session": 2.6842105263157894,
+     "hole": false
+    },
+    {
+     "month": "2025-01",
+     "year": 2025,
+     "month_of_year": 1,
+     "sessions": 19,
+     "detections": 45,
+     "detections_per_session": 2.3684210526315788,
+     "hole": false
+    },
+    {
+     "month": "2025-02",
+     "year": 2025,
+     "month_of_year": 2,
+     "sessions": 20,
+     "detections": 67,
+     "detections_per_session": 3.35,
+     "hole": false
+    },
+    {
+     "month": "2025-03",
+     "year": 2025,
+     "month_of_year": 3,
+     "sessions": 19,
+     "detections": 87,
+     "detections_per_session": 4.578947368421052,
+     "hole": false
+    },
+    {
+     "month": "2025-04",
+     "year": 2025,
+     "month_of_year": 4,
+     "sessions": 16,
+     "detections": 49,
+     "detections_per_session": 3.0625,
+     "hole": false
+    },
+    {
+     "month": "2025-05",
+     "year": 2025,
+     "month_of_year": 5,
+     "sessions": 17,
+     "detections": 104,
+     "detections_per_session": 6.117647058823529,
+     "hole": false
+    },
+    {
+     "month": "2025-06",
+     "year": 2025,
+     "month_of_year": 6,
+     "sessions": 18,
+     "detections": 128,
+     "detections_per_session": 7.111111111111111,
+     "hole": false
+    },
+    {
+     "month": "2025-07",
+     "year": 2025,
+     "month_of_year": 7,
+     "sessions": 23,
+     "detections": 128,
+     "detections_per_session": 5.565217391304348,
+     "hole": false
+    },
+    {
+     "month": "2025-08",
+     "year": 2025,
+     "month_of_year": 8,
+     "sessions": 20,
+     "detections": 199,
+     "detections_per_session": 9.95,
+     "hole": false
+    },
+    {
+     "month": "2025-09",
+     "year": 2025,
+     "month_of_year": 9,
+     "sessions": 21,
+     "detections": 146,
+     "detections_per_session": 6.9523809523809526,
+     "hole": false
+    },
+    {
+     "month": "2025-10",
+     "year": 2025,
+     "month_of_year": 10,
+     "sessions": 23,
+     "detections": 109,
+     "detections_per_session": 4.739130434782608,
+     "hole": false
+    },
+    {
+     "month": "2025-11",
+     "year": 2025,
+     "month_of_year": 11,
+     "sessions": 20,
+     "detections": 187,
+     "detections_per_session": 9.35,
+     "hole": false
+    },
+    {
+     "month": "2025-12",
+     "year": 2025,
+     "month_of_year": 12,
+     "sessions": 20,
+     "detections": 112,
+     "detections_per_session": 5.6,
+     "hole": false
+    },
+    {
+     "month": "2026-01",
+     "year": 2026,
+     "month_of_year": 1,
+     "sessions": 20,
+     "detections": 171,
+     "detections_per_session": 8.55,
+     "hole": false
+    },
+    {
+     "month": "2026-02",
+     "year": 2026,
+     "month_of_year": 2,
+     "sessions": 18,
+     "detections": 170,
+     "detections_per_session": 9.444444444444445,
+     "hole": false
+    },
+    {
+     "month": "2026-03",
+     "year": 2026,
+     "month_of_year": 3,
+     "sessions": 17,
+     "detections": 95,
+     "detections_per_session": 5.588235294117647,
+     "hole": false
+    },
+    {
+     "month": "2026-04",
+     "year": 2026,
+     "month_of_year": 4,
+     "sessions": 21,
+     "detections": 155,
+     "detections_per_session": 7.380952380952381,
+     "hole": false
+    },
+    {
+     "month": "2026-05",
+     "year": 2026,
+     "month_of_year": 5,
+     "sessions": 16,
+     "detections": 107,
+     "detections_per_session": 6.6875,
+     "hole": false
+    },
+    {
+     "month": "2026-06",
+     "year": 2026,
+     "month_of_year": 6,
+     "sessions": 20,
+     "detections": 52,
+     "detections_per_session": 2.6,
+     "hole": false
+    },
+    {
+     "month": "2026-07",
+     "year": 2026,
+     "month_of_year": 7,
+     "sessions": 23,
+     "detections": 90,
+     "detections_per_session": 3.9130434782608696,
+     "hole": false
+    },
+    {
+     "month": "2026-08",
+     "year": 2026,
+     "month_of_year": 8,
+     "sessions": 15,
+     "detections": 100,
+     "detections_per_session": 6.666666666666667,
+     "hole": false
+    }
+   ]
+  }
+ ]
+}

--- a/references/backtest_figures.txt
+++ b/references/backtest_figures.txt
@@ -1,0 +1,169 @@
+favourable outcome: R > 0 on a closed trade, before costs
+note: these are before costs — commission and slippage are applied by the phase that computes the pre-registered primary metric, and precision computed before them overstates
+
+US — detections per session, 2012–2026
+  the contract's close > SMA50 universe gate overlaps the detector's own trend logic, so these counts sit below an unfiltered run — the gate working, not the detector becoming more selective
+
+  year  sessions  detections  per session
+  2012       250        1927    7.708  ████
+  2013       252        1671    6.631  ███
+  2014       252        1940    7.698  ████
+  2015       252        2760   10.952  █████
+  2016       252        3471   13.774  ██████
+  2017       251        2336    9.307  ████
+  2018       251        3650   14.542  ███████
+  2019       252        4036   16.016  ███████
+  2020       253       12684   50.134  ███████████████████████
+  2021       252       12150   48.214  ██████████████████████
+  2022       251       10269   40.912  ███████████████████
+  2023       250        7514   30.056  ██████████████
+  2024       252        8379   33.250  ███████████████
+  2025       250       12182   48.728  ██████████████████████
+  2026       162       11945   73.735  ██████████████████████████████████
+
+  year  detections  decided  triggered  precision A  precision B  precision C
+  2012        1927     1927   273 /1927     78 /1927     65 /1927     53 /1927
+  2013        1671     1671   231 /1671     77 /1671     71 /1671     63 /1671
+  2014        1940     1938   226 /1938     53 /1938     47 /1938     45 /1938
+  2015        2760     2757   317 /2757     85 /2757     72 /2757     57 /2757
+  2016        3471     3471   438 /3471    155 /3471    132 /3471    124 /3471
+  2017        2336     2336   304 /2336     92 /2336     76 /2336     70 /2336
+  2018        3650     3650   448 /3650    128 /3650    108 /3650     92 /3650
+  2019        4036     4036   560 /4036    161 /4036    141 /4036    117 /4036
+  2020       12684    12684  1737 /12684    561 /12684    499 /12684    444 /12684
+  2021       12150    12149  1485 /12149    415 /12149    334 /12149    257 /12149
+  2022       10269    10269  1403 /10269    363 /10269    304 /10269    250 /10269
+  2023        7514     7514   900 /7514    231 /7514    202 /7514    161 /7514
+  2024        8379     8379  1028 /8379    290 /8379    254 /8379    223 /8379
+  2025       12182    12182  1420 /12182    409 /12182    367 /12182    330 /12182
+  2026       11945    11867  1592 /11867    394 /11816    338 /11816    249 /11788
+
+  detections per session by month  (JFMAMJJASOND)
+    · is a month inside the window the store never covered — a hole, not a quiet month
+
+    2012  ▁▂▂▁▁▁▁▂▁▁▁▁
+    2013  ▁▁▁▁▁▁▁▁▁▁▁▁
+    2014  ▁▂▂▂▁▁▂▁▁▁▁▁
+    2015  ▁▂▁▂▂▁▁▁▂▂▂▂
+    2016  ▁▂▃▂▂▂▁▂▁▁▁▂
+    2017  ▂▁▂▁▁▂▂▂▁▂▁▂
+    2018  ▂▂▂▂▂▂▂▁▂▁▂▂
+    2019  ▂▂▂▂▂▂▂▂▂▂▂▂
+    2020  ▂▂▂▃▆█▄▄▃▃▄▄
+    2021  ▄▆▆▄▃▃▃▂▃▃▃▃
+    2022  ▂▃▄▃▂▃▄▄▃▂▅▄
+    2023  ▃▅▃▂▂▃▃▃▂▂▂▂
+    2024  ▃▂▃▃▂▃▃▃▃▃▃▃
+    2025  ▄▃▃▃▄▃▄▄▃▅▄▅
+    2026  ▄▅▄▄▅▆▇▅    
+
+  sessions measured   3682
+  detections          96914
+  triggered           12.8% (12362 of 96830)
+  never broke         84468  (asked, and the market said no — in precision's denominator)
+  unfilled            12  (triggered, and the window ended before a fill)
+  undecided           84  (the bars could not answer these; they are not misses)
+  price-scale flag would drop 0 of the trades behind these figures
+
+  arm A
+    filled            12350
+    closed            12311
+    open at end       39  (no outcome — never counted as a loss)
+    precision         3.6% (3492 of 96779)  — of every answered detection
+    win rate          28.4% (3492 of 12311)  — of the trades taken
+  arm B
+    filled            12350
+    closed            12311
+    open at end       39  (no outcome — never counted as a loss)
+    precision         3.1% (3010 of 96779)  — of every answered detection
+    win rate          24.4% (3010 of 12311)  — of the trades taken
+  arm C
+    filled            12350
+    closed            12283
+    open at end       67  (no outcome — never counted as a loss)
+    precision         2.6% (2535 of 96751)  — of every answered detection
+    win rate          20.6% (2535 of 12283)  — of the trades taken
+
+IDX — detections per session, 2012–2026
+  the contract's close > SMA50 universe gate overlaps the detector's own trend logic, so these counts sit below an unfiltered run — the gate working, not the detector becoming more selective
+
+  year  sessions  detections  per session
+  2012       246         452    1.837  ██████████
+  2013       244         829    3.398  ██████████████████
+  2014       242         515    2.128  ████████████
+  2015       244         469    1.922  ██████████
+  2016       246         636    2.585  ██████████████
+  2017       238         460    1.933  ██████████
+  2018       240         664    2.767  ███████████████
+  2019       245         807    3.294  ██████████████████
+  2020       242        1032    4.264  ███████████████████████
+  2021       247        1461    5.915  ████████████████████████████████
+  2022       246        1307    5.313  █████████████████████████████
+  2023       239         819    3.427  ███████████████████
+  2024       237        1069    4.511  ████████████████████████
+  2025       236        1361    5.767  ███████████████████████████████
+  2026       150         940    6.267  ██████████████████████████████████
+
+  year  detections  decided  triggered  precision A  precision B  precision C
+  2012         452      450    33 / 450     13 / 450     11 / 450     11 / 450
+  2013         829      820    73 / 820     21 / 820     19 / 820     18 / 820
+  2014         515      515    74 / 515     19 / 515     16 / 515     16 / 515
+  2015         469      469    40 / 469     11 / 469      8 / 469      4 / 469
+  2016         636      611    49 / 611     14 / 611     13 / 611     12 / 611
+  2017         460      456    42 / 456     19 / 456     17 / 456     16 / 456
+  2018         664      642    78 / 642     26 / 642     23 / 642     22 / 642
+  2019         807      804    67 / 804     16 / 804     13 / 804     10 / 804
+  2020        1032     1031    89 /1031     27 /1031     27 /1031     23 /1031
+  2021        1461     1459   123 /1459     35 /1459     31 /1459     31 /1459
+  2022        1307     1306   115 /1306     30 /1306     25 /1306     23 /1306
+  2023         819      819    75 / 819     25 / 819     21 / 819     21 / 819
+  2024        1069     1060   114 /1060     31 /1060     24 /1060     23 /1060
+  2025        1361     1359   142 /1359     45 /1359     39 /1359     35 /1359
+  2026         940      926    89 / 926     21 / 919     15 / 919     10 / 917
+
+  detections per session by month  (JFMAMJJASOND)
+    · is a month inside the window the store never covered — a hole, not a quiet month
+
+    2012  ▂▃▂▂▃▂▃▂▂▂▂▂
+    2013  ▃▂▃▅▂▃▂▂▅▅▃▃
+    2014  ▂▂▃▃▃▂▂▃▂▃▂▂
+    2015  ▂▂▂▂▃▂▂▂▁▃▃▃
+    2016  ▃▃▃▃▃▂▂▃▂▂▃▃
+    2017  ▂▃▂▃▂▄▂▂▂▂▂▂
+    2018  ▂▃▃▃▂▂▃▄▄▂▂▃
+    2019  ▃▄▃▃▂▃▄▃▃▃▃▃
+    2020  ▃▂▂▂▄█▄▅▅▃▄▄
+    2021  ▆▅▆▃▂▃▄▆▇▆▄▅
+    2022  ▄▃▅▅▅▅▃▄▅▄▅▄
+    2023  ▂▄▄▂▂▄▄▄▃▃▃▃
+    2024  ▄▃▃▄▄▄▃▄▄▅▅▃
+    2025  ▃▃▄▃▅▆▅▇▅▄▇▅
+    2026  ▆▇▅▆▅▃▄▅    
+
+  sessions measured   3542
+  detections          12821
+  triggered           9.5% (1203 of 12727)
+  never broke         11524  (asked, and the market said no — in precision's denominator)
+  unfilled            2  (triggered, and the window ended before a fill)
+  undecided           94  (the bars could not answer these; they are not misses)
+  price-scale flag would drop 0 of the trades behind these figures
+
+  arm A
+    filled            1201
+    closed            1196
+    open at end       5  (no outcome — never counted as a loss)
+    precision         2.8% (353 of 12720)  — of every answered detection
+    win rate          29.5% (353 of 1196)  — of the trades taken
+  arm B
+    filled            1201
+    closed            1196
+    open at end       5  (no outcome — never counted as a loss)
+    precision         2.4% (302 of 12720)  — of every answered detection
+    win rate          25.3% (302 of 1196)  — of the trades taken
+  arm C
+    filled            1201
+    closed            1194
+    open at end       7  (no outcome — never counted as a loss)
+    precision         2.2% (275 of 12718)  — of every answered detection
+    win rate          23.0% (275 of 1194)  — of the trades taken
+

--- a/references/backtest_findings-plain.md
+++ b/references/backtest_findings-plain.md
@@ -1,0 +1,269 @@
+# Testing the app's method against fourteen years of two markets — findings, in plain language
+
+*This is a plain-language retelling of [`backtest_findings.md`](backtest_findings.md).
+Same run, same numbers, same conclusions — just without assuming you already speak the
+project's vocabulary. Where the two ever disagree, **the technical version is the
+authority**, because that's the one whose figures are checked against the committed run
+output.*
+
+**Nothing in the app was changed by this run.** One change is *allowed* by it, and the
+rules say that change has to be named in writing before anything moves. It's named below.
+It hasn't been made.
+
+---
+
+## What this was for
+
+The [earlier study](qullamaggie-replay-findings-plain.md) looked at 828 trades a real
+trader actually made and asked how many of them the app would have shown him. That's a
+useful question, but it has a hole in the middle of it: every trade in that record is a
+trade he **chose to take**. Nobody wrote down the setups he looked at and passed on.
+
+So the earlier study could say "the app would have caught 84% of his trades". It could
+*not* say "and of everything the app shows you, this fraction is worth taking" — because
+it never saw anything he didn't take. It had a numerator and no denominator.
+
+This run builds the denominator. It takes **every single setup the app's detector names**,
+over fourteen years, in two markets, and trades all of them mechanically by a fixed rule.
+No judgement, no skipping, no picking. Then it asks the question the earlier study
+couldn't:
+
+> **Does the method have an edge, or did the trader?**
+
+## The vocabulary, up front
+
+- **R — profit compared to what was risked.** Risk $100 and make $200, that's "+2R".
+  Lose the planned amount, that's "−1R". Using R instead of dollars lets a $5 stock and a
+  $500 stock be compared fairly.
+- **Expectancy** — the average R across every trade, winners and losers together. This is
+  the headline number. Positive means the rule made money on average; negative means it
+  lost.
+- **A detection** — one setup the app's detector names on one evening. Fourteen years of
+  US evenings produced about 97,000 of them.
+- **The two markets** — US stocks and IDX (Indonesian stocks, on the Jakarta exchange).
+  They are always reported separately, never averaged together. There's a reason for that
+  below.
+- **Survivorship bias** — the reason this whole document keeps two numbers instead of
+  one. Explained in its own section, because it's the biggest thing here.
+
+---
+
+## The headline
+
+Here is the whole result. Every row is "trade every setup the detector names, hold it on a
+10-day moving-average trail, and see what the average trade earned."
+
+| | period | what it earned | what it earned if you count the missing stocks | trades |
+| --- | --- | ---: | ---: | ---: |
+| **US** | all 14 years | **+0.050R** | **−0.363R** | 12,311 |
+| **US** | with 2020–21 removed | **−0.081R** | **−0.446R** | 9,092 |
+| **IDX** | all 14 years | **+0.680R** | **+0.418R** | 1,196 |
+| **IDX** | with 2020–21 removed | **+0.284R** | **+0.072R** | 986 |
+
+Read that as four separate results, not one. Three things explain the shape of the table.
+
+**Why 2020–21 gets its own row.** 2020 and 2021 were a once-in-a-decade momentum tape —
+almost anything that broke out kept going. A fourteen-year average that includes them
+describes a market that mostly wasn't there. So every figure is reported twice: with those
+two years and without. On the US, taking them out flips the result from barely positive to
+slightly negative. That flip is the most honest single fact in the table.
+
+**Why there are two money columns.** The right-hand column is the same result with the
+missing stocks counted. That's the next section, and it's the important one.
+
+**Why the two markets are never combined.** The earlier study established that the *shape*
+of these findings travels between the US and Jakarta, but the *sizes* don't — Indonesian
+stocks are more volatile and cost far more to trade. An average of the two would describe
+neither. There is no combined number anywhere in either document.
+
+## The missing stocks — the biggest limitation, stated before any result
+
+The price data available for this run only covers companies that **still exist today**.
+Every company that went bankrupt, got acquired, or was delisted somewhere in the last
+fourteen years is simply absent from it.
+
+That is not a small gap and it doesn't point in a random direction. The missing companies
+are disproportionately the ones that *died*, which means the data is a study of survivors.
+A backtest run on survivors will look better than reality, always.
+
+So the run measured the gap instead of mentioning it. Someone reconstructed a dated list of
+every US stock ticker that existed at various points since 2008 — 96 archived snapshots of
+the official exchange listing files — and compared it to what's actually in the price data.
+
+**The US is missing 37.7% of the trading history it should have.** (By raw count of
+company names it's 51.8%; 37.7% is the fairer figure, because it weights each missing
+company by how long it was actually listed.)
+
+Then the run did the pessimistic thing: it re-ran the whole result assuming **every single
+missing stock would have been a full losing trade**. That's the right-hand column in the
+table. And here's the part that matters:
+
+> At 37.7%, the missing stocks would contribute six losing trades for every ten real ones.
+> That drags the result down by about 0.6R. **The US headline is +0.050R.** The correction
+> is more than ten times the effect.
+
+This is why the bound isn't a footnote. On the US, the size of what we can't see is larger
+than the thing we're trying to measure. Any positive US result here should be read as "we
+cannot rule out zero", not as "it works".
+
+**Jakarta's version of this number is weaker, and that matters, because Jakarta is the
+market that passed.** No free source exists that reconstructs a dated list of Indonesian
+listings, so its 12.7% gap was counted a cruder way — by comparing what the data provider
+lists today against what the exchange says is listed today. That count misses recycled
+ticker symbols entirely and doesn't weight by time listed. **So Jakarta's 12.7% is
+optimistic in a known direction: the real figure can only be worse.** The document says
+so on the same line as the result, not underneath it.
+
+## The verdict
+
+Before any code was written, two rules were fixed in advance, so that nobody could look at
+the result and then decide what counted as success.
+
+**The "kill" rule:** if the method loses money in *both* markets across *both* periods, the
+detector doesn't work and the app's claim shrinks to "we rank what a human picks."
+**It didn't fire.** Jakarta was positive throughout and the US was barely positive over the
+full window.
+
+**The "ship" rule:** a market passes if it makes money across both periods *and* still
+makes money after the missing-stocks correction.
+
+**The US: inconclusive.** Positive over fourteen years, negative with 2020–21 removed. It
+neither passes nor fails, and the rule written in advance says exactly what to do about
+that:
+
+> *nothing. The run is reported as inconclusive, and reaching for a swept variant to break
+> the tie is the failure mode the contract exists to prevent*
+
+That's worth unpacking, because there was a real temptation here. Afterwards, the run tried
+eight variations — different cost assumptions, different quality thresholds. One of them
+lifts the US to +0.153R, which looks like a pass. It isn't one, for the reason the rule
+names: if you try enough variations, one of them wins by luck. That's why the number of
+variations tried is printed next to every variant figure. The pre-registered number stands.
+
+**Jakarta: passes.** +0.680R and +0.284R, and still positive after the correction (+0.418R
+and +0.072R). It is the only market anything is allowed in.
+
+Two cautions belong right next to that pass, and they're in the technical document too.
+**+0.072R is thin** — that's the number the whole pass actually turns on. And **it rests on
+the weaker of the two corrections**, the Jakarta one that can only be too generous.
+
+## The change this allows
+
+The rules say a passing market allows a change, and that the change must be **named in
+writing before anything moves**. This is that naming.
+
+Some background. The app scores each setup on several qualities. Two more qualities are
+"registered candidates" — measured, written down, not yet used. One of them, called
+**Relative move**, has been stuck for months: the rule for admitting a new quality asks
+whether the trader *picked* stocks that had it, and Relative move landed **0.06 percentage
+points** short of the line — a line the rule itself admits is a judgement call rather than a
+measurement. Nothing could move it, because the same test kept landing in the same place.
+
+This run asks a different question of it: not "did he pick these stocks" but **"did these
+stocks make money"**. And on Jakarta, it's the one clear positive in the entire study:
+
+| market | quality | with it | without it | difference | verdict |
+| --- | --- | ---: | ---: | ---: | --- |
+| US | RS line | −0.099R | +0.092R | −0.191R | no evidence |
+| US | Relative move | +0.098R | −0.298R | +0.396R | no evidence |
+| IDX | RS line | +1.066R | +0.541R | +0.525R | no evidence |
+| IDX | **Relative move** | **+0.852R** | **−1.075R** | **+1.927R** | **predicts** |
+
+Jakarta setups with Relative move earned +0.852R. The ones without it lost 1.075R. That's
+a gap of nearly two full R, and it's the only one in the table statistically clear of zero.
+
+**So: the change this allows is to settle Relative move's stuck threshold, on Jakarta,
+using outcomes.** With four limits attached, all binding:
+
+- **Jakarta only.** The same quality shows nothing on the US.
+- **It still goes through the normal evidence rule** for changing anything in the app. An
+  outcome result is evidence entering that process, not a way around it.
+- **It is not an automatic admission.** The admission rule asks a different question, and
+  the two don't convert into each other. What's allowed is *settling the threshold*, not
+  overruling it.
+- **It's allowed, not done.** Nothing has moved. Doing it is a separate piece of work.
+
+## What else the run found
+
+**Of everything the detector shows you, how much is any good?** This is the question the
+earlier study literally could not answer. Now it can:
+
+| | US | IDX |
+| --- | ---: | ---: |
+| Setups named | 96,914 | 12,821 |
+| Of those, how many actually broke out | 12.8% | 9.5% |
+| Of those, how many closed in profit | 3.1% | 2.4% |
+| Of the trades actually taken, how many won | 24.4% | 25.3% |
+
+Those bottom two rows are the same trades measured against different denominators, and the
+difference is the point. **About one setup in thirty-two closes green** — that sounds
+terrible until you notice that the thirty-one others mostly never trigger at all, and a
+setup that never triggers costs nothing. Of the trades you'd actually be *in*, about one in
+four wins. That's normal for this style: the winners are big enough to carry the losers.
+
+**Does the star score predict which setups run? No evidence that it does — in either
+market.** The score does one thing reliably: the *worst*-scoring US setups are reliably bad
+(−0.335R, clearly below zero, over 2,608 trades). Above that floor it doesn't order
+anything, and in both markets the *top* band is not the best band. So the honest description
+is **"it filters, it doesn't rank"** — which is a narrower claim than the app currently
+makes. Note carefully: "no evidence it ranks" is not "it doesn't rank". One study can't
+prove that.
+
+**Is the app's market-condition advice right?** The app tells you to "sit out" in a
+`HOSTILE` market and trade "reduced" in a `CHOPPY` one, and until now that was written on
+no evidence at all. The run priced it, and the answer is *undecided in both markets, and
+the two markets disagree*:
+
+- On the US, sitting out `HOSTILE` would have saved **450.6R** over 2,924 trades. The word
+  points the right way.
+- On Jakarta, sitting out `HOSTILE` would have **cost 95.0R**. There, `HOSTILE` was the
+  middle state, not the worst one.
+- "Reduced" for `CHOPPY` isn't supported either way. On the US `CHOPPY` was actually
+  *slightly better* than the friendly state.
+
+Neither result is statistically clear, so the run leaves the app's wording as unfounded as
+it found it. But it does establish that the same word isn't earning the same thing in the
+two markets, which is itself worth knowing.
+
+## What this cannot say
+
+These limits were written down before the run, not after it. A limitation named in advance
+is a caveat; one discovered afterwards is a retraction.
+
+- **It can't say what the trader would have done.** It takes everything the detector names,
+  mechanically. He picked. Nobody knows what he'd have skipped.
+- **It can't see inside a trading day.** Everything is decided on daily closing prices.
+- **It can't tell you whether you could actually run this with real money.** This is a
+  *signal-level* study: it takes every setup independently, with unlimited capital and no
+  limit on how many positions are open at once. So it says nothing about how much money the
+  method could absorb, how many trades pile up at the same time, how deep the losing
+  stretches get, or what happens when all the winners arrive together — which, in a momentum
+  method, is exactly what they do. That question is **deferred rather than dismissed**: it's
+  specified and waiting, not answered.
+- **It can't bring back the delisted companies.** It can only put a bound on how much their
+  absence flatters the result, which is what the second money column does.
+
+And three more this run added to the list. It **can't test a looser volatility filter**,
+because it never generated the setups that filter excludes — answering that needs a fresh
+run, not a query. It **can't compare Jakarta setups against the trader's picks**, because
+the trade record contains no Indonesian trades at all. And it **can't settle the US**, which
+is the actual content of an inconclusive result rather than a gap to be closed by picking a
+friendlier variant.
+
+## Checking this yourself
+
+One command, from the top of the repository:
+
+```
+bash scripts/backtest_headline.sh
+```
+
+It prints both markets, both periods, each figure next to its missing-stocks correction,
+and the verdict in the words that were fixed in advance. It reads the committed result files
+under `references/` — so what it checks is that the recorded result and these documents
+still say the same thing. It tells you that on its first line.
+
+To recompute the numbers from the raw price data instead of reading them back, add
+`--from-store data/backtest.duckdb`. That needs the price database built first, which is
+about two hours of paced downloading and a gigabyte on disk — which is why it isn't in the
+repository.

--- a/references/backtest_findings-plain.md
+++ b/references/backtest_findings-plain.md
@@ -99,8 +99,9 @@ missing stock would have been a full losing trade**. That's the right-hand colum
 table. And here's the part that matters:
 
 > At 37.7%, the missing stocks would contribute six losing trades for every ten real ones.
-> That drags the result down by about 0.6R. **The US headline is +0.050R.** The correction
-> is more than ten times the effect.
+> That drags the average trade down by **0.413R**, from +0.050R to −0.363R. **The US headline
+> is +0.050R.** The correction is about eight times the size of the thing being measured, and
+> it points down.
 
 This is why the bound isn't a footnote. On the US, the size of what we can't see is larger
 than the thing we're trying to measure. Any positive US result here should be read as "we
@@ -191,8 +192,8 @@ earlier study literally could not answer. Now it can:
 | | US | IDX |
 | --- | ---: | ---: |
 | Setups named | 96,914 | 12,821 |
-| Of those, how many actually broke out | 12.8% | 9.5% |
-| Of those, how many closed in profit | 3.1% | 2.4% |
+| Of every setup named, how many actually broke out | 12.8% | 9.5% |
+| Of every setup named, how many closed in profit | 3.1% | 2.4% |
 | Of the trades actually taken, how many won | 24.4% | 25.3% |
 
 Those bottom two rows are the same trades measured against different denominators, and the

--- a/references/backtest_findings.md
+++ b/references/backtest_findings.md
@@ -537,8 +537,18 @@ produced it.
 | [`backtest_score_ranking.json`](backtest_score_ranking.json) | Outcomes by score band, per market and per year |
 | [`backtest_candidate_outcomes.json`](backtest_candidate_outcomes.json) | Both registered candidates against outcomes |
 | [`backtest_regime_posture.json`](backtest_regime_posture.json) | Expectancy per regime state, and both counterfactuals |
-| [`backtest_full_run.json`](backtest_full_run.json) | The denominator itself — sessions, detections, coverage |
+| [`backtest_full_run.json`](backtest_full_run.json) | The run *over* the denominator — sessions persisted and measured, detections per market and per session, the references each market excluded, and the anchor gate it passed |
 | [`backtest_anchors.json`](backtest_anchors.json) | Phase 6's table, as it settled |
+
+**Two things this table does not hold, and the distinction matters to anyone reproducing.**
+The **bar store** (`data/backtest.duckdb`, 1.1GB) and the **denominator store** beside it
+(`data/backtest.duckdb.denominator.duckdb`, 446MB) are what *the denominator* names — one
+persisted row per session per market, carrying universe membership, the regime state with its
+companions, the rank table, and every detection with its full record and score breakdown.
+`.gitignore` keeps both out of the repository, so every figure above is committed and the rows
+underneath them are not. Rebuilding them is the `backtest.crawl` / `backtest.full_run` pair
+[above](#reproducing-this); `backtest_full_run.json` is the *report* that run printed, not the
+rows it read.
 
 Their printed pages sit beside them as `.txt`, and the prose companions to individual
 measurements are [`backtest_survivorship.md`](backtest_survivorship.md),

--- a/references/backtest_findings.md
+++ b/references/backtest_findings.md
@@ -1,0 +1,544 @@
+# The out-of-sample backtest — findings
+
+**Study:** every setup the detector names, taken mechanically, across two markets and
+fourteen years ([the plan](../docs/out-of-sample-backtest-plan.md), PRD #182).
+**Scope:** US and IDX, 2012-01-01 through each market's latest complete session, reported
+separately throughout. Long breakout, end-of-day, **signal level**.
+**Status of the app:** unchanged. No constant in `detection.py`, `score.py`, `universe.py`,
+`ranks.py` or `relative_strength.py` is touched by this run or by this write-up. One change is
+*licensed* by it and named below; naming it is what the contract required, and spending it is
+a separate ticket.
+
+**A plain-language version of this document** — same numbers, same conclusions, no assumed
+vocabulary — is at [`backtest_findings-plain.md`](backtest_findings-plain.md). This file
+remains the authority: its figures are the ones checked against the committed run output.
+
+[`qullamaggie-replay-findings.md`](qullamaggie-replay-findings.md) measured 828 entries a
+trader **took**, which is why its §9 reports no precision and no false-positive rate: it had a
+numerator and no denominator. This run built the denominator. It answers what that study could
+not — does the *method* have an edge, or did the *trader*?
+
+> **Every magnitude below is measured**, against `data/backtest.duckdb` — 15.1M bars, US
+> 5,495 symbols and IDX 840, 2011-01-03 onward, crawled 2026-08-26 (#187) and replayed forward
+> in one unbroken pass per market (#198). 96,914 US detections over 3,682 measured sessions and
+> 12,821 IDX over 3,542. The figures were readable only because all six of
+> [Phase 6](#the-anchors)'s anchors settled first. Nothing here is projected; where a number is
+> absent it is because the measurement is impossible, and it says so.
+
+---
+
+## The headline, and its bound
+
+**One pre-registered metric, fixed before any code ran**: arm B's after-cost expectancy in R,
+per market, per year. Arm B is the pure 10MA trail — the reference set's primary exit, so the
+headline stays comparable to it. Both windows are reported because the sample contains a
+crash and a mania: the full window, and the same window with 2020–21 taken out.
+
+Each figure is printed beside its **pessimistic twin** — the same metric re-run with the
+survivorship hole assigned a full stop-out. The twin is not a footnote and never was. On the
+US it is larger than the effect the run is looking for.
+
+| | window | expectancy | pessimistic | trades | symbols |
+| --- | --- | ---: | ---: | ---: | ---: |
+| **US** | full | **+0.050R** | **−0.363R** | 12,311 | 1,631 |
+| **US** | excluding 2020–21 | **−0.081R** | **−0.446R** | 9,092 | 1,396 |
+| **IDX** | full | **+0.680R** | **+0.418R** | 1,196 | 247 |
+| **IDX** | excluding 2020–21 | **+0.284R** | **+0.072R** | 986 | 225 |
+
+Costs are charged both sides at the contract's per-market rates — 0bps commission + 5bps
+slippage per side on the US, 15bps + 25bps on IDX. Intervals are a 2,000× bootstrap
+**clustered by symbol**, because a stock throwing three signals in a fortnight contributes
+three correlated rows and row-counting the significance flatters every p-value.
+
+**The bias bound, stated here rather than later.** The two markets' holes were counted by
+different instruments and are not the same quality of number:
+
+- **US — 37.7%**, weighted by how long each missing name was listed (51.8% by raw name count),
+  measured against a dated listing spine of 96 archived Nasdaq Trader captures. At that weight
+  the missing population contributes 0.605 trades for every covered trade, each a full stop, so
+  **the pessimistic twin is negative for any headline below +0.605R** — a figure no breakout
+  expectancy in this repo comes near. On the US the bound does not qualify the headline; it
+  exceeds it.
+- **IDX — 12.7%**, counted from the enumeration side, because no free source reconstructs a
+  dated Jakarta roster. It is neither exposure-weighted nor separated from recycled tickers, so
+  **IDX's bound is optimistic in a known direction: the true bound can only be lower.** Its
+  recycled half is reported *unmeasured* rather than zero — "we could not tell" and "there are
+  none" are opposite findings.
+
+**The markets are never pooled**, here or anywhere below. Findings §8 measured that shapes
+travel between US and IDX and magnitudes do not, so a combined figure would describe neither.
+There is no total in this document to read.
+
+## The verdict, in the words the contract fixed in advance
+
+Both criteria were written into [Phase 0](../docs/out-of-sample-backtest-plan.md#phase-0--the-run-contract)
+before a line of the run existed, and each carries the change it licenses, so the decision was
+made then rather than in the moment. Evaluated by `python -m backtest.verdict`; the payload is
+[`backtest_verdict.json`](backtest_verdict.json).
+
+**The kill did not fire.** It is global by design — it needs *both* markets at or below zero
+on *both* windows, because findings §8 says magnitudes do not transfer, so one market failing
+is evidence about that market rather than about the method. The US is +0.050R on the full
+window and Jakarta is positive on both.
+
+**US — inconclusive.** +0.050R on the full window and −0.081R with 2020–21 excluded: positive
+on one window and not the other, so it neither ships nor fails. What it licenses, verbatim:
+
+> nothing. The run is reported as inconclusive, and reaching for a swept variant to break the
+> tie is the failure mode the contract exists to prevent
+
+That clause has a live temptation behind it. A score floor of 4 lifts the US to +0.153R on the
+full window — one of eight variants tried, and itself +0.007R once 2020–21 comes out. It is not
+in the verdict and it does not break the tie.
+
+**IDX — ship**, and it is the only market anything is licensed in. +0.680R and +0.284R across
+the two windows, with the pessimistic bound holding at +0.418R and +0.072R. What it licenses,
+verbatim:
+
+> the change this licenses is named in the write-up before any constant moves, and goes through
+> the calibration rule (findings §7) like any other; it is licensed only in the market that
+> passed
+
+**Read the second IDX window before quoting the first.** +0.072R is thin, it is the figure the
+ship criterion actually turns on, and it rides on the weaker of the two bounds. The verdict
+carries that caveat on the market's own block rather than in a note, and this document does the
+same.
+
+**Why the kill line is drawn on the survivor-biased number and the ship line is not.**
+Survivorship inflates in a known direction, so a failure on the biased figure is decisive — the
+honest number can only be worse. A *pass* proves much less, which is why ship has to clear the
+bound and kill does not.
+
+## The change this licenses
+
+The ship verdict's own condition is that the change be **named in the write-up before any
+constant moves**. This is that naming. Nothing in the app moved to earn it and nothing moves
+here.
+
+**The change: settle `Relative move`'s admission threshold, on IDX, against outcomes.**
+
+ADR 0005 admits a candidate dimension on a **selection contrast** — did he pick names the
+dimension fires on — because when the rule was written no outcome variable existed. `Relative
+move` was measured on both fields and then stalled: it landed **0.06pp inside** a threshold the
+ADR itself calls a judgement rather than a measurement, and nothing has shipped and no third
+candidate has registered since. That threshold cannot be settled by the contrast that keeps
+colliding with it.
+
+This run gives the same dimension an outcome variable, and on IDX it is the one cell in the
+whole matrix that comes back **predicts**: a hit-minus-miss gap of **+1.927R** with a
+symbol-clustered interval of [+0.57, +3.14] entirely above zero, on 1,087 hits against 92
+misses ([below](#do-the-registered-candidates-predict-or-only-select)). It is also the only
+market that ships, which is the coincidence that makes the licence usable rather than merely
+interesting.
+
+Four limits on the licence, all of them binding:
+
+- **It is licensed only in the market that passed.** Nothing here licenses a `Relative move`
+  change on the US, where the same dimension returns no evidence it predicts.
+- **It goes through the calibration rule** — ADR 0002, as findings §7 restates it — like any
+  other change. An outcome result is evidence entering that rule, not a bypass around it.
+- **It is not an ADR 0005 admission.** That rule's instrument is the selection contrast; an
+  outcome claim is a different claim about the same dimension and neither converts into the
+  other. What this licenses is *settling the threshold*, not overriding it.
+- **It is licensed, not spent.** No weight moved, the rubric is still v3, and the register is
+  unchanged. Spending it is a separate ticket with its own evidence rule.
+
+---
+
+## What was measured, and how
+
+**Point-in-time throughout.** Every value entering a decision is computed from bars at or
+before that decision's session — universe gates and regime at t−1, the entry filled the session
+after the trigger. A look-ahead bug produces a beautiful equity curve and no error message, so
+the claim is held by a test that shifts a future bar into an entry decision and asserts the
+result is unchanged, not by care.
+
+**The universe is the contract's, not the app's.** Three gates measured through t−1 — close >
+SMA50, ADTV ≥ $10M (US) or Rp 10B (IDX) as a 20-day median, ADR20 ≥ 3.5% — plus a Rp 100
+nominal-price trim on IDX. That trim is **data validity, not cost control**: below it Jakarta
+quotes hit the tick grid hard enough that range geometry stops meaning what it means elsewhere.
+It is not a penny-stock filter and carries no implied cost story.
+
+Two consequences worth stating before any count is read. The contract's universe is
+**stateless** where the app's carries a hysteresis band, so names oscillating around the
+liquidity floor churn in and out day by day — nearly free at signal level, where each signal is
+evaluated on its own session, and a real difference at portfolio level. And the SMA50 gate
+**overlaps the detector's own trend logic**, so detection counts fall against an unfiltered run:
+that is the gate working, not the detector becoming more selective.
+
+**Regime conditions and never filters.** Nothing is excluded by regime anywhere in the run;
+every state got to trade, and each state's expectancy is measured rather than assumed. That is
+what makes the counterfactual below arithmetic instead of a model.
+
+**Three exit arms off one entry and one stop** — A (half off at day 5, remainder on a 10MA
+trail), B (pure 10MA trail), C (pure 20MA trail) — so any difference between them is
+attributable to the exit alone. Arm B is the headline and the only arm the verdict reads.
+
+## The denominator — precision, at last
+
+The figures no prior study in this repo could produce, because none had a control group.
+Committed at [`backtest_figures.json`](backtest_figures.json), printed at
+`backtest_figures.txt`.
+
+| | US | IDX |
+| --- | ---: | ---: |
+| Measured sessions | 3,682 | 3,542 |
+| Detections | 96,914 | 12,821 |
+| Detections per session | 26.3 | 3.6 |
+| **The share that trigger** | **12.8%** (12,362 of 96,830) | **9.5%** (1,203 of 12,727) |
+| Never broke — asked, and the market said no | 84,468 | 11,524 |
+| Undecided — the bars could not answer | 84 | 94 |
+| **Precision, arm B** | **3.1%** (3,010 of 96,779) | **2.4%** (302 of 12,720) |
+| Win rate, arm B | 24.4% (3,010 of 12,311) | 25.3% (302 of 1,196) |
+
+**That is the false-positive rate findings §9 could not report**, and #149 could only record
+as *volume carrying no verdict*. Roughly one detection in eight trades at all, and about one in
+thirty-two closes green before costs. Read the two rates as the different questions they are:
+the detector names thirty-two setups for every one that pays, and the trader who takes all
+thirty-two wins on one trade in four, because the ones it never asks about never cost anything.
+
+**Detections per session are not stable across the window** — the US runs 7.7 per session in
+2012 against 73.7 in the eight months of 2026, and IDX's tall 2020 cell is the same volatility
+arriving in a second market rather than a like-for-like magnitude. Read the panels for shape,
+not for level. **No month in either market is a hole**: 176 months each, all covered.
+
+## What the third arm buys
+
+Arm A takes half the position off at the close of day 5 and trails the rest — the trader's own
+documented behaviour, and the one arm with no counterpart in the reference set. It trades tail
+for hit rate **by construction**, so the question Phase 5 asks is whether it raises expectancy
+or merely smooths it. Those are different results and only one of them is a reason to adopt it.
+
+The hit-rate half is visible before any expectancy is read: precision runs 3.6% / 3.1% / 2.6%
+on the US for arms A / B / C and 2.8% / 2.4% / 2.2% on IDX, with the win rate ordering the same
+way (28.4% / 24.4% / 20.6% on the US). The longer the trail, the fewer trades close green and
+the larger the survivors have to be.
+
+The expectancy half, **before costs** — the arms are simulated ahead of the phase that charges
+commission and slippage, so these are not comparable to the headline and are not a second
+headline. Payloads at [`backtest_arms_US.json`](backtest_arms_US.json) and
+[`backtest_arms_IDX.json`](backtest_arms_IDX.json):
+
+| arm | US, per trade | IDX, per trade |
+| --- | ---: | ---: |
+| A — half off day 5, remainder trailed | +0.096R (n=12,311) | +0.683R (n=1,196) |
+| B — 10MA trail | +0.096R (n=12,311) | +1.062R (n=1,196) |
+| C — 20MA trail | +0.279R (n=12,283) | +1.002R (n=1,194) |
+
+**Arm A smooths; it does not raise expectancy.** It matches arm B on the US to three decimals
+and gives up 0.379R per trade on IDX, in exchange for the four-point-higher hit rate above.
+Taking half off at day 5 sells exactly the part of the distribution the method lives on, which
+is what a momentum method's own arithmetic predicts and is now measured rather than assumed.
+
+**Arm C is the best US arm here, and that changes nothing.** The pre-registered metric is arm B
+alone, chosen before the run because it is the reference set's primary exit and keeps the
+headline comparable. Promoting arm C on this table would be the same failure mode as promoting
+a swept threshold, arriving through a different door — three arms are three views of one
+dataset before any threshold is swept. The result is recorded as what it is: a question worth a
+run of its own, with its own contract.
+
+Two rates that are routinely quoted as one, kept apart here because they differ in the
+denominator and the difference is the point. **Precision** is favourable outcomes over every
+*answered* detection, the ones that never broke included — a figure about the **detector**: of
+everything it named, what share paid. **The win rate** is favourable outcomes over the trades
+actually taken — a figure about the **exit**, and the one comparable to the reference set's own
+shape, where 22.7% of his trades made money and the mean R was positive anyway. A method with a
+24% win rate is not broken; a method with a 24% win rate and no right tail is.
+
+Every rate carries its coverage, and two ways of deflating one silently are refused by
+construction. **A detection the bars cannot answer is not a miss** — one sitting on the last
+session of the window has not failed to trigger, nothing has asked it yet — so the trigger
+share's denominator is the decided detections only. **A trade still running is not a loss**;
+closing it at the last available close would invent an exit the rules never gave,
+systematically, for every name open when the window ended, so an open trade leaves precision's
+denominator and is counted separately. Both errors push the same way — they make the method look
+worse — which is the direction nobody investigates.
+
+The denominator figures are computed **before costs**, and the payload carries `costs_applied:
+false` beside every one of them. The overstatement is larger on IDX, where the contract's fees
+and spread are an order of magnitude above the US's.
+
+## Does the rubric rank, out of sample?
+
+**No evidence it ranks, in either market.** Full working in
+[`backtest_score_ranking.md`](backtest_score_ranking.md), payload at
+[`backtest_score_ranking.json`](backtest_score_ranking.json).
+
+| | trades | symbols | gap, bottom → top | Spearman's rho | verdict |
+| --- | ---: | ---: | ---: | ---: | --- |
+| US | 12,350 | 1,637 | +0.461R [−0.38, +1.60] | +0.038 [+0.02, +0.06] | no evidence it ranks |
+| IDX | 1,201 | 249 | −0.191R [−1.72, +1.54] | +0.075 [+0.01, +0.13] | no evidence it ranks |
+
+The rule requires the gap **and** rho to have symbol-clustered intervals entirely above zero.
+In both markets rho clears and the gap does not, which is the exact case the rule was written
+to catch: a rho can be positive and negligible.
+
+Two things in the bands are worth more than the headline. **The top band is not the best band
+in either market** — the US peaks at 2.5★ and IDX peaks hard at 3.5★, and both fall at 4.0★. A
+rubric that ranks does not do that. And **the bottom US band is reliably bad**: −0.335R on
+2,608 trades across 889 symbols, interval entirely below zero, the only band in either market
+that clears zero downward. So the score separates the worst material from everything else and
+does not order anything above that floor. *Filters, does not rank* is the shape of these
+tables, and it is a narrower claim than the product's.
+
+**This is a null, not a refutation.** "No evidence it ranks" is never "the score does not
+rank": one sample cannot license that. And it is not findings §4a — that measured a rate of
+scores between his picks and the field, on the field v2's weights had been *fitted* to, at
+p = 0.055. This measures after-cost R by score band on trades nobody selected, so the outcome
+variable is independent of the weights. The two are never to be lined up as one.
+
+## Do the registered candidates predict, or only select?
+
+ADR 0005 admits a dimension on a selection contrast because outcomes were unavailable. They are
+available now. Committed at
+[`backtest_candidate_outcomes.json`](backtest_candidate_outcomes.json) and printed at
+`backtest_candidate_outcomes.txt`.
+
+| market | dimension | hit | miss | gap (hit − miss) | clustered 95% | verdict |
+| --- | --- | ---: | ---: | ---: | --- | --- |
+| US | `RS line` | −0.099R (n=2,705) | +0.092R (n=9,603) | −0.191R | [−0.45, +0.07] | no evidence it predicts |
+| US | `Relative move` | +0.098R (n=11,014) | −0.298R (n=1,217) | +0.396R | [−0.03, +0.77] | no evidence it predicts |
+| IDX | `RS line` | +1.066R (n=318) | +0.541R (n=874) | +0.525R | [−0.73, +1.89] | no evidence it predicts |
+| IDX | **`Relative move`** | **+0.852R (n=1,087)** | **−1.075R (n=92)** | **+1.927R** | **[+0.57, +3.14]** | **predicts** |
+
+One cell of four comes back positive, and it is [the one the ship
+licenses](#the-change-this-licenses). The US `Relative move` gap points the same way and does
+not clear — +0.396R on an interval that crosses zero at −0.03, which is a near miss and is
+reported as a miss.
+
+Three disciplines this table keeps, each of which would otherwise be misread:
+
+- **The verdict is the gap's alone**, because ADR 0005 admits a dimension as a boolean. The
+  rank correlation is reported beside it and excluded — and on the US it is *negative*
+  (−0.021), which is worth seeing next to a positive gap.
+- **The absent group is not a miss.** Detections whose candidate value is `NULL` — the question
+  was never asked, because the name had not listed six months back or a price was missing at an
+  anchor — get their own n and enter no gap. `Relative move`'s cut sits at **zero**, so an
+  absence coerced to a number would land exactly on the boundary and let the strictness of a
+  comparison decide a verdict nobody measured. What a shipped boolean would do with it is
+  reported separately and sets no verdict.
+- **This measurement admits no dimension and retires none.** It is not ADR 0005's instrument.
+  Neither candidate's weight, the rubric version, nor the register moved.
+
+## The regime posture, priced
+
+The app prints "sit out" for `HOSTILE` and "reduced" for `CHOPPY` today, on no measured basis
+at all. This is the measurement — the most product-relevant figure in the run. Payload at
+[`backtest_regime_posture.json`](backtest_regime_posture.json), printed at
+`backtest_regime_posture.txt`. State is the app's own, read off each market's index on the
+**detection session** (t−1) — the night the candidate was listed with its posture beside it.
+
+| state | US, full | US, excl. 2020–21 | IDX, full | IDX, excl. 2020–21 |
+| --- | ---: | ---: | ---: | ---: |
+| `FRIENDLY` | +0.070R (n=5,605) | −0.075R (n=3,783) | +1.502R (n=414) | +0.942R (n=330) |
+| `CHOPPY` | +0.177R (n=3,782) | −0.050R (n=2,916) | +0.207R (n=465) | −0.100R (n=377) |
+| `HOSTILE` | −0.154R (n=2,924) | −0.131R (n=2,393) | +0.300R (n=317) | +0.024R (n=279) |
+
+**"Sit out" for `HOSTILE` — undecided in both markets, and the point estimates disagree.**
+Sitting the state out would have changed the book by **+450.6R** over 2,924 US trades and by
+**−95.0R** over 317 IDX trades. On the US the word points the right way; on IDX `HOSTILE` was
+the middle state, not the worst, and sitting it out cost money. Neither interval decides it, so
+the run leaves the app's word as unfounded as it found it — but it does establish that the same
+word is not earning the same thing in the two markets.
+
+**"Reduced" for `CHOPPY` — undecided, and on the US the point estimate points the wrong way.**
+Judged against `FRIENDLY`, because "reduced" claims the state is worse to trade rather than
+unprofitable, `CHOPPY` came in **+0.107R better** than `FRIENDLY` on the US full window and
+−1.295R worse on IDX. A word that advises trading smaller in the state that paid slightly more
+is not supported by this run in either direction.
+
+Both verdicts are the **interval's, never the mean's**, and both are priced at **signal
+level**: sitting a state out here removes its trades and frees no capital, because this run has
+no shared position budget to redeploy. The figure is what the posture costs or saves directly,
+never what it might buy — which is a portfolio question and is deferred.
+
+**The two regime companions, reported and never conditioned on.** Breadth: median 49.1% (US)
+and 46.2% (IDX). It is the column survivorship corrupts most directly — worse in a backtest
+than live, because the names missing from the store are disproportionately the ones that later
+died — so it is descriptive only and gates nothing. Follow-through: the index broke out on
+22.5% of US sessions and 16.3% of IDX ones, and it is **unbiased where breadth is not**. The
+index series carries no survivorship hole, so this run could legitimately reconstruct across
+fourteen years the one regime signal the live app can never backfill.
+
+## The sweep, and why the headline stands
+
+Eight variants, swept **after** the pre-registered figure was computed and recorded — an
+ordering the code enforces rather than the convention asks for: `backtest.sweep` cannot run
+without a recorded headline to read off disk, and a sweep of a sweep is refused because it
+would report the second count and hide the first. Two axes: the contract's per-market costs at
+0.5×, 2× and 3×, and a floor on the replayed score at 3 through 7 of 8. Committed at
+[`backtest_sweep.json`](backtest_sweep.json).
+
+| | the pre-registered headline | the most flattering swept figure |
+| --- | ---: | --- |
+| US, full | +0.050R | +0.153R (score ≥ 4) |
+| US, excl. 2020–21 | −0.081R | +0.007R (score ≥ 4) |
+| IDX, full | +0.680R | +2.412R (score ≥ 7, n=183) |
+| IDX, excl. 2020–21 | +0.284R | +1.628R (score ≥ 7, n=136) |
+
+**None of these entered the verdict, and the headline stands against every one of them.** The
+IDX score ≥ 7 row is worth reading precisely as the illustration it is: +2.412R on 183 trades
+is what a winner-from-noise looks like, and the count of variants tried is printed beside it as
+a field rather than a number the reader has to reconstruct. Three exit arms and three regime
+states are already nine views of one dataset before any threshold is swept.
+
+**The detection gate is not swept**, and the payload says so. The denominator was built against
+the contract's four-lookback width, so a swept gate is a new crawl rather than a variant of this
+run.
+
+## The anchors
+
+The plan's third rule is *anchor before believing*: the run had to reproduce figures already
+committed to this repo, or explain the divergence in writing, before any new figure from it was
+read. All six settled — one matches and five diverge with a written cause. The table as it
+printed is at `backtest_anchors.txt`, the payload at
+[`backtest_anchors.json`](backtest_anchors.json), and the causes are set out in
+[`backtest_anchor_divergence.md`](backtest_anchor_divergence.md).
+
+The one that matches is the one built to detect drift from here on: `in_field` over the
+contract's stateless universe, **165 of 503, gap −5.01pp**. Getting there meant splitting that
+anchor into one pin per universe, because §4b's gap is a property of the pair (rubric,
+universe) — **+1.95pp under the app's universe, −5.01pp under the contract's** — so holding a
+stateless-universe run to the app-universe figure was a subtraction between two numbers that
+were never the same number. **No constant moved, no tolerance widened, and the sign check was
+not waived**; a stateless run coming back positive still fails.
+
+**Never cite findings §4b's gap without naming the field it was measured over.** That is the
+rule the split leaves behind, and it applies to every future quotation of that figure.
+
+## The caveats, carried with the same weight as the results
+
+- **Survivorship, and it is the big one.** The US hole is 37.7% exposure-weighted, which is
+  larger than the effect the run is looking for. Every US figure in this document should be
+  read as an upper bound on a quantity whose pessimistic twin is negative.
+- **The two bounds are not the same instrument.** The US bound rests on a dated listing spine;
+  IDX's is an enumeration-side count with its recycled half unmeasured, so it is optimistic in a
+  known direction. The market that ships is the market with the weaker bound.
+- **The spine's count is a floor.** Its captures are roughly annual, so a name that listed
+  *and* delisted between two of them appears in neither and is invisible to the count. The
+  largest gap between captures is 552 days.
+- **2020–21.** The tape rewarded momentum nearly everywhere. Every year is reported separately
+  and every window figure has its 2020–21-excluded twin beside it, which is why the US verdict
+  is inconclusive rather than positive.
+- **IDX is thin.** 1,196 closed trades over 247 symbols across fourteen years, against 12,311
+  over 1,631 on the US. The per-year IDX cells run to double digits and swing from −1.582R to
+  +3.495R; they are diagnostics, not measurements.
+- **`in_field` moves with the pair it is measured over**, and the stateless pin is a first
+  measurement made by this run, so it detects drift rather than confirming this run.
+- **Free adjusted EOD data.** Yahoo carries an *unlabelled* retroactive rescale for rights
+  issues — measured on BBRI, pre-2021-09-08 OHLC scaled by exactly 10/11 with no split or
+  dividend row to explain it. Geometry in ADR units is immune because both terms rescale
+  together; absolute prices are not, including IDX's Rp 100 trim.
+- **Cold start.** The contract's stateless universe has no hysteresis band, so this run and the
+  app disagree about names oscillating around the liquidity floor. Nearly free at signal level;
+  real at portfolio level; recorded rather than engineered away.
+
+## What this cannot say
+
+Named in advance, in [the plan](../docs/out-of-sample-backtest-plan.md#what-this-still-cannot-say),
+and restated here unchanged. A limitation named in advance is a caveat; one discovered
+afterwards is a retraction.
+
+Even run perfectly, this measures **the detector as encoded**, on **free adjusted EOD data**,
+over **one fourteen-year sample of two markets**, at **signal level**.
+
+- **It cannot say what he would have traded.** It measures the detector's names taken
+  mechanically, not a trader's selection from among them.
+- **It cannot recover intraday behaviour.** Every decision is made on a daily close; what
+  happened inside a session is invisible to it, including whether a stop that filled at the next
+  open would have filled there.
+- **It cannot speak to capacity, concurrency, drawdown path, or correlated clustering.** This is
+  signal level: every qualifying signal is taken independently and equal-weighted, with no
+  capital constraint, no concurrency cap and no position limit. In a momentum method the winners
+  arrive together, so the portfolio question is **deferred rather than dismissed** — specified in
+  the plan and not built.
+- **It cannot make the delisted names reappear.** It can only bound their absence, which is what
+  the pessimistic twin on every figure above is doing.
+
+Three narrower ones this run adds to the list. It **cannot sweep the ADR floor downward**,
+because the run never generated detections below the gate — answering that needs re-detection
+over a wider universe, which is a crawl rather than a query. It **cannot measure an IDX
+selection contrast**, because the trade record holds no IDX picks: on Jakarta only the field
+half of that comparison exists. And it **cannot settle the US**, which is the honest content of
+an inconclusive verdict rather than a gap to be closed by choosing a different variant.
+
+## Reproducing this
+
+**One command**, from the repository root:
+
+```
+bash scripts/backtest_headline.sh
+```
+
+It prints both markets, both windows, each figure beside its pessimistic twin, and the verdict
+in the words the contract fixed — read back from the payloads committed under `references/`.
+That path touches no bar, and it says so on its first line: what it checks is that the committed
+result and this document still agree.
+
+To recompute the figure from the bars themselves:
+
+```
+bash scripts/backtest_headline.sh --from-store data/backtest.duckdb
+```
+
+which re-runs the pre-registered metric, attaches Phase 2's bound, sweeps, and re-reaches the
+verdict. **That path was run against the store on 2026-08-27 and reproduced all four figures and
+both bounds exactly**, so the committed payloads are the ones the bars produce rather than a
+recording that has drifted from them.
+
+It needs the store built first, and the store is 1.1GB of bars that `.gitignore` keeps out of
+the repository:
+
+```
+python -m backtest.crawl                                    # ~2h, paced; goes to the network
+python -m backtest.full_run --store data/backtest.duckdb \
+    --anchors references/backtest_anchors.json
+```
+
+The window and the markets come from [`backtest_run_contract.json`](backtest_run_contract.json)
+rather than from the command line, so "the full run" is a fact about the contract instead of a
+set of dates someone has to retype correctly.
+
+**The other measurements**, each reproducing one section above:
+
+```
+python -m backtest.figures    --store data/backtest.duckdb --market US --market IDX
+python -m backtest.ranking    --store data/backtest.duckdb
+python -m backtest.candidates --store data/backtest.duckdb
+python -m backtest.posture    --store data/backtest.duckdb
+python -m backtest.simulate   --store data/backtest.duckdb --market US   # and --market IDX
+python -m backtest.survivorship --store data/backtest.duckdb   # --fetch-spine goes to the network
+```
+
+Each takes `--out-json` and writes a contract-stamped payload; the committed ones are listed
+below. `backtest.survivorship` without `--fetch-spine` reads the cached spine beside the store,
+so the count is reproducible from committed inputs rather than from a second 101-minute crawl of
+the Internet Archive.
+
+## The committed payloads
+
+Every figure above has one of these behind it, and each is stamped with the contract that
+produced it.
+
+| File | What it holds |
+| --- | --- |
+| [`backtest_run_contract.json`](backtest_run_contract.json) | The contract, fixed before any code ran |
+| [`backtest_primary_metric.json`](backtest_primary_metric.json) | The pre-registered headline, per market per year, with the bound attached |
+| [`backtest_survivorship.json`](backtest_survivorship.json) | The dated count of the hole, and the sensitivity |
+| [`backtest_verdict.json`](backtest_verdict.json) | The contract's criteria evaluated, with the licence on each market |
+| [`backtest_sweep.json`](backtest_sweep.json) | Eight variants, none of which entered the verdict |
+| [`backtest_figures.json`](backtest_figures.json) | Detections per session, the trigger share, precision |
+| [`backtest_arms_US.json`](backtest_arms_US.json), [`backtest_arms_IDX.json`](backtest_arms_IDX.json) | All three exit arms off one entry and one stop, before costs |
+| [`backtest_score_ranking.json`](backtest_score_ranking.json) | Outcomes by score band, per market and per year |
+| [`backtest_candidate_outcomes.json`](backtest_candidate_outcomes.json) | Both registered candidates against outcomes |
+| [`backtest_regime_posture.json`](backtest_regime_posture.json) | Expectancy per regime state, and both counterfactuals |
+| [`backtest_full_run.json`](backtest_full_run.json) | The denominator itself — sessions, detections, coverage |
+| [`backtest_anchors.json`](backtest_anchors.json) | Phase 6's table, as it settled |
+
+Their printed pages sit beside them as `.txt`, and the prose companions to individual
+measurements are [`backtest_survivorship.md`](backtest_survivorship.md),
+[`backtest_score_ranking.md`](backtest_score_ranking.md),
+[`backtest_anchor_divergence.md`](backtest_anchor_divergence.md),
+[`backtest_gate_isolation.md`](backtest_gate_isolation.md),
+[`backtest_idx_adr_floor.md`](backtest_idx_adr_floor.md) and
+[`backtest_store_coverage.md`](backtest_store_coverage.md).

--- a/references/backtest_findings.md
+++ b/references/backtest_findings.md
@@ -55,10 +55,15 @@ different instruments and are not the same quality of number:
 
 - **US — 37.7%**, weighted by how long each missing name was listed (51.8% by raw name count),
   measured against a dated listing spine of 96 archived Nasdaq Trader captures. At that weight
-  the missing population contributes 0.605 trades for every covered trade, each a full stop, so
-  **the pessimistic twin is negative for any headline below +0.605R** — a figure no breakout
+  the missing population contributes 0.605 trades for every covered trade, each a full stop.
+  That costs the US headline **0.413R**, taking +0.050R to −0.363R, and it means **the
+  pessimistic twin is negative for any headline below +0.605R** — a figure no breakout
   expectancy in this repo comes near. On the US the bound does not qualify the headline; it
-  exceeds it.
+  is eight times the size of it, and it points down.
+
+  The two numbers are different quantities and are easy to run together: **0.605 is a count**
+  (missing trades per covered trade) and **0.413R is the drag on the mean** that count
+  produces. Neither is the other.
 - **IDX — 12.7%**, counted from the enumeration side, because no free source reconstructs a
   dated Jakarta roster. It is neither exposure-weighted nor separated from recycled tickers, so
   **IDX's bound is optimistic in a known direction: the true bound can only be lower.** Its

--- a/references/backtest_regime_posture.json
+++ b/references/backtest_regime_posture.json
@@ -1,0 +1,1301 @@
+{
+ "contract": {
+  "contract_version": "1",
+  "label": "out-of-sample backtest \u2014 US+IDX, 2012 onward (PRD #182)",
+  "cells": [
+   {
+    "key": "scope.setups",
+    "value": "long_breakout_eod",
+    "justification": "Long breakout EOD setups only, so the run measures the same thing the reference set and the detector do (PRD story 7)."
+   },
+   {
+    "key": "scope.level",
+    "value": "signal_primary_portfolio_deferred",
+    "justification": "Signal level is declared primary and portfolio level specified but deferred, so the open question is answered without the capital model blocking it (story 8)."
+   },
+   {
+    "key": "scope.markets",
+    "value": [
+     "US",
+     "IDX"
+    ],
+    "justification": "US and IDX reported separately throughout, so findings \u00a78's result that magnitudes do not transfer is honoured rather than averaged away (story 4)."
+   },
+   {
+    "key": "window.measured_start",
+    "value": "2012-01-01",
+    "justification": "The measured window starts 2012-01-01 so the sample spans several regimes rather than one (story 5)."
+   },
+   {
+    "key": "window.measured_end",
+    "value": "latest_complete_session",
+    "justification": "The measured window runs to the latest complete session, so the sample extends as far as the data legitimately allows (story 5)."
+   },
+   {
+    "key": "window.store_start",
+    "value": "2011-01-01",
+    "justification": "The store window starts 2011-01-01 so the detector's 80-bar minimum history, the universe gates and the regime's 25-bar warm-up are all satisfied before the first measured session (story 6)."
+   },
+   {
+    "key": "universe.trend_gate",
+    "value": "close > SMA50",
+    "justification": "The trend gate is close > SMA50 on both markets, so the universe reflects the method's own precondition (story 10)."
+   },
+   {
+    "key": "universe.liquidity_floor",
+    "value": {
+     "US": 10000000.0,
+     "IDX": 10000000000.0
+    },
+    "justification": "Liquidity floors are $10M for US and Rp 10B for IDX \u2014 a deliberate contract value, not the app's inherited $20M / Rp 1B (story 11)."
+   },
+   {
+    "key": "universe.adtv",
+    "value": "median_20d_unadjusted_close_x_volume",
+    "justification": "ADTV is the 20-day median of unadjusted close \u00d7 volume, so one block trade cannot lift an illiquid name over the floor (story 12)."
+   },
+   {
+    "key": "universe.adtv_aggregator",
+    "value": "median",
+    "justification": "The aggregator is the median; a switch to mean is a deliberate act, so which spiky small caps qualify never changes by accident (story 13)."
+   },
+   {
+    "key": "universe.volatility_gate",
+    "value": "ADR20 >= 3.5%",
+    "justification": "The volatility gate is ADR20 \u2265 3.5%, set deliberately below the rubric's 5% floor so the ADR dimension is left with spread to test (story 14)."
+   },
+   {
+    "key": "universe.volatility_gap_reason",
+    "value": "gate_below_rubric_floor_is_deliberate",
+    "justification": "The gap below the rubric's 5% floor is recorded so nobody later 'fixes' it to match and silently destroys the thing being measured \u2014 findings \u00a76 Finding 2 measured the 5% floor withholding a score point from 31% of his real entries (story 15)."
+   },
+   {
+    "key": "universe.idx_price_floor",
+    "value": 100.0,
+    "justification": "A nominal price floor of Rp 100 on the split-corrected series excludes IDX names whose quotes hit the tick grid hard enough to distort ADR and range geometry (story 16)."
+   },
+   {
+    "key": "universe.idx_price_floor_role",
+    "value": "data_validity",
+    "justification": "The Rp 100 floor is data validity and never cost control, so no reader infers a penny-stock filter with an implied cost story (story 17)."
+   },
+   {
+    "key": "universe.statelessness",
+    "value": "stateless_gates_through_t_minus_1",
+    "justification": "The universe is stateless \u2014 three gates measured through t\u22121 with no reference to prior membership \u2014 a known difference from the app's hysteresis band whose boundary churn is nearly free at signal level and real at portfolio level (stories 9, 18, 19)."
+   },
+   {
+    "key": "universe.reference_exclusion",
+    "value": "exclude_index_and_benchmark_etfs",
+    "justification": "The five benchmark references stay out of the ranked field, pinned against the enumeration by a test, so this fresh build inherits the #162 fix rather than reproducing the contamination (stories 73, 74)."
+   },
+   {
+    "key": "detection.gate",
+    "value": [
+     "1m",
+     "3m",
+     "6m",
+     "12m"
+    ],
+    "justification": "The detection gate is the four-lookback width (detector v3, ADR 0003 amendment); the denominator is built against that width and it is not swept in the primary run (PRD Implementation Decisions)."
+   },
+   {
+    "key": "regime.source",
+    "value": "app_regime_off_market_index_at_t_minus_1",
+    "justification": "Regime is the app's own regime, unmodified, read off each market's own index at t\u22121 \u2014 so findings are actionable in the product and the conditioning input obeys the point-in-time rule (stories 21, 23)."
+   },
+   {
+    "key": "regime.role",
+    "value": "conditioning_variable_never_filter",
+    "justification": "Regime is a conditioning variable and never a filter: every state trades and each one's expectancy is measured instead of assumed (story 22)."
+   },
+   {
+    "key": "entry.rule",
+    "value": "detection_trigger_filled_next_session",
+    "justification": "Entry is taken at the detection's own trigger, filled the next session, so the simulated trade uses the detector's own decision rather than a second definition (story 31)."
+   },
+   {
+    "key": "stop.rule",
+    "value": "detection_stop_unmodified",
+    "justification": "The stop is the detection's own stop, used unmodified, so R is denominated the way the app denominates it (story 32)."
+   },
+   {
+    "key": "exit.arm_a",
+    "value": {
+     "scale_fraction": 0.5,
+     "scale_day": 5,
+     "trail_ma": 10,
+     "trail_live_from": "fill",
+     "arbitrary_mechanics": true
+    },
+    "justification": "Arm A scales 50% off at the close of the fifth session after entry and trails the remainder on a 10MA \u2014 the trader's documented behaviour; its R is two position-weighted legs summed, and 'day 5' and the trail are recorded as arbitrary (stories 34, 36, 37, 39). The trail is live from the fill rather than from the scale day, so a runner that rolls over before day 5 takes the whole position and the scale never happens; that is a third arbitrary choice and is recorded here rather than left in the code, so a later run can sweep it (story 39)."
+   },
+   {
+    "key": "exit.arm_b",
+    "value": {
+     "trail_ma": 10
+    },
+    "justification": "Arm B is a pure 10MA trail, directly comparable to the reference set's simulated exit and the arm the primary metric is computed on (story 35)."
+   },
+   {
+    "key": "exit.arm_c",
+    "value": {
+     "trail_ma": 20
+    },
+    "justification": "Arm C is a pure 20MA trail, the reference set's second simulated exit (story 35)."
+   },
+   {
+    "key": "exit.trail_mechanic",
+    "value": "close_through_ma_signals_fill_next_open",
+    "justification": "A trail signals on a close through the MA and fills at the next open, so the exit is point-in-time and reproducible; recorded as arbitrary so a later run can vary it deliberately (stories 38, 39)."
+   },
+   {
+    "key": "costs.per_market",
+    "value": {
+     "US": {
+      "commission_bps": 0.0,
+      "slippage_bps": 5.0
+     },
+     "IDX": {
+      "commission_bps": 15.0,
+      "slippage_bps": 25.0
+     }
+    },
+    "justification": "Commission and slippage are per-market contract values applied before any sweep, so IDX's real fees and spread are not modelled with US's near-zero assumptions; this pre-registered baseline is recorded here and swept variants are reported with the count of variants tried (story 40)."
+   },
+   {
+    "key": "metric.primary",
+    "value": "arm_b_after_cost_expectancy_r_per_market_per_year",
+    "justification": "The one pre-registered primary metric is arm B's after-cost expectancy in R, per market per year, so the headline cannot be chosen after the fact (story 41)."
+   },
+   {
+    "key": "decision.kill",
+    "value": {
+     "metric": "arm_b_after_cost_expectancy_r",
+     "comparator": "<=",
+     "threshold": 0.0,
+     "requires": [
+      "both_markets",
+      "full_window",
+      "and_excluding_2020_2021"
+     ],
+     "basis": "survivor_biased_number"
+    },
+    "justification": "Kill fires only when arm B's after-cost expectancy is \u2264 0 in both markets on the full window and with 2020\u201321 excluded, and the line is drawn on the survivor-biased number so a failure is decisive \u2014 the honest figure can only be worse (stories 42, 43)."
+   },
+   {
+    "key": "decision.ship",
+    "value": {
+     "requires": [
+      "positive_result",
+      "clears_phase2_pessimistic_bound"
+     ],
+     "scope": "per_market"
+    },
+    "justification": "Ship requires a positive result that also clears the Phase 2 pessimistic bound, scoped per market so a US pass licenses nothing in Jakarta (stories 44, 45)."
+   },
+   {
+    "key": "decision.one_market_failure",
+    "value": "method_stands_that_market_off_until_explained",
+    "justification": "A one-market failure is its own pre-named verdict: the method stands and that market is off until a run explains the difference, so it is not improvised in the moment (story 46)."
+   },
+   {
+    "key": "decision.inconclusive",
+    "value": "report_inconclusive_no_swept_tiebreak",
+    "justification": "An inconclusive run is reported as inconclusive; reaching for a swept variant to break the tie is ruled out by the contract that exists to prevent it (story 47)."
+   },
+   {
+    "key": "decision.licensed_changes",
+    "value": "write_licensed_change_before_any_constant_moves",
+    "justification": "Each verdict's licensed change is written down before any constant moves, so a result cannot be converted into an unguarded edit (story 48)."
+   }
+  ]
+ },
+ "regime_source": "app_regime_off_market_index_at_t_minus_1",
+ "regime_role": "conditioning_variable_never_filter",
+ "state_read_at": "detection_session",
+ "state_read_at_note": "the detection session \u2014 the night the candidate was listed with the app's posture beside it, one session before the break that signals entry and two before the fill; no bar after it is read to date the trade",
+ "arm": "B",
+ "states": [
+  "FRIENDLY",
+  "CHOPPY",
+  "HOSTILE",
+  "UNDEFINED"
+ ],
+ "per_year": "states are reported over the full window and with 2020\u201321 excluded, not per year: three states crossed with fourteen years is mostly cells below the bootstrap's cluster floor, and 2020\u201321 is the stretch that would inflate FRIENDLY specifically \u2014 which is the time-slice this cell needs",
+ "views": "three exit arms and three regime states is nine views of one dataset before any threshold is swept; the pre-registered metric stands as the headline even where a view here looks better",
+ "bootstrap": {
+  "cluster": "symbol",
+  "resamples": 2000,
+  "seed": 191,
+  "confidence": 0.95
+ },
+ "markets": [
+  {
+   "market": "US",
+   "index": "^IXIC",
+   "arm": "B",
+   "states": [
+    {
+     "state": "FRIENDLY",
+     "basis_counts": {
+      "measured": 5619,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "FRIENDLY full",
+       "trades": 5619,
+       "closed": 5605,
+       "open_at_end": 14,
+       "undenominated": 0,
+       "symbols": 1270,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.07026877102120678,
+       "expectancy_r_before_cost": 0.11635829843016844,
+       "cost_r": 0.04608952740896167,
+       "win_rate": 0.24210526315789474,
+       "wins": 1357,
+       "losses": 4248,
+       "total_r": 393.856461573864,
+       "distribution": {
+        "min": -30.675226550617438,
+        "p10": -3.4799884684951143,
+        "q1": -2.356639544783779,
+        "median": -1.4165599241396003,
+        "q3": -0.03446094147732655,
+        "p90": 4.989817524709988,
+        "max": 141.8356198363432,
+        "mean_win": 6.938172497207264,
+        "mean_loss": -2.1236449192882283
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1265,
+        "observations": 5605,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.12967432436081733,
+        "ci_high": 0.2593373451167698,
+        "p_value": 0.2345
+       },
+       "state": "FRIENDLY"
+      },
+      {
+       "label": "FRIENDLY excluding_2020_2021",
+       "trades": 3797,
+       "closed": 3783,
+       "open_at_end": 14,
+       "undenominated": 0,
+       "symbols": 1028,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.07500755329966326,
+       "expectancy_r_before_cost": -0.026403600004762592,
+       "cost_r": 0.04860395329490067,
+       "win_rate": 0.23420565688606926,
+       "wins": 886,
+       "losses": 2897,
+       "total_r": -283.7535741326261,
+       "distribution": {
+        "min": -26.898528101632703,
+        "p10": -3.468014387328032,
+        "q1": -2.3289149337339214,
+        "median": -1.412269848571906,
+        "q3": -0.048956836957551375,
+        "p90": 4.6071416842575355,
+        "max": 72.52665594916905,
+        "mean_win": 6.508472373494871,
+        "mean_loss": -2.0884570580079673
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1023,
+        "observations": 3783,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.2790774202614727,
+        "ci_high": 0.13755136911425173,
+        "p_value": 0.7585
+       },
+       "state": "FRIENDLY",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 5619
+    },
+    {
+     "state": "CHOPPY",
+     "basis_counts": {
+      "measured": 3802,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "CHOPPY full",
+       "trades": 3802,
+       "closed": 3782,
+       "open_at_end": 20,
+       "undenominated": 0,
+       "symbols": 1153,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.1770726114665508,
+       "expectancy_r_before_cost": 0.22485619967257914,
+       "cost_r": 0.04778358820602838,
+       "win_rate": 0.23611845584346908,
+       "wins": 893,
+       "losses": 2889,
+       "total_r": 669.688616566495,
+       "distribution": {
+        "min": -35.977822684303476,
+        "p10": -3.3182416345090284,
+        "q1": -2.2167047004809666,
+        "median": -1.3586514921802815,
+        "q3": -0.044792426953860806,
+        "p90": 5.187969474549157,
+        "max": 108.85396708300148,
+        "mean_win": 7.232675473561956,
+        "mean_loss": -2.00383889973151
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1148,
+        "observations": 3782,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.04841475225015531,
+        "ci_high": 0.42816077690948573,
+        "p_value": 0.0685
+       },
+       "state": "CHOPPY"
+      },
+      {
+       "label": "CHOPPY excluding_2020_2021",
+       "trades": 2936,
+       "closed": 2916,
+       "open_at_end": 20,
+       "undenominated": 0,
+       "symbols": 969,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.04966083758795524,
+       "expectancy_r_before_cost": -0.00021363080496295857,
+       "cost_r": 0.049447206782992276,
+       "win_rate": 0.22325102880658437,
+       "wins": 651,
+       "losses": 2265,
+       "total_r": -144.81100240647748,
+       "distribution": {
+        "min": -35.977822684303476,
+        "p10": -3.3965946774999285,
+        "q1": -2.258482907118994,
+        "median": -1.406701868500237,
+        "q3": -0.06535244701976609,
+        "p90": 4.710214633109677,
+        "max": 108.85396708300148,
+        "mean_win": 6.85607137137858,
+        "mean_loss": -2.0344871810922442
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 963,
+        "observations": 2916,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.2917996137368208,
+        "ci_high": 0.2140274020973413,
+        "p_value": 0.6535
+       },
+       "state": "CHOPPY",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 3802
+    },
+    {
+     "state": "HOSTILE",
+     "basis_counts": {
+      "measured": 2929,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "HOSTILE full",
+       "trades": 2929,
+       "closed": 2924,
+       "open_at_end": 5,
+       "undenominated": 0,
+       "symbols": 1005,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.1541095384601298,
+       "expectancy_r_before_cost": -0.10779009115115563,
+       "cost_r": 0.04631944730897416,
+       "win_rate": 0.2506839945280438,
+       "wins": 733,
+       "losses": 2191,
+       "total_r": -450.61629045741955,
+       "distribution": {
+        "min": -79.84078091028827,
+        "p10": -3.451247979655914,
+        "q1": -2.2908450009013386,
+        "median": -1.2697025728669724,
+        "q3": 0.02388849874793498,
+        "p90": 4.135838397721287,
+        "max": 91.84238367531734,
+        "mean_win": 5.620116496886719,
+        "mean_loss": -2.0858793622434435
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 1004,
+        "observations": 2924,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.4053776321513088,
+        "ci_high": 0.11426870219416602,
+        "p_value": 0.888
+       },
+       "state": "HOSTILE"
+      },
+      {
+       "label": "HOSTILE excluding_2020_2021",
+       "trades": 2398,
+       "closed": 2393,
+       "open_at_end": 5,
+       "undenominated": 0,
+       "symbols": 861,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.1305129062092198,
+       "expectancy_r_before_cost": -0.08239585461049685,
+       "cost_r": 0.04811705159872294,
+       "win_rate": 0.2574174676138738,
+       "wins": 616,
+       "losses": 1777,
+       "total_r": -312.317384558663,
+       "distribution": {
+        "min": -79.84078091028827,
+        "p10": -3.4545118738593295,
+        "q1": -2.291382748128933,
+        "median": -1.2420126169243004,
+        "q3": 0.1593186723500037,
+        "p90": 4.2715879255918985,
+        "max": 91.84238367531734,
+        "mean_win": 5.503885001776939,
+        "mean_loss": -2.0836862946838814
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 860,
+        "observations": 2393,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.3887895722260207,
+        "ci_high": 0.16945029027847386,
+        "p_value": 0.8055
+       },
+       "state": "HOSTILE",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 2929
+    },
+    {
+     "state": "UNDEFINED",
+     "basis_counts": {
+      "measured": 0,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "UNDEFINED full",
+       "trades": 0,
+       "closed": 0,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 0,
+       "price_scale_dropped": 0,
+       "expectancy_r": null,
+       "expectancy_r_before_cost": null,
+       "cost_r": null,
+       "win_rate": null,
+       "wins": 0,
+       "losses": 0,
+       "total_r": 0,
+       "distribution": {
+        "min": null,
+        "p10": null,
+        "q1": null,
+        "median": null,
+        "q3": null,
+        "p90": null,
+        "max": null,
+        "mean_win": null,
+        "mean_loss": null
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 0,
+        "observations": 0,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": "0 symbols is fewer than 5: too thin for an interval, and a degenerate one would read as significance",
+        "ci_low": null,
+        "ci_high": null,
+        "p_value": null
+       },
+       "state": "UNDEFINED"
+      },
+      {
+       "label": "UNDEFINED excluding_2020_2021",
+       "trades": 0,
+       "closed": 0,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 0,
+       "price_scale_dropped": 0,
+       "expectancy_r": null,
+       "expectancy_r_before_cost": null,
+       "cost_r": null,
+       "win_rate": null,
+       "wins": 0,
+       "losses": 0,
+       "total_r": 0,
+       "distribution": {
+        "min": null,
+        "p10": null,
+        "q1": null,
+        "median": null,
+        "q3": null,
+        "p90": null,
+        "max": null,
+        "mean_win": null,
+        "mean_loss": null
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 0,
+        "observations": 0,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": "0 symbols is fewer than 5: too thin for an interval, and a degenerate one would read as significance",
+        "ci_low": null,
+        "ci_high": null,
+        "p_value": null
+       },
+       "state": "UNDEFINED",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 0
+    }
+   ],
+   "counterfactual": {
+    "state": "HOSTILE",
+    "posture": "sit out",
+    "judged_against": "zero",
+    "judged_against_note": "the word instructs no trade at all, so the comparison is with not trading rather than with another state",
+    "trades": 2929,
+    "closed": 2924,
+    "expectancy_r": -0.1541095384601298,
+    "total_r": -450.61629045741955,
+    "delta_total_r": 450.61629045741955,
+    "delta_expectancy_r": 0.06351270089018102,
+    "effect": "saved",
+    "verdict": "undecided",
+    "bootstrap": {
+     "cluster": "symbol",
+     "clusters": 1004,
+     "observations": 2924,
+     "resamples": 2000,
+     "seed": 191,
+     "confidence": 0.95,
+     "min_clusters": 5,
+     "suppressed": null,
+     "ci_low": -0.4053776321513088,
+     "ci_high": 0.11426870219416602,
+     "p_value": 0.888
+    },
+    "book": {
+     "all": {
+      "trades": 12350,
+      "closed": 12311,
+      "total_r": 612.9287876829395,
+      "expectancy_r": 0.049787083720488956
+     },
+     "without_hostile": {
+      "trades": 9421,
+      "closed": 9387,
+      "total_r": 1063.545078140359,
+      "expectancy_r": 0.11329978461066997
+     }
+    },
+    "basis": "priced at signal level: sitting a state out removes its trades and frees no capital, because this run has no shared position budget to redeploy \u2014 the figure is what the posture costs or saves directly, never what it might buy"
+   },
+   "reduced": {
+    "state": "CHOPPY",
+    "posture": "reduced",
+    "judged_against": "FRIENDLY",
+    "trades": 3802,
+    "trades_friendly": 5619,
+    "expectancy_r": 0.1770726114665508,
+    "expectancy_r_friendly": 0.07026877102120678,
+    "delta_expectancy_r": 0.10680384044534401,
+    "shape": {
+     "closed": 3782,
+     "win_rate": 0.23611845584346908,
+     "wins": 893,
+     "losses": 2889,
+     "distribution": {
+      "min": -35.977822684303476,
+      "p10": -3.3182416345090284,
+      "q1": -2.2167047004809666,
+      "median": -1.3586514921802815,
+      "q3": -0.044792426953860806,
+      "p90": 5.187969474549157,
+      "max": 108.85396708300148,
+      "mean_win": 7.232675473561956,
+      "mean_loss": -2.00383889973151
+     }
+    },
+    "shape_friendly": {
+     "closed": 5605,
+     "win_rate": 0.24210526315789474,
+     "wins": 1357,
+     "losses": 4248,
+     "distribution": {
+      "min": -30.675226550617438,
+      "p10": -3.4799884684951143,
+      "q1": -2.356639544783779,
+      "median": -1.4165599241396003,
+      "q3": -0.03446094147732655,
+      "p90": 4.989817524709988,
+      "max": 141.8356198363432,
+      "mean_win": 6.938172497207264,
+      "mean_loss": -2.1236449192882283
+     }
+    },
+    "verdict": "undecided",
+    "bootstrap": {
+     "cluster": "symbol",
+     "clusters_a": 1148,
+     "clusters_b": 1265,
+     "observations_a": 3782,
+     "observations_b": 5605,
+     "mean_a": 0.1770726114665508,
+     "mean_b": 0.07026877102120678,
+     "difference": 0.10680384044534401,
+     "resamples": 2000,
+     "seed": 191,
+     "confidence": 0.95,
+     "min_clusters": 5,
+     "ci_low": -0.19959216106106806,
+     "ci_high": 0.4200000294355511,
+     "p_value": 0.7455,
+     "suppressed": null
+    }
+   },
+   "breadth": {
+    "sessions": 3682,
+    "sessions_without_breadth": 0,
+    "min": 0.0,
+    "median": 0.49122807017543857,
+    "max": 0.9411764705882353,
+    "mean": 0.490560791910775,
+    "basis": "descriptive_survivorship_biased",
+    "conditioned_on": false,
+    "warning": "breadth is descriptive only and is never conditioned on: survivorship bias corrupts it more directly than anything else reported here, and in a backtest worse rather than better, because the names missing from the store are disproportionately the ones that later died"
+   },
+   "follow_through": {
+    "sessions": 3682,
+    "sessions_without_reading": 0,
+    "breakouts": 828,
+    "breakout_rate": 0.22487778381314502,
+    "basis": "reconstructed_unbiased",
+    "conditioned_on": false,
+    "note": "follow-through is unbiased where breadth is not: the live app captures it forward nightly because a survivorship-biased past cannot rebuild it, but the index series carries no survivorship hole, so this run reconstructs it legitimately across the whole window \u2014 reported, and still never conditioned on"
+   },
+   "conditioning": {
+    "role": "conditioning_variable_never_filter",
+    "handed_in": 13551,
+    "excluded_other_markets": 1201,
+    "excluded_other_arms": 0,
+    "trades": 12350,
+    "in_cells": 12350,
+    "excluded_by_regime": 0,
+    "partition_holds": true,
+    "sessions": 3682,
+    "warmup_bars": 25,
+    "upstream_guarantee": "the trades reaching this module are produced without reading any regime column at all (backtest.simulate), and the contract's regime.role cell is refused if it ever names a filter; the counts below show only that the states partition what did arrive"
+   }
+  },
+  {
+   "market": "IDX",
+   "index": "^JKSE",
+   "arm": "B",
+   "states": [
+    {
+     "state": "FRIENDLY",
+     "basis_counts": {
+      "measured": 416,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "FRIENDLY full",
+       "trades": 416,
+       "closed": 414,
+       "open_at_end": 2,
+       "undenominated": 0,
+       "symbols": 151,
+       "price_scale_dropped": 0,
+       "expectancy_r": 1.5019545770476204,
+       "expectancy_r_before_cost": 1.8904475441615836,
+       "cost_r": 0.3884929671139629,
+       "win_rate": 0.2632850241545894,
+       "wins": 109,
+       "losses": 305,
+       "total_r": 621.8091948977149,
+       "distribution": {
+        "min": -8.81313678920598,
+        "p10": -3.888410061988921,
+        "q1": -2.7705486089979994,
+        "median": -1.8323693800290701,
+        "q3": 0.3408109211268502,
+        "p90": 8.55415257553337,
+        "max": 152.37834670993914,
+        "mean_win": 12.565560495340206,
+        "mean_loss": -2.451924259325795
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 150,
+        "observations": 414,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": 0.19517892220517172,
+        "ci_high": 3.049253341001544,
+        "p_value": 0.01
+       },
+       "state": "FRIENDLY"
+      },
+      {
+       "label": "FRIENDLY excluding_2020_2021",
+       "trades": 332,
+       "closed": 330,
+       "open_at_end": 2,
+       "undenominated": 0,
+       "symbols": 129,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.9420866373803418,
+       "expectancy_r_before_cost": 1.3330521318257316,
+       "cost_r": 0.3909654944453898,
+       "win_rate": 0.2606060606060606,
+       "wins": 86,
+       "losses": 244,
+       "total_r": 310.8885903355128,
+       "distribution": {
+        "min": -8.81313678920598,
+        "p10": -3.9003051620050257,
+        "q1": -2.8274601839204285,
+        "median": -1.7730299871227424,
+        "q3": 0.26058696713908314,
+        "p90": 7.938723985656362,
+        "max": 152.37834670993914,
+        "mean_win": 10.626474701548473,
+        "mean_loss": -2.471263254088753
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 128,
+        "observations": 330,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.21758026621608373,
+        "ci_high": 2.406979904835817,
+        "p_value": 0.072
+       },
+       "state": "FRIENDLY",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 416
+    },
+    {
+     "state": "CHOPPY",
+     "basis_counts": {
+      "measured": 468,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "CHOPPY full",
+       "trades": 468,
+       "closed": 465,
+       "open_at_end": 3,
+       "undenominated": 0,
+       "symbols": 181,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.20704845231206204,
+       "expectancy_r_before_cost": 0.5970372636828302,
+       "cost_r": 0.38998881137076813,
+       "win_rate": 0.22795698924731184,
+       "wins": 106,
+       "losses": 359,
+       "total_r": 96.27753032510884,
+       "distribution": {
+        "min": -16.685163502499186,
+        "p10": -3.7963581915761164,
+        "q1": -2.827592281830288,
+        "median": -1.9280828906992986,
+        "q3": -0.33285931849459016,
+        "p90": 6.82366551187987,
+        "max": 76.78301057565258,
+        "mean_win": 9.49213813247968,
+        "mean_loss": -2.5345100604950894
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 179,
+        "observations": 465,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.608500384660779,
+        "ci_high": 1.1516029005328972,
+        "p_value": 0.35
+       },
+       "state": "CHOPPY"
+      },
+      {
+       "label": "CHOPPY excluding_2020_2021",
+       "trades": 380,
+       "closed": 377,
+       "open_at_end": 3,
+       "undenominated": 0,
+       "symbols": 155,
+       "price_scale_dropped": 0,
+       "expectancy_r": -0.09957475623544172,
+       "expectancy_r_before_cost": 0.300399813085465,
+       "cost_r": 0.39997456932090675,
+       "win_rate": 0.21750663129973474,
+       "wins": 82,
+       "losses": 295,
+       "total_r": -37.53968310076153,
+       "distribution": {
+        "min": -16.685163502499186,
+        "p10": -3.863233432275277,
+        "q1": -2.8677821099409035,
+        "median": -1.9297438606955488,
+        "q3": -0.48243962916021965,
+        "p90": 6.094043479026167,
+        "max": 43.76367961443724,
+        "mean_win": 8.701410977540682,
+        "mean_loss": -2.545950451725754
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 153,
+        "observations": 377,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.8966746664080089,
+        "ci_high": 0.825231744013137,
+        "p_value": 0.6205
+       },
+       "state": "CHOPPY",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 468
+    },
+    {
+     "state": "HOSTILE",
+     "basis_counts": {
+      "measured": 317,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "HOSTILE full",
+       "trades": 317,
+       "closed": 317,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 145,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.2996959607146867,
+       "expectancy_r_before_cost": 0.6638119630126686,
+       "cost_r": 0.3641160022979821,
+       "win_rate": 0.2302839116719243,
+       "wins": 73,
+       "losses": 244,
+       "total_r": 95.00361954655568,
+       "distribution": {
+        "min": -16.975065333581725,
+        "p10": -3.685465845282949,
+        "q1": -2.6777332679163868,
+        "median": -1.8914341554290763,
+        "q3": -0.4373508419821256,
+        "p90": 5.434251959828936,
+        "max": 76.09611993498979,
+        "mean_win": 9.625762741862426,
+        "mean_loss": -2.490479756595907
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 145,
+        "observations": 317,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.5773560990485934,
+        "ci_high": 1.2107335727091078,
+        "p_value": 0.269
+       },
+       "state": "HOSTILE"
+      },
+      {
+       "label": "HOSTILE excluding_2020_2021",
+       "trades": 279,
+       "closed": 279,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 134,
+       "price_scale_dropped": 0,
+       "expectancy_r": 0.023839593576887547,
+       "expectancy_r_before_cost": 0.3937137627725111,
+       "cost_r": 0.36987416919562355,
+       "win_rate": 0.23655913978494625,
+       "wins": 66,
+       "losses": 213,
+       "total_r": 6.6512466079516255,
+       "distribution": {
+        "min": -16.975065333581725,
+        "p10": -3.6681336125054718,
+        "q1": -2.6909498608409814,
+        "median": -1.8961977251836761,
+        "q3": -0.4006262577580818,
+        "p90": 5.270723104169057,
+        "max": 49.5107356328922,
+        "mean_win": 8.255473853556898,
+        "mean_loss": -2.5268076419098766
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 134,
+        "observations": 279,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": null,
+        "ci_low": -0.7178645183748549,
+        "ci_high": 0.8339893113166224,
+        "p_value": 0.48
+       },
+       "state": "HOSTILE",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 317
+    },
+    {
+     "state": "UNDEFINED",
+     "basis_counts": {
+      "measured": 0,
+      "below_warmup": 0,
+      "session_absent": 0
+     },
+     "windows": [
+      {
+       "label": "UNDEFINED full",
+       "trades": 0,
+       "closed": 0,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 0,
+       "price_scale_dropped": 0,
+       "expectancy_r": null,
+       "expectancy_r_before_cost": null,
+       "cost_r": null,
+       "win_rate": null,
+       "wins": 0,
+       "losses": 0,
+       "total_r": 0,
+       "distribution": {
+        "min": null,
+        "p10": null,
+        "q1": null,
+        "median": null,
+        "q3": null,
+        "p90": null,
+        "max": null,
+        "mean_win": null,
+        "mean_loss": null
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 0,
+        "observations": 0,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": "0 symbols is fewer than 5: too thin for an interval, and a degenerate one would read as significance",
+        "ci_low": null,
+        "ci_high": null,
+        "p_value": null
+       },
+       "state": "UNDEFINED"
+      },
+      {
+       "label": "UNDEFINED excluding_2020_2021",
+       "trades": 0,
+       "closed": 0,
+       "open_at_end": 0,
+       "undenominated": 0,
+       "symbols": 0,
+       "price_scale_dropped": 0,
+       "expectancy_r": null,
+       "expectancy_r_before_cost": null,
+       "cost_r": null,
+       "win_rate": null,
+       "wins": 0,
+       "losses": 0,
+       "total_r": 0,
+       "distribution": {
+        "min": null,
+        "p10": null,
+        "q1": null,
+        "median": null,
+        "q3": null,
+        "p90": null,
+        "max": null,
+        "mean_win": null,
+        "mean_loss": null
+       },
+       "bootstrap": {
+        "cluster": "symbol",
+        "clusters": 0,
+        "observations": 0,
+        "resamples": 2000,
+        "seed": 191,
+        "confidence": 0.95,
+        "min_clusters": 5,
+        "suppressed": "0 symbols is fewer than 5: too thin for an interval, and a degenerate one would read as significance",
+        "ci_low": null,
+        "ci_high": null,
+        "p_value": null
+       },
+       "state": "UNDEFINED",
+       "excluded_years": [
+        2020,
+        2021
+       ]
+      }
+     ],
+     "trades": 0
+    }
+   ],
+   "counterfactual": {
+    "state": "HOSTILE",
+    "posture": "sit out",
+    "judged_against": "zero",
+    "judged_against_note": "the word instructs no trade at all, so the comparison is with not trading rather than with another state",
+    "trades": 317,
+    "closed": 317,
+    "expectancy_r": 0.2996959607146867,
+    "total_r": 95.00361954655568,
+    "delta_total_r": -95.00361954655568,
+    "delta_expectancy_r": 0.13709455324556696,
+    "effect": "cost",
+    "verdict": "undecided",
+    "bootstrap": {
+     "cluster": "symbol",
+     "clusters": 145,
+     "observations": 317,
+     "resamples": 2000,
+     "seed": 191,
+     "confidence": 0.95,
+     "min_clusters": 5,
+     "suppressed": null,
+     "ci_low": -0.5773560990485934,
+     "ci_high": 1.2107335727091078,
+     "p_value": 0.269
+    },
+    "book": {
+     "all": {
+      "trades": 1201,
+      "closed": 1196,
+      "total_r": 813.0903447693794,
+      "expectancy_r": 0.6798414253924577
+     },
+     "without_hostile": {
+      "trades": 884,
+      "closed": 879,
+      "total_r": 718.0867252228237,
+      "expectancy_r": 0.8169359786380247
+     }
+    },
+    "basis": "priced at signal level: sitting a state out removes its trades and frees no capital, because this run has no shared position budget to redeploy \u2014 the figure is what the posture costs or saves directly, never what it might buy"
+   },
+   "reduced": {
+    "state": "CHOPPY",
+    "posture": "reduced",
+    "judged_against": "FRIENDLY",
+    "trades": 468,
+    "trades_friendly": 416,
+    "expectancy_r": 0.20704845231206204,
+    "expectancy_r_friendly": 1.5019545770476204,
+    "delta_expectancy_r": -1.2949061247355584,
+    "shape": {
+     "closed": 465,
+     "win_rate": 0.22795698924731184,
+     "wins": 106,
+     "losses": 359,
+     "distribution": {
+      "min": -16.685163502499186,
+      "p10": -3.7963581915761164,
+      "q1": -2.827592281830288,
+      "median": -1.9280828906992986,
+      "q3": -0.33285931849459016,
+      "p90": 6.82366551187987,
+      "max": 76.78301057565258,
+      "mean_win": 9.49213813247968,
+      "mean_loss": -2.5345100604950894
+     }
+    },
+    "shape_friendly": {
+     "closed": 414,
+     "win_rate": 0.2632850241545894,
+     "wins": 109,
+     "losses": 305,
+     "distribution": {
+      "min": -8.81313678920598,
+      "p10": -3.888410061988921,
+      "q1": -2.7705486089979994,
+      "median": -1.8323693800290701,
+      "q3": 0.3408109211268502,
+      "p90": 8.55415257553337,
+      "max": 152.37834670993914,
+      "mean_win": 12.565560495340206,
+      "mean_loss": -2.451924259325795
+     }
+    },
+    "verdict": "undecided",
+    "bootstrap": {
+     "cluster": "symbol",
+     "clusters_a": 179,
+     "clusters_b": 150,
+     "observations_a": 465,
+     "observations_b": 414,
+     "mean_a": 0.20704845231206204,
+     "mean_b": 1.5019545770476204,
+     "difference": -1.2949061247355584,
+     "resamples": 2000,
+     "seed": 191,
+     "confidence": 0.95,
+     "min_clusters": 5,
+     "ci_low": -3.0975654171464946,
+     "ci_high": 0.38552564792656885,
+     "p_value": 0.066,
+     "suppressed": null
+    }
+   },
+   "breadth": {
+    "sessions": 3538,
+    "sessions_without_breadth": 4,
+    "min": 0.0,
+    "median": 0.46153846153846156,
+    "max": 1.0,
+    "mean": 0.46589311095785135,
+    "basis": "descriptive_survivorship_biased",
+    "conditioned_on": false,
+    "warning": "breadth is descriptive only and is never conditioned on: survivorship bias corrupts it more directly than anything else reported here, and in a backtest worse rather than better, because the names missing from the store are disproportionately the ones that later died"
+   },
+   "follow_through": {
+    "sessions": 3542,
+    "sessions_without_reading": 0,
+    "breakouts": 577,
+    "breakout_rate": 0.16290231507622813,
+    "basis": "reconstructed_unbiased",
+    "conditioned_on": false,
+    "note": "follow-through is unbiased where breadth is not: the live app captures it forward nightly because a survivorship-biased past cannot rebuild it, but the index series carries no survivorship hole, so this run reconstructs it legitimately across the whole window \u2014 reported, and still never conditioned on"
+   },
+   "conditioning": {
+    "role": "conditioning_variable_never_filter",
+    "handed_in": 13551,
+    "excluded_other_markets": 12350,
+    "excluded_other_arms": 0,
+    "trades": 1201,
+    "in_cells": 1201,
+    "excluded_by_regime": 0,
+    "partition_holds": true,
+    "sessions": 3542,
+    "warmup_bars": 25,
+    "upstream_guarantee": "the trades reaching this module are produced without reading any regime column at all (backtest.simulate), and the contract's regime.role cell is refused if it ever names a filter; the counts below show only that the states partition what did arrive"
+   }
+  }
+ ]
+}

--- a/references/backtest_regime_posture.txt
+++ b/references/backtest_regime_posture.txt
@@ -1,0 +1,53 @@
+regime posture — arm B, state read at detection_session (t−1)
+  the detection session — the night the candidate was listed with the app's posture beside it, one session before the break that signals entry and two before the fill; no bar after it is read to date the trade
+  conditioning_variable_never_filter: nothing is excluded by regime, every state trades, and each one's expectancy is measured
+  three exit arms and three regime states is nine views of one dataset before any threshold is swept; the pre-registered metric stands as the headline even where a view here looks better
+
+US — regime off ^IXIC, 12350 trades over 3682 sessions, 0 excluded by regime (1201 other-market and 0 other-arm trades were set aside first)
+  FRIENDLY
+    FRIENDLY full                  +0.070R  win 24.2%  n=5605  med -1.42  [-0.13, +0.26] p=0.234
+    FRIENDLY excluding_2020_2021   -0.075R  win 23.4%  n=3783  med -1.41  [-0.28, +0.14] p=0.758
+  CHOPPY
+    CHOPPY full                    +0.177R  win 23.6%  n=3782  med -1.36  [-0.05, +0.43] p=0.069
+    CHOPPY excluding_2020_2021     -0.050R  win 22.3%  n=2916  med -1.41  [-0.29, +0.21] p=0.653
+  HOSTILE
+    HOSTILE full                   -0.154R  win 25.1%  n=2924  med -1.27  [-0.41, +0.11] p=0.888
+    HOSTILE excluding_2020_2021    -0.131R  win 25.7%  n=2393  med -1.24  [-0.39, +0.17] p=0.805
+  UNDEFINED
+    UNDEFINED full                 n=0  no closed trades
+    UNDEFINED excluding_2020_2021  n=0  no closed trades
+
+  "sit out" for HOSTILE — undecided against zero; point estimate saved 450.6R
+    sitting out HOSTILE changes the book by +450.6R over 2924 closed trades; priced at signal level: sitting a state out removes its trades and frees no capital, because this run has no shared position budget to redeploy — the figure is what the posture costs or saves directly, never what it might buy
+  "reduced" for CHOPPY — undecided against FRIENDLY; point estimate +0.107R
+    CHOPPY n=3782 win 23.6% against FRIENDLY n=5605 win 24.2%
+
+  breadth (descriptive, never conditioned on): median 49.1% over 3682 sessions
+    breadth is descriptive only and is never conditioned on: survivorship bias corrupts it more directly than anything else reported here, and in a backtest worse rather than better, because the names missing from the store are disproportionately the ones that later died
+  follow-through (unbiased, never conditioned on): index broke out on 22.5% of 3682 sessions
+    follow-through is unbiased where breadth is not: the live app captures it forward nightly because a survivorship-biased past cannot rebuild it, but the index series carries no survivorship hole, so this run reconstructs it legitimately across the whole window — reported, and still never conditioned on
+
+IDX — regime off ^JKSE, 1201 trades over 3542 sessions, 0 excluded by regime (12350 other-market and 0 other-arm trades were set aside first)
+  FRIENDLY
+    FRIENDLY full                  +1.502R  win 26.3%  n=414  med -1.83  [+0.20, +3.05] p=0.010
+    FRIENDLY excluding_2020_2021   +0.942R  win 26.1%  n=330  med -1.77  [-0.22, +2.41] p=0.072
+  CHOPPY
+    CHOPPY full                    +0.207R  win 22.8%  n=465  med -1.93  [-0.61, +1.15] p=0.350
+    CHOPPY excluding_2020_2021     -0.100R  win 21.8%  n=377  med -1.93  [-0.90, +0.83] p=0.621
+  HOSTILE
+    HOSTILE full                   +0.300R  win 23.0%  n=317  med -1.89  [-0.58, +1.21] p=0.269
+    HOSTILE excluding_2020_2021    +0.024R  win 23.7%  n=279  med -1.90  [-0.72, +0.83] p=0.480
+  UNDEFINED
+    UNDEFINED full                 n=0  no closed trades
+    UNDEFINED excluding_2020_2021  n=0  no closed trades
+
+  "sit out" for HOSTILE — undecided against zero; point estimate cost 95.0R
+    sitting out HOSTILE changes the book by -95.0R over 317 closed trades; priced at signal level: sitting a state out removes its trades and frees no capital, because this run has no shared position budget to redeploy — the figure is what the posture costs or saves directly, never what it might buy
+  "reduced" for CHOPPY — undecided against FRIENDLY; point estimate -1.295R
+    CHOPPY n=465 win 22.8% against FRIENDLY n=414 win 26.3%
+
+  breadth (descriptive, never conditioned on): median 46.2% over 3538 sessions
+    breadth is descriptive only and is never conditioned on: survivorship bias corrupts it more directly than anything else reported here, and in a backtest worse rather than better, because the names missing from the store are disproportionately the ones that later died
+  follow-through (unbiased, never conditioned on): index broke out on 16.3% of 3542 sessions
+    follow-through is unbiased where breadth is not: the live app captures it forward nightly because a survivorship-biased past cannot rebuild it, but the index series carries no survivorship hole, so this run reconstructs it legitimately across the whole window — reported, and still never conditioned on
+

--- a/scripts/backtest_headline.sh
+++ b/scripts/backtest_headline.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# The headline figure, and its bound — one command (PRD #182 Phase 7, issue #200).
+#
+# Phase 7 is done when "a reader who has seen none of this can reproduce the
+# headline figure from the committed command, and can state its bound without
+# reading the code". This is that command.
+#
+# Usage:
+#   bash scripts/backtest_headline.sh                      # from the committed payloads
+#   bash scripts/backtest_headline.sh --from-store PATH    # recomputed from the bar store
+#
+# Two paths, and they are deliberately not the same claim:
+#
+#   The default reads the recorded payloads under references/ and re-evaluates the
+#   contract's own criteria over them. What it checks is that the committed result
+#   and the write-up's prose still agree — it does not touch a bar, and it says so
+#   on its first line. This is the path a reader can run today: `data/*.duckdb` is
+#   1.1GB of bars and 446MB of denominator, and `.gitignore` keeps both out of the
+#   repository, so there is nothing here to read them from.
+#
+#   `--from-store` recomputes the headline from a built store: the pre-registered
+#   metric, Phase 2's bound attached to it, the sweep whose count rides beside the
+#   verdict, and then the verdict itself. That is the reproduction proper, and it
+#   needs the store built first (`python -m backtest.crawl`, then
+#   `python -m backtest.full_run`) — roughly two hours of paced fetching before it
+#   can run at all.
+#
+# Either way the last thing printed is the same page: both markets, both windows,
+# each figure beside its pessimistic twin, and the verdict in the words the
+# contract fixed before the run.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+REPO="$PWD"
+REFERENCES=references
+METRIC="$REPO/$REFERENCES/backtest_primary_metric.json"
+SWEEP="$REPO/$REFERENCES/backtest_sweep.json"
+SURVIVORSHIP="$REPO/$REFERENCES/backtest_survivorship.json"
+
+# Absolute, because every step below runs from backend/ so that `backtest` and
+# `screener` import the way pyproject's pythonpath expects.
+PYTHON="${PYTHON:-$PWD/backend/.venv/bin/python}"
+if [[ ! -x "$PYTHON" ]]; then
+  PYTHON="$(command -v python3)"
+fi
+
+STORE=""
+if [[ "${1:-}" == "--from-store" ]]; then
+  STORE="${2:-}"
+  if [[ -z "$STORE" ]]; then
+    echo "error: --from-store needs the path to a built bar store." >&2
+    exit 2
+  fi
+  if [[ ! -f "$STORE" ]]; then
+    # A missing store is refused rather than quietly falling back to the recorded
+    # payloads, which would print the right numbers under the wrong claim.
+    echo "error: no bar store at $STORE." >&2
+    echo "Build it first: python -m backtest.crawl && python -m backtest.full_run" >&2
+    exit 2
+  fi
+  # Absolute from here on: every step runs from backend/, so a path the caller
+  # gave relative to the repository root would resolve one directory too deep.
+  STORE="$(cd "$(dirname "$STORE")" && pwd)/$(basename "$STORE")"
+elif [[ -n "${1:-}" ]]; then
+  echo "usage: bash scripts/backtest_headline.sh [--from-store PATH]" >&2
+  exit 2
+fi
+
+if [[ -n "$STORE" ]]; then
+  WORK="$(mktemp -d)"
+  trap 'rm -rf "$WORK"' EXIT
+  echo "Recomputing the headline from the bars at $STORE."
+  echo "The recorded payloads under $REFERENCES/ are read for nothing here;"
+  echo "run without --from-store to re-read them instead."
+  echo
+
+  # The order is the contract's, not a convenience: the sweep refuses to run until
+  # a pre-registered headline has been recorded, and the verdict refuses a metric
+  # with no bound attached. Each step's output is the next step's required input.
+  ( cd backend && "$PYTHON" -m backtest.metric \
+      --store "$STORE" --out-json "$WORK/metric.json" ) > /dev/null
+  ( cd backend && "$PYTHON" -m backtest.survivorship \
+      --store "$STORE" \
+      --metric-json "$WORK/metric.json" \
+      --out-json "$WORK/survivorship.json" \
+      --out-metric-json "$WORK/metric_bounded.json" ) > /dev/null
+  ( cd backend && "$PYTHON" -m backtest.sweep \
+      --store "$STORE" \
+      --recorded "$WORK/metric.json" \
+      --out-json "$WORK/sweep.json" ) > /dev/null
+
+  METRIC="$WORK/metric_bounded.json"
+  SWEEP="$WORK/sweep.json"
+  SURVIVORSHIP="$WORK/survivorship.json"
+else
+  echo "Read back from the recorded payloads committed under $REFERENCES/:"
+  echo "  $METRIC"
+  echo "  $SURVIVORSHIP"
+  echo "  $SWEEP"
+  echo "No bar is read on this path — it checks that the committed result and the"
+  echo "write-up still agree. To recompute the figure from the bars themselves,"
+  echo "build the store and pass --from-store data/backtest.duckdb."
+  echo
+fi
+
+cd backend
+exec "$PYTHON" -m backtest.verdict \
+  --metric-json "$METRIC" \
+  --sweep-json "$SWEEP" \
+  --survivorship-json "$SURVIVORSHIP"

--- a/scripts/backtest_headline.sh
+++ b/scripts/backtest_headline.sh
@@ -46,8 +46,38 @@ if [[ ! -x "$PYTHON" ]]; then
   PYTHON="$(command -v python3)"
 fi
 
+# Both paths read the verdict off `backtest.verdict`, which imports the package,
+# which imports duckdb. That is worth one clear sentence rather than a traceback:
+# the reader who runs this has cloned a repository, not installed a tool, and the
+# failure they are about to hit is a missing environment rather than a missing
+# figure. Checked before anything is printed, so the two do not interleave.
+require_environment() {
+  if "$PYTHON" -c 'import duckdb' 2>/dev/null; then
+    return
+  fi
+  echo "error: $PYTHON cannot import duckdb, so the backtest package will not load." >&2
+  echo "This command needs the project's Python environment (no bar store, but the" >&2
+  echo "same dependencies). Set it up with:" >&2
+  echo "    python3 -m venv backend/.venv" >&2
+  echo "    backend/.venv/bin/pip install -r backend/requirements.txt" >&2
+  echo "Or point PYTHON at an interpreter that already has them:" >&2
+  echo "    PYTHON=/path/to/python bash scripts/backtest_headline.sh" >&2
+  exit 3
+}
+
+usage() {
+  echo "usage: bash scripts/backtest_headline.sh [--from-store PATH]"
+  echo
+  echo "  (no arguments)      print the headline and its bound from the payloads"
+  echo "                      committed under references/; reads no bars"
+  echo "  --from-store PATH   recompute it from a built bar store instead"
+}
+
 STORE=""
-if [[ "${1:-}" == "--from-store" ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+elif [[ "${1:-}" == "--from-store" ]]; then
   STORE="${2:-}"
   if [[ -z "$STORE" ]]; then
     echo "error: --from-store needs the path to a built bar store." >&2
@@ -64,9 +94,12 @@ if [[ "${1:-}" == "--from-store" ]]; then
   # gave relative to the repository root would resolve one directory too deep.
   STORE="$(cd "$(dirname "$STORE")" && pwd)/$(basename "$STORE")"
 elif [[ -n "${1:-}" ]]; then
-  echo "usage: bash scripts/backtest_headline.sh [--from-store PATH]" >&2
+  usage >&2
   exit 2
 fi
+
+# After the argument parsing, so --help answers without an environment at all.
+require_environment
 
 if [[ -n "$STORE" ]]; then
   WORK="$(mktemp -d)"
@@ -105,8 +138,10 @@ else
   echo
 fi
 
+# Not `exec`: that replaces the shell image, so bash would never run the EXIT
+# trap and every --from-store run would leave its temp directory behind.
 cd backend
-exec "$PYTHON" -m backtest.verdict \
+"$PYTHON" -m backtest.verdict \
   --metric-json "$METRIC" \
   --sweep-json "$SWEEP" \
   --survivorship-json "$SURVIVORSHIP"


### PR DESCRIPTION
Closes #200. PRD #182 Phase 7 — the write-up, and with it the last phase of the plan.

## What lands

**[`references/backtest_findings.md`](https://github.com/ajitimur/screening-dashboard/blob/issue-200-writeup/references/backtest_findings.md)** — the authority document, and **[`backtest_findings-plain.md`](https://github.com/ajitimur/screening-dashboard/blob/issue-200-writeup/references/backtest_findings-plain.md)** beside it, following the convention the replay study set. The bias bound sits in the summary rather than a footnote, because on the US it is larger than the effect the run is looking for. US and IDX are apart everywhere including the summary, and there is no pooled figure in either document to read.

**`scripts/backtest_headline.sh`** — the one command. Its two paths are deliberately different claims and it says on its first line which it took: by default it re-reads the committed payloads and checks that the recorded result and the prose still agree, and `--from-store` recomputes from the bars. **The second path was run against the store and reproduced all four figures and both bounds exactly.**

## The headline, and its bound

| | full window | ex-2020–21 | bound (full / ex) | verdict |
|---|---|---|---|---|
| US | +0.050R | **−0.081R** | −0.363R / −0.446R | inconclusive |
| IDX | +0.680R | +0.284R | +0.418R / **+0.072R** | ship |

The US hole is 37.7% exposure-weighted, and it costs the headline **0.413R** — about eight times the size of the thing being measured, pointing down. Jakarta's 12.7% is counted on the enumeration side, so the market that ships is the market with the weaker bound, and both documents say so on the same line as the result.

The verdict is quoted in the licence strings the contract fixed before the run, rather than restated more warmly than it was decided. **The change IDX licenses is named and unspent**: settle `Relative move`'s stalled admission threshold, on IDX, against outcomes — licensed only in the market that passed, and still going through the calibration rule.

## Three Phase 5 measurements that had no committed payload

#192, #193 and #195 landed their machinery and closed without committing a result, so the write-up ran them. A phase reported from a payload nobody committed is a phase whose figures cannot be checked. Three results are recorded here for the first time:

- **Precision, at last** — 3.1% (US) and 2.4% (IDX) at arm B, against a 12.8% / 9.5% trigger share. The false-positive rate findings §9 could not report and #149 could only log as volume carrying no verdict.
- **`Relative move` predicts on IDX** — a +1.927R hit-minus-miss gap on [+0.57, +3.14], the one positive cell of four.
- **Arm A smooths without raising expectancy** — level with arm B on the US, and 0.379R per trade worse on IDX, for four points of hit rate.

The regime posture is priced too, and the two markets disagree: sitting out `HOSTILE` saves 450.6R on the US and costs 95.0R on IDX, both undecided by interval. `CHOPPY` does not earn its "reduced" in either.

## Reproduce

```
bash scripts/backtest_headline.sh                                 # from the committed payloads
bash scripts/backtest_headline.sh --from-store data/backtest.duckdb   # from the bars
```

## The tests are drift guards

Every figure the documents quote is re-read from the payload that produced it, so a rerun that moves a number and leaves the prose behind fails in CI rather than in a reader's hands. The payload table's rows are checked against `git ls-files` rather than `Path.exists`, because "committed beside both" is a claim about the repository and a locally-present ignored file satisfies the weaker check while being available to nobody.

The second commit answers a two-axis review. Two real defects: the plain companion quoted the missing-trades-per-covered-trade **count** (0.605) as an R amount where the drag is 0.413R, so the two documents disagreed — the one failure the companion's own preamble rules out; and `exec` on the script's last line replaced the shell image, so the EXIT trap never fired and every `--from-store` run leaked its temp directory. Both fixed and both verified, the second by re-running the whole recomputation and confirming nothing is left behind. The default path also no longer dies with a bare `ModuleNotFoundError` when the venv is missing.

The third commit corrects the `backtest_full_run.json` row, which called the payload "the denominator itself". The denominator is 1.5GB across two gitignored stores; the row would have sent a reader looking in the repository for 15.1M bars.

No constant moved. The contract, the rubric, the detector and the register are all as this run measured them.

Backend suite: 1080 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Coe8Abvuh9iBAGPwgSr33E
