### PR TITLE
ADR 0006 — what a candidate outcome test licenses, and `Relative move` admitted (#221)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -246,13 +246,19 @@ cross-sectional cuts — because precision is not measurable and recall alone wo
 every gate. Stated in `docs/adr/0002-what-evidence-licenses-loosening-a-gate.md`; not
 restated anywhere else.
 
+**It does not govern admission.** Adding a dimension to the rubric is neither limb — ADR 0005
+governs that, as narrowed by ADR 0006. Findings §7 draws the same line for the stop convention
+and the tightness restructure.
+
 **Constant dimension**:
 A score dimension true for every detection by construction, so it shifts every score equally
 and can never move the sort. `Prior move` is the only one, measured at pooled spread 0.000 in
 findings §5b and again in §5d, on a field 171% larger.
 
-**It stays at ×1, and is retired only when something takes its slot** (#160/#161). ADR 0005
-(`proposed`) calls keeping it "documentation bought at the price of a point", but that presumes
+**It stays at ×1, and is retired only when something takes its slot** (#160/#161) — and
+**#221 took it**: `Relative move` is admitted, so `Prior move` retires with the replacement
+metadata, in **#222**. Until that ships it is still ×1 and still the rubric's floor. ADR 0005
+calls keeping it "documentation bought at the price of a point", but that presumes
 the point is **scarce** — and it is not: the ceiling is the sum of the weights, not a budget, so
 a ninth dimension can be added without retiring the eighth and retiring this one frees nothing.
 The measurement is not in doubt; what fails is the case for acting on it alone. Because the
@@ -264,6 +270,24 @@ that metadata exists loses information outright.
 _Avoid_: reading §5b's 0.000 as a standing instruction to retire it; the spread says the
 dimension cannot discriminate, not that removing it is free.
 
+**Crowded dimension**:
+A **candidate dimension** true of **85% or more** of the not-taken detections — or within one
+standard error of that line, which is what `relative_move_contrast.py` returns as
+`on_the_bound`. Under ADR 0005 that was a refusal: a dimension firing on nearly every name he
+passed over was "the constant in a new costume". **ADR 0006 (#221) narrowed it without moving
+the threshold** — a crowded dimension is not refused, it **owes a candidate outcome test**, and
+ADR 0005's criteria cannot be read on it until that test has run.
+
+The firing rate was only ever a **stand-in** for informativeness inside an already-gated field,
+and the backtest measured that quantity directly and refuted the stand-in: `Relative move` fires
+on 90.0% of US and 92.2% of IDX detections there — both further past the ceiling than the
+84.94% that stalled it — and the 7.8% of IDX names it does not fire on returned −1.075R against
+the hit group's +0.852R. Being true of nearly everything did not mean having nothing left to
+say.
+_Avoid_: reading this as the same object as a **constant dimension**. That one is true of
+**everything**, has pooled spread 0.000, and can never discriminate under any field; this one
+can, and has to prove it. Conflating the two is the error ADR 0006 corrects.
+
 **Candidate dimension**:
 A dimension **under measurement**, not in the rubric: computed on every detection in the
 replay, carried beside the star score, reported as a column of the **selection contrast** and —
@@ -271,9 +295,9 @@ since #195 — as a cohort of the **candidate outcome test**, and weighted by no
 rubric slot on a measured non-zero gap with non-zero pooled spread, and until that measurement
 exists it must be unable to move a star, a sort or a board place. So it lives on a field member
 of its own (`RS line` on `replay.field.ScoredDetection.rs_line`), never inside `SevenDimScore`,
-and nothing in `screener` scores it. Two are registered, both measured, neither admitted —
-`RS line` (rejected on a wrong-way gap) and **Relative move** (a positive gap that landed on its
-own refusal threshold, #171). **Pre-registered as one variant, pass or fail** — trying several
+and nothing in `screener` scores it. Two are registered, both measured, **one admitted** —
+`RS line` (rejected on a wrong-way gap) and **Relative move** (crowded, and admitted on a
+candidate outcome test under ADR 0006, #221; the rubric change is **#222**). **Pre-registered as one variant, pass or fail** — trying several
 and keeping the largest gap is magnitude-fitting (#128 Q2). A study may report further columns
 beside a candidate, as §5e does for the raw and other-window moves; those are **descriptive and
 permanently inadmissible**, and they are handed to `contrast_dimensions` as readers rather than
@@ -300,10 +324,14 @@ was proposed for is still open, and **Relative move** is the second candidate fo
 **Relative move**:
 The `6m` return **relative to `MARKET_INDEX`**, compounded — `(1 + stock) / (1 + index) − 1` —
 divided by the name's own `ADR`, taken at the session being scored and never past it. Hit when it is above zero: the name outran the index over six
-months. The second **candidate dimension** (#170), **measured and not admitted** (findings §5e,
-#171): Δ **+3.6pp** under the live detector — positive, unlike `RS line` — on a not-taken hit
-rate of **84.94%** against a pre-registered ~85% ceiling, 0.29 standard errors inside it. The
-criteria do not separate, so `Prior move` keeps its ×1 and `RUBRIC_VERSION` stays 3. Both legs read `calendar_return`, so the anchor is
+months. The second **candidate dimension** (#170), and the first **admitted**: Δ **+3.6pp** under the
+live detector — positive, unlike `RS line` — on a not-taken hit rate of **84.94%** against a
+pre-registered ~85% ceiling, 0.29 standard errors inside it (findings §5e, #171). That made it a
+**crowded dimension**, which under ADR 0006 owes a **candidate outcome test** rather than a
+refusal; it passed — IDX +1.927R [+0.57, +3.14] clears, and no market points the wrong way — and
+was admitted **at ×1** from the selection-gap ordering, **provisionally**, to be re-read at the
+next out-of-sample measurement (#221). `RUBRIC_VERSION` is still 3 and `Prior move` still holds
+its ×1 until **#222** ships the change. Both legs read `calendar_return`, so the anchor is
 calendar-dated and resolves to the last bar on or before it, and a missing leg is **absent**,
 scoring `False` and never carried forward. Named apart from `Prior move` on purpose — a
 **rubric version** re-scores a stored row by dimension name, so one label cannot mean two
@@ -319,7 +347,9 @@ currently 3 — v2's nine weights with `Tightness` graded, #154; v2 was the PRD 
 boolean rubric, v1 the ten-point one). Rides the API candidates payload and the digest header.
 A star figure quoted without one cannot be compared to another. Every superseded version stays
 live in `score.RUBRICS` so the paired A2 re-run can hold a field fixed and swap only the
-rubric; adding a version never edits an older one.
+rubric; adding a version never edits an older one. **v4 is decided and not shipped**: #221
+admitted `Relative move` and retired `Prior move`, #222 lands it, and the star range goes
+0.5–4.5 → **0.0–4.5** when it does.
 
 **Regime**:
 `FRIENDLY`, `CHOPPY` or `HOSTILE` per market, from one index each. Advisory only — never
@@ -672,6 +702,17 @@ by the candidate's own pre-registered cut, **per market**, with the **clustered 
 on the hit-minus-miss gap. It is not ADR 0005's admission instrument and admits nothing —
 that rule reads a **selection contrast**, and the two are a different claim about the same
 dimension: one says he picked names the dimension fires on, the other says those names paid.
+
+**What it does license, per ADR 0006 (#221): it changes what a dimension owes, never what it
+gets.** A **crowded dimension** owes one before ADR 0005's criteria can be read on it, and
+passing means **one market's gap clears zero and no market points the wrong way** — read on the
+pre-registered gap with the **absent group** excluded, never on the as-shipped figure. A gap's
+*size* is a magnitude and stays in its market (§8); **sign agreement across both markets** is a
+shape and travels, which is why one market's pass can license a change to a rubric that ships to
+both. Going the other way, a gap clearing **entirely below** zero retires nothing — it obliges
+the dimension's selection contrast to be **re-argued** under the current detector, with the
+weight untouched meanwhile. It never sets a weight: those come from the ordering of the
+selection gaps and nothing else (#128 Q2).
 So §5d's and §5e's figures ride on every cell under their own verdict key and are never
 summed with this one's. The verdict is the **gap's alone**, because ADR 0005 admits a
 dimension as a boolean; the rank correlation against the stored value is reported beside it

--- a/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
+++ b/docs/adr/0005-what-admits-a-dimension-to-the-rubric.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: accepted
 ---
 
 # What admits a dimension to the rubric, and what retires one
@@ -79,6 +79,13 @@ these four criteria fixed in advance:
 Criterion 2's ~15% is a judgement, not a measurement, and is the one magnitude in this design
 without evidence behind it. It is stated here so that a later argument about it is an argument
 about a number on the record rather than a number nobody wrote down.
+
+> **Narrowed by ADR 0006 (#221).** That argument has now happened. The threshold is unchanged,
+> and criterion 2 no longer returns a refusal: a dimension at or above the ceiling — or within
+> one standard error of it — is a **crowded dimension**, and owes a **candidate outcome test**
+> before these criteria can be read on it. See
+> [`0006-what-an-outcome-result-licenses.md`](0006-what-an-outcome-result-licenses.md). Read
+> every occurrence of criterion 2 below with that narrowing applied.
 
 **The verdict was do not ship**, on criterion 4 (findings §5d): Δ **−5.8pp** under detector v1
 and **−2.1pp** under the live v3, with criterion 2 at 11.2% disagreement standing ready to
@@ -258,6 +265,18 @@ choice is not small: admission retires `Prior move`, forces `RUBRIC_VERSION = 4`
 composition of every star ceiling frozen afterwards, which the consequences below call hard to
 reverse in the direction that matters.
 
+> **Resolved by ADR 0006 (#221).** The argument this section declined to have is now on the
+> record, and it did not move the number. Criterion 2's firing rate turned out to be a
+> **stand-in** for informativeness inside an already-gated field, and the backtest measured that
+> quantity directly: `Relative move` fires on 90.0% of US and 92.2% of IDX detections there —
+> both further past the ceiling than the 84.94% that stalled it here — and the 7.8% of IDX names
+> it does not fire on returned −1.075R against the hit group's +0.852R. Being true of nearly
+> every name did not mean having nothing left to say. So the threshold stands where it was
+> written and its **job** changed: it now decides which candidates owe a further measurement,
+> which is a task a number can do approximately and correctly. `Relative move` was read under
+> the narrowed rule and **admitted, at ×1, as `RUBRIC_VERSION = 4`** — provisionally, and re-read
+> at the next out-of-sample measurement. The reading is recorded in ADR 0006.
+
 **A third outcome, added after the fact and labelled as such.** This ADR promised pass or fail on
 one variant, and the study returned exactly that until the deciding number landed on the bound.
 `scripts/relative_move_contrast.py` now returns `on_the_bound` when the not-taken hit rate sits
@@ -287,6 +306,10 @@ and the anchor distinction the registration argued for in advance held up. What 
 this threshold. **No third candidate should be registered until the ~15% has been argued on its
 own**, because the next one will meet the same bound and a threshold chosen after two dimensions
 have bounced off it is not a pre-registration.
+
+> **This block is lifted (#221).** ADR 0006 is that argument, and the register is open. A
+> candidate registered from here that expects to be crowded should say so when it registers,
+> rather than discovering the obligation after the contrast runs.
 
 ## The regime bound every candidate carries (#169)
 
@@ -348,7 +371,7 @@ restated as a hope reads as a weaker commitment than it is.
   such hole — but the margin is thin enough that the lookback's *name* is the honest thing to
   publish and the percentile is declined.
 - **A new dimension forces a rubric version.** An admitted dimension ships as
-  `RUBRIC_VERSION = 4`, joining the `RUBRIC_WEIGHTS` table so the paired re-run (#136)
+  `RUBRIC_VERSION = 4`, joining the `RUBRICS` table so the paired re-run (#136)
   can score one field under v3 and v4 and separate a rubric change from a field change.
   Digests written under v3 are not recomputed.
 - **The new dimension is measured on US only and ships to IDX unmeasured.** The replay field is

--- a/docs/adr/0006-what-an-outcome-result-licenses.md
+++ b/docs/adr/0006-what-an-outcome-result-licenses.md
@@ -1,0 +1,271 @@
+---
+status: accepted
+---
+
+# What a candidate outcome test licenses
+
+ADR 0005 admits a dimension to the rubric on a **selection contrast** — taken detections
+against not-taken detections, no outcome variable — and its considered options record why:
+"Require an outcome regression rather than a selection contrast. **Not available**." When that
+was written it was true. §5a found no dimension predicts MFE, and ADR 0001 rules outcome
+inadmissible against the rubric, which is a claim about what the rubric *encodes* and not a
+claim that outcomes are unmeasurable.
+
+The out-of-sample backtest (PRD #182) changed the availability. `backtest.candidates` (#195)
+measured both registered candidates against an outcome variable — R after costs, on trades
+taken mechanically over a window the trade record does not cover, with no rubric weight fitted
+to it and no detection able to see it. That instrument did not exist for ADR 0005 and this ADR
+says what it licenses.
+
+**Decided (#221): a candidate outcome test changes what a dimension owes, never what it gets.**
+
+It admits nothing on its own and retires nothing on its own. The selection contrast remains the
+only instrument that decides. What this ADR adds is a rule for when a *further* measurement is
+required before ADR 0005's criteria can be read, and what a wrong-way outcome result obliges.
+
+## The measurement this ADR governs
+
+The **candidate outcome test** as `backtest.candidates` defines it and
+`references/backtest_candidate_outcomes.json` commits it: for a registered candidate
+dimension, the hit group's mean R against the miss group's mean R, with a symbol-clustered 95%
+interval on the gap. Absence is a group and never a value on the cut — a name that had not
+listed six months back, or that was missing a price at an anchor, enters no gap.
+
+## What it licenses, coming in: the crowding rule
+
+ADR 0005's criterion 2 refuses a dimension whose not-taken hit rate is above ~85% — restated
+there as disagreement with `Prior move` under ~15%, which is the same number read from the other
+side. **That criterion is narrowed here, and the threshold does not move.**
+
+A dimension whose not-taken hit rate is **at or above 85%, or within one standard error of it**,
+is a **crowded dimension**. It is no longer refused. It owes a candidate outcome test, and ADR
+0005's criteria cannot be read on it until that test has been run.
+
+`scripts/relative_move_contrast.py` already computes exactly this region: `HIT_RATE_CEILING =
+0.85` with a one-standard-error band, returning `on_the_bound`. Nothing in that script changes.
+What changes is what `on_the_bound` obliges — a further measurement rather than a stall.
+
+### Why the old criterion was wrong, and what it was right about
+
+Criterion 2 was guarding against a real thing, stated in its own words: a `6m`-relative grade
+"may have little left to say *within* that population even though it has plenty within his trade
+record." That is a claim about the dimension being **uninformative inside an already-gated
+field**. It is not a claim about the dimension being mechanically unable to move the sort —
+criterion 1's pooled-spread limb owns that, and criterion 3 owns its mirror.
+
+The firing rate was a **stand-in** for informativeness, chosen because nothing measured
+informativeness directly. The stand-in is now measurable, and it was wrong. On the backtest
+field `Relative move` fires on **90.0%** of US detections (11,014 hit against 1,217 miss) and
+**92.2%** of IDX detections (1,087 against 92) — both *further past* the ceiling than the 84.94%
+that stalled it on the replay field. On IDX the 7.8% it does not fire on returned **−1.075R**
+against the hit group's **+0.852R**. A dimension true of nearly every name separated outcomes
+decisively.
+
+The "constant in disguise" language criterion 2 carries was borrowed from `Prior move`, which is
+true of **100%** of detections in both groups and genuinely cannot move anything. 85% is not
+100%, and 92 IDX trades is not nothing. **`Constant dimension` and `Crowded dimension` are
+different objects**, and ADR 0005 treated them as one.
+
+### Why the threshold does not move
+
+Choosing a new number now — with `Relative move`'s 84.94% already visible — is the
+magnitude-fitting ADR 0005's pre-registration section exists to prevent, and it is the specific
+failure that section warned about: "Choosing a rounding here is choosing a verdict after seeing
+the number." So 85% stays exactly where it was written.
+
+What changes is the **job** it does, and the change repairs the complaint ADR 0005 filed against
+it. That ADR called the ~15% "a judgement, not a measurement… the one magnitude in this design
+with nothing behind it," and it was right to, because a number deciding *ship or do not ship*
+must be defensible to the hundredth of a point. A number deciding **which candidates owe a
+further measurement** can be approximately right and still do its job correctly. The threshold
+was never fit for the first task. It is fit for the second.
+
+## What passing the test means
+
+A candidate outcome test is **passed** when:
+
+1. **At least one market's gap clears zero** — its symbol-clustered 95% interval sits entirely
+   above zero, which is the verdict rule `backtest.candidates` fixed in advance (#195); and
+2. **No market points the wrong way** — no market's gap interval sits entirely below zero.
+
+**The gap is read with the absent group excluded.** `backtest.candidates` reports a second
+figure that reads absence as a miss, which is what a shipped boolean would do; that figure is a
+diagnostic and the payload says so — "what a shipped boolean would do with it is reported
+separately and sets no verdict." The two disagree on the US for `Relative move` (+0.396R
+crossing zero at −0.03; +0.454R clearing it at +0.05), and choosing the passing row after seeing
+which one passes is verdict-shopping. **The pre-registered row is read, always, including when it
+is the one that fails.**
+
+### Why one market suffices, and why §8 permits it
+
+`score.py` holds **one rubric for both markets** and argues its own case for that: "one set
+serves both markets… a weight *ordering* is shape not magnitude, so §8 permits it travelling to
+IDX." Findings §8 is the governing prior — **shapes travel between US and IDX, magnitudes do
+not** — and it constrains what a single-market outcome result may carry.
+
+**A gap's size is a magnitude and does not travel.** `+1.927R` is a fact about Jakarta.
+
+**Sign agreement across markets is a shape and does travel.** Across the four measured cells,
+`Relative move` is positive in **both** markets and `RS line` is negative in one. §8's own
+examples of travelling shape are rules of this kind — "that a dimension's null must be read
+against its spread" — and this is one: *a dimension that points the same way in both tapes, and
+decisively in the one with power, is showing a property of the method rather than of a regime.*
+
+Condition 2 is what makes this a shape claim rather than a magnitude claim, and it has teeth:
+`RS line` fails it on the US (−0.191R), so this rule would have refused it on outcome grounds
+the way ADR 0005's criterion 4 refused it on selection grounds.
+
+**This does not license a per-market rubric.** `references/backtest_idx_adr_floor.md` reached
+the same conclusion for `ADR_FLOOR` — "keep 3.5%, and do not make the constant per-market on
+this evidence" — and the same reasoning holds here. Splitting the rubric would need to overturn
+`score.py`'s §8 argument, which nothing measured here does.
+
+## What it licenses, going out
+
+**A wrong-way candidate outcome test retires nothing.** Money evidence does not decide in either
+direction; ADR 0005's instrument still does.
+
+A dimension whose gap interval sits **entirely below zero** in any market is **re-argued**: a
+ticket is opened, at the time the outcome result is recorded and not deferred, requiring that
+dimension's **selection contrast to be re-run under the current detector**. The dimension
+**keeps its weight** while that is pending, because weights come from the selection ordering and
+nothing else (below).
+
+Dropping the dimension to **×0** is an outcome the re-argument may reach, not something that
+happens automatically. ADR 0005 already holds ×0 to be "a live question held open at zero cost,"
+and that is the right shape for a dimension under re-argument — but ×0 is a rubric change and
+forces a version stamp, so it is a conclusion the re-argument draws rather than a consequence
+this ADR imposes.
+
+**The asymmetry is deliberate.** Neither direction decides. Coming in, the outcome test unblocks
+ADR 0005's criteria; going out, it obliges ADR 0005's criteria to be re-read. In both directions
+the selection contrast is what speaks.
+
+## Weight is untouched
+
+**A candidate outcome test never sets, raises, or lowers a weight.** ADR 0001's companion rule
+(#128 Q2) stands unqualified: the replay licenses a change's *direction*, from the **ordering**
+of the measured selection gaps, and never a gap's value. An outcome gap is a value, from a
+different instrument on a different field, and ranking dimensions by it would mix two orderings
+into one — the field-change-versus-rubric-change confound ADR 0005 spent a consequence guarding
+against.
+
+There is also nothing to rank in. Two of eight dimensions have ever had a candidate outcome
+test run on them. A dimension admitted with an outcome test in the loop takes its ordinal
+position in the **selection** gap ordering, exactly as one admitted without.
+
+## ADR 0002 does not govern admission
+
+`references/backtest_findings.md` records that an outcome result "goes through the calibration
+rule — ADR 0002, as findings §7 restates it — like any other change." That phrasing is loose and
+is corrected here.
+
+ADR 0002 governs **loosening a gate**. Its score-dimension limb reads "a score dimension may be
+loosened only when A3 shows that dimension has no signal *and* that dimension shows real
+spread"; its four-condition limb governs a cross-sectional cut. Admitting a new dimension is
+neither. Replay findings §7 already draws this distinction for two other changes — the stop
+convention is "outside the rule entirely" and the tightness restructure is one "ADR 0002 does not
+govern… and ADR 0004 records what does" — and admission is a third case of the same kind.
+
+**Admission is governed by ADR 0005, as narrowed here.** Making this ADR pretend to satisfy a
+rule built for a different kind of change would be worse than naming the rule that applies.
+
+## Provisional admission
+
+**Any dimension admitted with a candidate outcome test in the loop is admitted provisionally**,
+and is re-read when the next out-of-sample measurement runs. `docs/out-of-sample-backtest-plan.md`
+is the instrument.
+
+**No minimum sample size is set**, and the omission is deliberate. A floor chosen now would be a
+magnitude picked with the answer already visible — the same failure as moving the 85%. The
+symbol-clustered interval already prices small samples, which is what a clustered bootstrap is
+for. What the thinness obliges is that it be **stated wherever the figure is quoted**, not that
+an arbitrary threshold be invented to gate it.
+
+## The bounds this rule carries
+
+Every one of these attaches to any admission made under this ADR.
+
+- **The deciding sample is thin.** IDX holds 1,196 closed trades over 247 symbols across
+  fourteen years, and the miss group behind `Relative move`'s gap is **92 trades**. The interval
+  clears zero; the sample is small.
+- **IDX's survivorship bound is the weaker one.** Jakarta's hole is counted on the enumeration
+  side, is neither exposure-weighted nor separated from recycled tickers, and is therefore
+  optimistic in a known direction. The true bound can only be lower.
+- **The regime bound is inherited whole from ADR 0005.** No index-relative dimension has been
+  validated against a falling tape. `QQQ` was negative before 1.7% of his entries, and the
+  backtest does not retire this bound so much as widen the window it was measured in.
+- **Multiple testing.** `backtest.candidates` reports 20 intervals at a nominal 95%, of which the
+  four gap rows are the measurement and the rest are diagnostics. IDX `Relative move`'s gap is
+  p=0.002, which clears a correction over the four gap rows comfortably. Recorded so a later
+  reader does not have to reconstruct it.
+- **The US graded correlation points the wrong way.** ρ = −0.021 on the US against +0.068 on
+  IDX. This ADR admits booleans and the correlation sets no verdict here, but any ADR 0004
+  grading proposal for this dimension starts from it rather than discovering it.
+
+## Consequences
+
+- **ADR 0005's criterion 2 is narrowed, not deleted.** Its threshold is unchanged and its
+  purpose is unchanged. What changes is that tripping it obliges a measurement instead of
+  returning a refusal. ADR 0005 carries a pointer to this ADR at that criterion.
+- **ADR 0005's block on a third candidate is lifted.** That ADR held that "no third candidate
+  should be registered until the ~15% has been argued on its own." This is that argument, and
+  the register is open.
+- **`on_the_bound` changes meaning without changing behaviour.** The harness returns the same
+  verdict on the same computation; a `on_the_bound` result now means the dimension is crowded
+  and owes a candidate outcome test.
+- **`Relative move` is admitted**, at ×1, as `RUBRIC_VERSION = 4`. The reading is recorded in
+  full below. The code change is a separate ticket, so that no constant moves before this rule
+  lands.
+- **A candidate outcome test is now part of a crowded dimension's registration.** A candidate
+  registered from here that is expected to be crowded should say so when it registers, rather
+  than discovering the obligation after the contrast runs.
+
+## The reading: `Relative move` (#170, #171, #195) — **admitted**
+
+Applied after this rule was written, not before.
+
+| step | ADR 0005 criterion | reads | outcome |
+| --- | --- | --- | --- |
+| gap and spread | 1, first limb | Δ **+3.6pp**, pooled spread **0.357** (detector v3) | passes |
+| crowding | 2, as narrowed here | not-taken hit rate **84.94%**, 0.29 s.e. inside the ceiling | **crowded — owes a candidate outcome test** |
+| the outcome test | this ADR | IDX **+1.927R** [+0.57, +3.14] clears; US **+0.396R** [−0.03, +0.77] does not clear and does not point the wrong way | **passes** — one market clears, none against |
+| too few names | 3 | 84.94%, far above the ~15% floor | does not fire |
+| wrong-way gap | 4 | Δ positive on both fields | does not fire |
+
+**Admitted, at ×1.** Δ +3.6pp ranks below `Tightness` (+13.5) and `MA support` (+6.3) in §5d's
+republished ordering, so the ordinal rule puts it with the ×1s — the weight ADR 0005 had already
+computed for this dimension had it been admitted. `RUBRIC_VERSION = 4`. **Provisional**, and
+re-read at the next out-of-sample measurement.
+
+The consequences ADR 0005 wrote for an admission now fire: `Prior move` retires, the rubric's
+permanent 0.5★ floor goes with it, the star range becomes 0.0–4.5, and the decile gate returns
+as the **binding lookback name** on the candidates payload with its percentile deliberately not
+emitted.
+
+## Considered options
+
+- **Delete criterion 2 outright.** Rejected: a high firing rate is genuine grounds for
+  suspicion, and criterion 3 does not catch the crowded case — it catches the sparse one. The
+  guard was aimed at something real and only its instrument was wrong.
+- **Move the threshold instead.** Rejected: this is the exact move ADR 0005's pre-registration
+  section forbids, and doing it with `Relative move`'s 84.94% already on the page would be
+  indefensible however defensible the new number.
+- **Read the as-shipped gap** (absence counted as a miss). Rejected: it is the row that passes on
+  the US, and it was pre-registered as a diagnostic. Switching to it now is verdict-shopping.
+- **Require every market to pass.** Rejected: the thinner market will rarely have the power, so
+  the rule would refuse everything and never fire.
+- **Let any single market's pass suffice, with no wrong-way condition.** Rejected: it would carry
+  a magnitude across markets in violation of §8, and it would admit a dimension that loses money
+  in the market it mostly ships to.
+- **Make the rubric per-market.** Rejected: `score.py` argues the shared rubric is what §8
+  requires, `backtest_idx_adr_floor.md` refused the same split for `ADR_FLOOR` on the same
+  reasoning, and nothing measured here overturns either.
+- **Retire on a wrong-way outcome result.** Rejected (#221): it would let outcome evidence decide
+  on its own in one direction while merely unblocking in the other. Obliging a re-argument keeps
+  the instrument to one job in both directions.
+- **Set a minimum sample size for a passing outcome test.** Rejected: a magnitude chosen with the
+  answer visible. The clustered interval already does this work honestly.
+- **Amend ADR 0005 in place.** Rejected: 0005's considered options record that an outcome
+  instrument was *not available*, and that sentence is why the document is shaped as it is.
+  Overwriting it would delete the reasoning and leave the conclusion.

--- a/references/backtest_findings.md
+++ b/references/backtest_findings.md
@@ -148,6 +148,18 @@ Four limits on the licence, all of them binding:
 - **It is licensed, not spent.** No weight moved, the rubric is still v3, and the register is
   unchanged. Spending it is a separate ticket with its own evidence rule.
 
+**Spent in #221**, which wrote that evidence rule as
+[ADR 0006](../blob/main/docs/adr/0006-what-an-outcome-result-licenses.md) and then applied it.
+Two corrections to the four limits above, both recorded in that ADR:
+
+- **The calibration-rule citation was loose.** ADR 0002 governs *loosening a gate* and does not
+  govern admission — the same distinction §7 already draws for the stop convention and the
+  tightness restructure. Admission is ADR 0005's, as narrowed by 0006.
+- **The market limit held, and the licence still reached both markets.** Not on the +1.927R,
+  which is a magnitude and stays in Jakarta, but on **sign agreement across both markets** —
+  `Relative move` positive in each, `RS line` negative in one — which is a shape and travels
+  under §8. `Relative move` was admitted at ×1 as `RUBRIC_VERSION = 4`, provisionally, in #222.
+
 ---
 
 ## What was measured, and how

--- a/references/qullamaggie-replay-findings.md
+++ b/references/qullamaggie-replay-findings.md
@@ -1747,7 +1747,7 @@ reweight's direction survives the fix (§4b).
 **#136 — the paired re-run is now wired, and separates the two variables by construction.**
 The obstacle #136 was written against — "re-run A2 and risk moving the field *and* the rubric
 at once, then attribute the null to neither" — is now closed at the seam rather than left to a
-disciplined operator. `screener.score.RUBRIC_WEIGHTS` keeps the superseded **v1** ten-point
+disciplined operator. `screener.score.RUBRICS` keeps the superseded **v1** ten-point
 table beside the live **v2** nine-point one, keyed by the same `RUBRIC_VERSION` stamp, and
 `stars_under(breakdown, weights)` re-totals a detection's *hit booleans* under either. The
 hits are a property of the setup, not the rubric — only the weights move — so


### PR DESCRIPTION
Closes #221. Follow-up code ticket: #222.

Docs only — **no constant moves here**. `RUBRIC_VERSION` is still 3 and `DIMENSIONS` is untouched, which is #221's own condition.

## What was stuck

ADR 0005 refuses a dimension whose not-taken hit rate is above ~85%, on the ground that a dimension true of nearly every name he passed over is "the constant in a new costume". `Relative move` came in at **84.94%** — 0.06pp inside, 0.29 standard errors — and stalled for two tickets. The ADR itself had flagged the number as "a judgement, not a measurement… the one magnitude in this design with nothing behind it", to be argued about *before* it decided anything. It then decided something by six hundredths of a point and the argument never happened. Nothing shipped and no third candidate could register while it stood.

## What settles it

**ADR 0006 argues the threshold, and does not move it.**

The firing rate was only ever a **stand-in** for what criterion 2 actually feared — "little left to say inside an already-gated field". The backtest measured that quantity directly and refuted the stand-in:

| | fires on | the names it misses |
| --- | ---: | --- |
| US | **90.0%** (11,014 / 1,217) | −0.298R |
| IDX | **92.2%** (1,087 / 92) | **−1.075R**, against the hit group's +0.852R |

Both further past the ceiling than the 84.94% that stalled it. A dimension true of nearly everything separated outcomes decisively. Being crowded is not the same as being constant, and ADR 0005 treated them as one object.

So the threshold stays exactly where it was written — moving it with 84.94% already on the page would be the magnitude-fitting the pre-registration section exists to prevent — and its **job** changes. A **crowded dimension** (≥85%, or within one standard error, which is the region `relative_move_contrast.py` already returns as `on_the_bound`) is no longer refused. It **owes a candidate outcome test**.

That repairs the original complaint rather than dodging it: a number deciding *who owes a further measurement* can be approximately right and still be correct. A number deciding ship-or-don't cannot.

## The rule, in full

**A candidate outcome test changes what a dimension owes, never what it gets.** It admits nothing and retires nothing on its own; the selection contrast still decides.

- **Passing** = one market's gap clears zero **and** no market points the wrong way. Read on the **pre-registered gap with the absent group excluded** — never the as-shipped figure. The two disagree on the US (+0.396R crossing at −0.03; +0.454R clearing at +0.05) and switching after seeing which passes is verdict-shopping.
- **One market can license a shared-rubric change**, on **sign agreement across both markets** — a shape, which §8 permits travelling — and not on the +1.927R, which is a magnitude and stays in Jakarta. The second limb has teeth: it would have refused `RS line` on outcome grounds (US −0.191R).
- **No per-market rubric.** `score.py:47-50` argues the shared rubric is what §8 requires; `backtest_idx_adr_floor.md` refused the same split for `ADR_FLOOR`. Nothing here overturns either.
- **Weights are untouched.** Still from the ordering of the selection gaps (#128 Q2). There is no outcome ordering to rank in — two of eight dimensions have ever had the test run.
- **Wrong-way results retire nothing.** They oblige that dimension's selection contrast to be **re-argued** under the current detector, weight unchanged meanwhile. ×0 is an outcome the re-argument may reach, never automatic.
- **ADR 0002 does not govern admission.** It governs loosening a gate. Findings §7 already draws that line for the stop convention and the tightness restructure; admission is a third case. The backtest findings' citation was loose and is corrected.

## The verdict

`Relative move` is **admitted, at ×1, as `RUBRIC_VERSION = 4` — provisionally.**

×1 is not a new decision: Δ +3.6pp ranks below `Tightness` (+13.5) and `MA support` (+6.3), the weight ADR 0005 had already computed for it. Provisional because the deciding cell rests on **92 losing trades**, in the market whose survivorship bound is the weaker one — so it gets re-read at the next out-of-sample measurement.

## Also in here

- **ADR 0005 → `accepted`.** It has refused one dimension and stalled another while formally `proposed`.
- **Its block on a third candidate is lifted**, in as many words — it won't lift by implication.
- **`CONTEXT.md` gains `Crowded dimension`**, sitting beside `Constant dimension` so the pair teaches the distinction ADR 0005 got wrong.
- **`RUBRIC_WEIGHTS` → `RUBRICS`** in the replay findings. The symbol has never existed.

## Reviewing this

The load-bearing claim is that the ~85% was a **stand-in for informativeness**, not a mechanical claim about moving the sort — because that is what licenses replacing it with an outcome measurement. If criterion 2 was really mechanical, the backtest is the wrong instrument and the guard should stand. The case for it: criterion 1's pooled-spread limb already owns the mechanical claim, criterion 3 owns its mirror, and criterion 2's own sentence says the worry is "little left to say within that population".

The second thing to push on is whether **sign agreement** is genuinely a shape under §8, since that is what carries a Jakarta result into a rubric that ships to the US.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TWbaHxXiDaSfx3nPHmE1i
